### PR TITLE
Do not set parent.classid in properties. It is not needed

### DIFF
--- a/examples/custom_transport/README.txt
+++ b/examples/custom_transport/README.txt
@@ -81,11 +81,6 @@ library that creates the plugin, etc.
                             <propagate>0</propagate>
                         </element>                      
                         <element>
-                            <name>dds.transport.FILE.myPlugin.parent.classid</name>
-                            <value>FileTransport</value>
-                            <propagate>0</propagate>
-                        </element>   
-                        <element>
                             <name>dds.transport.FILE.myPlugin.address</name>
                             <value>3.3.3.3</value>
                             <propagate>0</propagate>


### PR DESCRIPTION
Enhanced clarity of the code and simplified maintenance.
