### PR TITLE
A few usability improvements....

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/build/eclipse/rticonnextdds-examples/.project
+++ b/build/eclipse/rticonnextdds-examples/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>rticonnextdds-examples</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+	<linkedResources>
+		<link>
+			<name>CONTRIBUTING.md</name>
+			<type>1</type>
+			<locationURI>PARENT-3-PROJECT_LOC/CONTRIBUTING.md</locationURI>
+		</link>
+		<link>
+			<name>README.md</name>
+			<type>1</type>
+			<locationURI>PARENT-3-PROJECT_LOC/README.md</locationURI>
+		</link>
+		<link>
+			<name>examples</name>
+			<type>2</type>
+			<locationURI>PARENT-3-PROJECT_LOC/examples</locationURI>
+		</link>
+		<link>
+			<name>resources</name>
+			<type>2</type>
+			<locationURI>PARENT-3-PROJECT_LOC/resources</locationURI>
+		</link>
+	</linkedResources>
+</projectDescription>

--- a/resources/copyright_md_style.txt
+++ b/resources/copyright_md_style.txt
@@ -1,0 +1,10 @@
+<!--
+ (c) 2005-2014 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+ RTI grants Licensee a license to use, modify, compile, and create derivative
+ works of the Software.  Licensee has the right to distribute object form only
+ for use with RTI products.  The Software is provided "as is", with no warranty
+ of any type, including any warranty for fitness for any purpose. RTI is under
+ no obligation to maintain or support the Software.  RTI shall not be liable for
+ any incidental or consequential damages arising out of the use or inability to
+ use the software.
+ -->

--- a/resources/copyright_sh_style.txt
+++ b/resources/copyright_sh_style.txt
@@ -1,0 +1,10 @@
+# ------------------------------------------------------------------------------
+# (c) 2005-2014 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+# RTI grants Licensee a license to use, modify, compile, and create derivative
+# works of the Software.  Licensee has the right to distribute object form only
+# for use with RTI products.  The Software is provided "as is", with no warranty
+# of any type, including any warranty for fitness for any purpose. RTI is under
+# no obligation to maintain or support the Software.  RTI shall not be liable 
+# for any incidental or consequential damages arising out of the use or
+# inability to use the software.
+# ------------------------------------------------------------------------------


### PR DESCRIPTION
Two usability improvements

1. Added a build/ folder to hold IDE and build related artifacts. This avoids polluting the examples with IDE files.
    - currently contains an eclipse project that allows one to open up all the examples as an eclipse project
    -  additional IDEs can be added 
   
2. Added copyright headers for markdown (.md) files and shell scripts (.sh). The perl script still needs to be updated to be smart enough to automatically apply these headers when it sees files with these extensions.
