### PR TITLE
Develop

### DIFF
--- a/examples/asynchronous_publication/cs/README.txt
+++ b/examples/asynchronous_publication/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32dotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable async.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable async.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable async.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable async.idl
 
 ...you will see messages that look like this:
 

--- a/examples/asynchronous_publication/java/README.txt
+++ b/examples/asynchronous_publication/java/README.txt
@@ -15,12 +15,12 @@ use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk async.idl
+rtiddsgen -language Java -example i86Win32VS2010 async.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk async.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 async.idl
 
 You will see messages that look like this:
 
@@ -40,41 +40,27 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar async.java asyncSeq.java asyncTypeSupport.java asyncTypeCode.java asyncDataReader.java asyncDataWriter.java asyncSubscriber.java asyncPublisher.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar async.java asyncSeq.java asyncTypeSupport.java asyncTypeCode.java asyncDataReader.java asyncDataWriter.java asyncSubscriber.java asyncPublisher.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar async.java asyncSeq.java asyncTypeSupport.java asyncTypeCode.java asyncDataReader.java asyncDataWriter.java asyncSubscriber.java asyncPublisher.java
-
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar async.java asyncSeq.java asyncTypeSupport.java asyncTypeCode.java asyncDataReader.java asyncDataWriter.java asyncSubscriber.java asyncPublisher.java
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar asyncPublisher  <domain_id> <samples_to_send>
-java -cp .;%NDDSHOME%\class\nddsjava.jar asyncSubscriber <domain_id> <sleep_periods>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar asyncPublisher  <domain_id> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar asyncSubscriber <domain_id> <sleep_periods>
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar asyncPublisher  <domain_id> <samples_to_send>
-java -cp .:$NDDSHOME/class/nddsjava.jar asyncSubscriber <domain_id> <sleep_periods>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar asyncPublisher  <domain_id> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar asyncSubscriber <domain_id> <sleep_periods>
 
 
 The applications accept up to two arguments:

--- a/examples/batching/cs/README.txt
+++ b/examples/batching/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 OOn Windows systems (assuming you want to generate an example for 
-i86Win32dotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable batch_data.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable batch_data.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable batch_data.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable batch_data.idl
 
 You will see messages that look like this:
 

--- a/examples/batching/java/README.txt
+++ b/examples/batching/java/README.txt
@@ -15,12 +15,12 @@ use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk batch_data.idl
+rtiddsgen -language Java -example i86Win32VS2010 batch_data.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk batch_data.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 batch_data.idl
 
 You will see messages that look like this:
 
@@ -43,40 +43,27 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar *.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar *.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar *.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar *.java
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar batch_dataPublisher  <domain_id> <turbo_mode> <samples_to_send>
-java -cp .;%NDDSHOME%\class\nddsjava.jar batch_dataSubscriber <domain_id> <turbo_mode> <sleep_periods>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar batch_dataPublisher  <domain_id> <turbo_mode> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar batch_dataSubscriber <domain_id> <turbo_mode> <sleep_periods>
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar batch_dataPublisher  <domain_id> <turbo_mode> <samples_to_send>
-java -cp .:$NDDSHOME/class/nddsjava.jar batch_dataSubscriber <domain_id> <turbo_mode> <sleep_periods>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar batch_dataPublisher  <domain_id> <turbo_mode> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar batch_dataSubscriber <domain_id> <turbo_mode> <sleep_periods>
 
 The applications accept up to three arguments:
 

--- a/examples/builtin_qos_profiles/c++/README.txt
+++ b/examples/builtin_qos_profiles/c++/README.txt
@@ -26,17 +26,16 @@ rtiddsgen -language C++ -example i86Linux2.6gcc4.4.3 profiles.idl
 
 You will see messages that look like this:
 
-File C:\local\builtin_qos_profiles\c++\profiles_subscriber.cxx already exists and will not be 
-replaced with updated content. If you would like to get a new file with the 
-new content, either remove this file or supply -replace option.
-File C:\local\ builtin_qos_profiles\c++\profiles_publisher.cxx already exists and will not be 
-replaced with updated content. If you would like to get a new file with the 
-new content, either remove this file or supply -replace option.
+File C:\local\builtin_qos_profiles\c++\profiles_subscriber.cxx already exists 
+and will not be replaced with updated content. If you would like to get a new 
+file with the new content, either remove this file or supply -replace option.
+File C:\local\ builtin_qos_profiles\c++\profiles_publisher.cxx already exists 
+and will not be replaced with updated content. If you would like to get a new 
+file with the new content, either remove this file or supply -replace option.
 
 This is normal and is only informing you that the subscriber/publisher code has 
 not been replaced, which is fine since all the source files for the example are 
 already provided.
-
 
 Link and Run with Dynamic Libraries
 ===================================
@@ -46,7 +45,7 @@ link with the other RTI libraries, this will fail at runtime.
 To dynamically link with the RTI libraries on Windows, choose the Debug DLL or 
 Release DLL build target.  Make sure that RTI's libraries are in the system 
 PATH environment variable, such as:
-PATH=c:\rti\ndds.5.1.0\lib\i86Win32VS2005;... 
+PATH=c:\rti\rti_connext_dds-5.2.0\lib\i86Win32VS2005;... 
 
 To dynamically link with the RTI libraries on Linux, modify the makefile to
 remove the 'z' from the end of the RTI library names, such as:

--- a/examples/builtin_qos_profiles/c/README.txt
+++ b/examples/builtin_qos_profiles/c/README.txt
@@ -26,17 +26,16 @@ rtiddsgen -language C -example i86Linux2.6gcc4.4.3 profiles.idl
 
 You will see messages that look like this:
 
-File C:\local\builtin_qos_profiles\c\profiles_subscriber.c already exists and will not be 
-replaced with updated content. If you would like to get a new file with the 
-new content, either remove this file or supply -replace option.
-File C:\local\ builtin_qos_profiles\c\profiles_publisher.c already exists and will not be 
-replaced with updated content. If you would like to get a new file with the 
-new content, either remove this file or supply -replace option.
+File C:\local\builtin_qos_profiles\c\profiles_subscriber.c already exists and 
+will not be replaced with updated content. If you would like to get a new file
+with the new content, either remove this file or supply -replace option.
+File C:\local\ builtin_qos_profiles\c\profiles_publisher.c already exists and
+will not be replaced with updated content. If you would like to get a new file
+with the new content, either remove this file or supply -replace option.
 
 This is normal and is only informing you that the subscriber/publisher code has 
 not been replaced, which is fine since all the source files for the example are 
 already provided.
-
 
 Link and Run with Dynamic Libraries
 ===================================
@@ -46,7 +45,7 @@ link with the other RTI libraries, this will fail at runtime.
 To dynamically link with the RTI libraries on Windows, choose the Debug DLL or 
 Release DLL build target.  Make sure that RTI's libraries are in the system 
 PATH environment variable, such as:
-PATH=c:\rti\ndds.5.1.0\lib\i86Win32VS2005;... 
+PATH=c:\rti\rti_connext_dds-5.2.0\lib\i86Win32VS2005;... 
 
 To dynamically link with the RTI libraries on Linux, modify the makefile to
 remove the 'z' from the end of the RTI library names, such as:
@@ -54,7 +53,7 @@ remove the 'z' from the end of the RTI library names, such as:
 
 Also, make sure that RTI's libraries are in the system LD_LIBRARY_PATH 
 environment variable, such as:
-export LD_LIBRARY_PATH=~/rti/ndds.5.1.0/lib/i86Linux2.6gcc4.4.5:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=~/rti/rti_connext_dds-5.2.0/lib/i86Linux2.6gcc4.4.5:$LD_LIBRARY_PATH
 
 Running C Example
 =================

--- a/examples/builtin_qos_profiles/java/README.txt
+++ b/examples/builtin_qos_profiles/java/README.txt
@@ -4,35 +4,68 @@ Example code: Using Built-in QoS Profiles
 
 Building Java Example
 =====================
-Make sure you are using one of the relevant RTI Data Distribution Service versions, as specified at the top of the Solution.
+Before compiling or running the example, make sure the environment variable 
+NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
-Before compiling or running the example, make sure the environment variable NDDSHOME is set to the directory where your version of RTI Data Distribution Service is installed.
+Run rtiddsgen with the -example option and the target architecture of your 
+choice (e.g., i86Win32VS2005 or i86Linux2.6gcc4.4.3). The RTI Connext Core 
+Libraries and Utilities Getting Started Guide describes this process in detail. 
+Follow the same procedure to generate the code and build the examples. Do not 
+use the -replace option.
 
-Run rtiddsgen with the -example option and the target architecture of your choice (for example, i86Win32jdk). The RTI Data Distribution Service Getting Started Guide describes this process in detail. Follow the same procedure to generate the code and build the examples. Do not use the -replace option.
+On Windows systems run:
 
-After running rtiddsgen like this...
+rtiddsgen -language Java -example i86Win32VS2010 profiles.idl
 
-C:\local\property_qos\java> rtiddsgen -language Java -example i86Win32jdk profiles.idl
+On UNIX systems (assuming you want to generate an example for 
+i86Linux2.6gcc4.4.3) run:
 
-...you will see messages that look like this:
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 profiles.idl
 
-File C:\local\builtin_qos_profiles\java\profilesSubscriber.java already exists and will not be replaced with updated content. If you would like to get a new file with the new content, either remove this file or supply -replace option.
-File C:\local\builtin_qos_profiles\java\profilesPublisher.java already exists and will not be replaced with updated content. If you would like to get a new file with the new content, either remove this file or supply -replace option.
+You will see messages that look like this:
 
-This is normal and is only informing you that the subscriber/publisher code has not been replaced, which is fine since all the source files for the example are already provided.
+File C:\local\builtin_qos_profiles\java\profilesSubscriber.java already exists 
+and will not be replaced with updated content. If you would like to get a new 
+file with the new content, either remove this file or supply -replace option.
+File C:\local\builtin_qos_profiles\java\profilesPublisher.java already exists 
+and will not be replaced with updated content. If you would like to get a new 
+file with the new content, either remove this file or supply -replace option.
 
-Before compiling in Java, make sure that the desired version of the javac compiler is in your PATH environment variable.
+This is normal and is only informing you that the subscriber/publisher code has 
+not been replaced, which is fine since all the source files for the example are 
+already provided.
+
+Before compiling in Java, make sure that the desired version of the javac 
+compiler is in your PATH environment variable.
+
+On Windows systems run:
+
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar *.java
+
+On Unix systems (including Linux and MacOS X):
+
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar *.java
 
 Running Java Example
 ====================
-Before running, make sure that the desired version of the java compiler is in your PATH environment variable.
+In two separate command prompt windows for the publisher and subscriber. 
+Run the following commands from the example directory (this is necessary to 
+ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
-In two separate command prompt windows for the publisher and subscriber, run these commands:
+On Windows systems run:
 
-    * java -cp .\;%nddshome%\class\nddsjava.jar profilesPublisher <domain#> 4
-    * java -cp .\;%nddshome%\class\nddsjava.jar profilesSubscriber <domain#> 4
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar profilesPublisher  <domain_id> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar profilesSubscriber <domain_id> <sleep_periods>
+
+On Unix systems (including Linux and MacOS X) run:
+
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar profilesPublisher  <domain_id> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar profilesSubscriber <domain_id> <sleep_periods>
 
 The applications accept two arguments:
 
-   1. The <domain #>. Both applications must use the same domain # in order to communicate. The default is 0.
-   2. How long the examples should run, measured in samples for the publisher and sleep periods for the subscriber. A value of '0' instructs the application to run forever; this is the default.
+   1. The <domain #>. Both applications must use the same domain # in order to 
+      communicate. The default is 0.
+   2. How long the examples should run, measured in samples for the publisher 
+      and sleep periods for the subscriber. A value of '0' instructs the 
+      application to run forever; this is the default.

--- a/examples/builtin_topics/cs/README.txt
+++ b/examples/builtin_topics/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32dotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable msg.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable msg.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable msg.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable msg.idl
 
 ...you will see messages that look like this:
 

--- a/examples/builtin_topics/java/README.txt
+++ b/examples/builtin_topics/java/README.txt
@@ -16,12 +16,12 @@ use the -replace option.
 
 On Windows systems run:
 
-    rtiddsgen -language Java -example i86Win32jdk msg.idl
+    rtiddsgen -language Java -example i86Win32VS2010 msg.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-    rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk msg.idl
+    rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 msg.idl
 
 You will see messages that look like this:
 
@@ -44,35 +44,28 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar *.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar *.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar *.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar *.java
 
 Running
 =======
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar msgPublisher  <domain_id> <samples_to_send>
-java -cp .;%NDDSHOME%\class\nddsjava.jar msgSubscriber <domain_id> <sleep_periods> <participant_auth> <reader_auth>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar msgPublisher  <domain_id> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar msgSubscriber <domain_id> <sleep_periods> <participant_auth> <reader_auth>
+
+On Unix systems (including Linux and MacOS X) run:
+
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar msgPublisher  <domain_id> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar msgSubscriber <domain_id> <sleep_periods> <participant_auth> <reader_auth>
+
 
 The applications accept up to two arguments (four to subscriber):
 

--- a/examples/coherent_presentation/cs/README.txt
+++ b/examples/coherent_presentation/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32dotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisablecoherent.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisablecoherent.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable coherent.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable coherent.idl
 
 You will see messages that look like this:
 

--- a/examples/coherent_presentation/java/README.txt
+++ b/examples/coherent_presentation/java/README.txt
@@ -15,12 +15,12 @@ use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk coherent.idl
+rtiddsgen -language Java -example i86Win32VS2010 coherent.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk coherent.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 coherent.idl
 
 You will see messages that look like this:
 
@@ -43,39 +43,26 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar *.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar *.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar *.java 
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar *.java 
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
-java -cp .;%NDDSHOME%\class\nddsjava.jar coherentPublisher  <domain_id> <samples_to_send>
-java -cp .;%NDDSHOME%\class\nddsjava.jar coherentSubscriber <domain_id> <sleep_periods>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar coherentPublisher  <domain_id> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar coherentSubscriber <domain_id> <sleep_periods>
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar coherentPublisher  <domain_id> <samples_to_send>
-java -cp .:$NDDSHOME/class/nddsjava.jar coherentSubscriber <domain_id> <sleep_periods>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar coherentPublisher  <domain_id> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar coherentSubscriber <domain_id> <sleep_periods>
 
 
 The applications accept up to two arguments:

--- a/examples/content_filtered_topic/cs/README.txt
+++ b/examples/content_filtered_topic/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32dotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable cft.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable cft.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable cft.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable cft.idl
 
 ...you will see messages that look like this:
 

--- a/examples/content_filtered_topic/java/README.txt
+++ b/examples/content_filtered_topic/java/README.txt
@@ -15,12 +15,12 @@ use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk cft.idl
+rtiddsgen -language Java -example i86Win32VS2010 cft.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk cft.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 cft.idl
 
 You will see messages that look like this:
 
@@ -40,40 +40,27 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar cft.java cftSeq.java cftTypeSupport.java cftTypeCode.java cftDataReader.java cftDataWriter.java cftSubscriber.java cftPublisher.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar cft.java cftSeq.java cftTypeSupport.java cftTypeCode.java cftDataReader.java cftDataWriter.java cftSubscriber.java cftPublisher.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar cft.java cftSeq.java cftTypeSupport.java cftTypeCode.java cftDataReader.java cftDataWriter.java cftSubscriber.java cftPublisher.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar cft.java cftSeq.java cftTypeSupport.java cftTypeCode.java cftDataReader.java cftDataWriter.java cftSubscriber.java cftPublisher.java
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar cftPublisher  <domain_id> <samples_to_send>
-java -cp .;%NDDSHOME%\class\nddsjava.jar cftSubscriber <domain_id> <sleep_periods>    <select_cft>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar cftPublisher  <domain_id> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar cftSubscriber <domain_id> <sleep_periods>    <select_cft>
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar cftPublisher  <domain_id> <samples_to_send>
-java -cp .:$NDDSHOME/class/nddsjava.jar cftSubscriber <domain_id> <sleep_periods>     <select_cft>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar cftPublisher  <domain_id> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar cftSubscriber <domain_id> <sleep_periods>     <select_cft>
 
 
 The applications accept two arguments:

--- a/examples/content_filtered_topic_string_filter/cs/README.txt
+++ b/examples/content_filtered_topic_string_filter/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32dotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable cft.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable cft.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable cft.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable cft.idl
 
 ...you will see messages that look like this:
 
@@ -44,7 +44,7 @@ already provided.
 
 Rtiddsgen generates two solutions for Visual Studio C++ and C#, that you will 
 use to build the types and the C# example, respectively. First open  
-async_type-dotnet4.0.sln and build the solution. Once you've done that, open
+cft_type-dotnet4.0.sln and build the solution. Once you've done that, open
 cft_example-csharp.sln and build the C# example.
 
 Running C# Example

--- a/examples/content_filtered_topic_string_filter/java/README.txt
+++ b/examples/content_filtered_topic_string_filter/java/README.txt
@@ -15,12 +15,12 @@ use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk cft.idl
+rtiddsgen -language Java -example i86Win32VS2010 cft.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk cft.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 cft.idl
 
 You will see messages that look like this:
 
@@ -46,40 +46,27 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar cft.java cftSeq.java cftTypeSupport.java cftTypeCode.java cftDataReader.java cftDataWriter.java cftSubscriber.java cftPublisher.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar cft.java cftSeq.java cftTypeSupport.java cftTypeCode.java cftDataReader.java cftDataWriter.java cftSubscriber.java cftPublisher.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar cft.java cftSeq.java cftTypeSupport.java cftTypeCode.java cftDataReader.java cftDataWriter.java cftSubscriber.java cftPublisher.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar cft.java cftSeq.java cftTypeSupport.java cftTypeCode.java cftDataReader.java cftDataWriter.java cftSubscriber.java cftPublisher.java
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar cftPublisher  <domain_id> <samples_to_send>
-java -cp .;%NDDSHOME%\class\nddsjava.jar cftSubscriber <domain_id> <sleep_periods> <select_cft>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar cftPublisher  <domain_id> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar cftSubscriber <domain_id> <sleep_periods> <select_cft>
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar cftPublisher  <domain_id> <samples_to_send>
-java -cp .:$NDDSHOME/class/nddsjava.jar cftSubscriber <domain_id> <sleep_periods> <select_cft>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar cftPublisher  <domain_id> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar cftSubscriber <domain_id> <sleep_periods> <select_cft>
 
 
 The applications accept two arguments:

--- a/examples/custom_content_filter/c++/README.txt
+++ b/examples/custom_content_filter/c++/README.txt
@@ -41,7 +41,7 @@ Running C++ Example
 In two separate command prompt windows for the publisher and subscriber. Run
 the following commands from the example directory. 
 
-n Windows systems run:
+On Windows systems run:
 
 objs\<arch_name>\ccf_publisher.exe  <domain_id> <samples_to_send>
 objs\<arch_name>\ccf_subscriber.exe <domain_id>  <sleep_periods> 

--- a/examples/custom_content_filter/java/README.txt
+++ b/examples/custom_content_filter/java/README.txt
@@ -8,19 +8,21 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32jdk or i86Linux2.6gcc4.4.3jdk). The RTI Connext Core 
+choice (e.g., i86Win32VS2010 or i86Linux2.6gcc4.4.3). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk ccf.idl
+rtiddsgen -language Java -example i86Win32VS2010 ccf.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk ccf.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 ccf.idl
+
+...you will see messages that look like this:
 
 File C:\local\custom_content_filter\java\cftSubscriber.java already exists and 
 will not be replaced with updated content. If you would like to get a new file
@@ -38,42 +40,27 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar *.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar *.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar *.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar *.java
 
 
 Running Java Example
 ====================
-
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory:
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar ccfPublisher  <domain_id> <samples_to_send>
-java -cp .;%NDDSHOME%\class\nddsjava.jar ccfSubscriber <domain_id> <sleep_periods>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar ccfPublisher  <domain_id> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar ccfSubscriber <domain_id> <sleep_periods>
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar ccfPublisher  <domain_id> <samples_to_send>
-java -cp .:$NDDSHOME/class/nddsjava.jar ccfSubscriber <domain_id> <sleep_periods>
-
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar ccfPublisher  <domain_id> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar ccfSubscriber <domain_id> <sleep_periods>
 
 The applications accept up to two arguments:
 

--- a/examples/custom_flow_controller/cs/README.txt
+++ b/examples/custom_flow_controller/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32dotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable cfc.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable cfc.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable cfc.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable cfc.idl
 
 ...you will see messages that look like this:
 

--- a/examples/custom_flow_controller/java/README.txt
+++ b/examples/custom_flow_controller/java/README.txt
@@ -8,19 +8,19 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (i86Win32jdk or i86Linux2.6gcc4.4.3jdk). The RTI Connext Core 
+choice (i86Win32VS2010 or i86Linux2.6gcc4.4.3). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk cfc.idl
+rtiddsgen -language Java -example i86Win32VS2010 cfc.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk cfc.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 cfc.idl
 
 You will see messages that look like this:
 
@@ -43,40 +43,27 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar *.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar *.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar *.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar *.java
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
- java -cp .;%NDDSHOME%\class\nddsjava.jar cfcPublisher <domain#> <samples_to_send>
- java -cp .;%NDDSHOME%\class\nddsjava.jar cfcSubscriber <domain#> <sleep_periods>
+ java -cp .;%NDDSHOME%\lib\java\nddsjava.jar cfcPublisher <domain#> <samples_to_send>
+ java -cp .;%NDDSHOME%\lib\java\nddsjava.jar cfcSubscriber <domain#> <sleep_periods>
 
 On Unix systems (including Linux and MacOS X) run:
 
- java -cp .:$NDDSHOME/class/nddsjava.jar cfcPublisher  <domain_id> <samples_to_send>
- java -cp .:$NDDSHOME/class/nddsjava.jar cfcSubscriber <domain_id> <sleep_periods>
+ java -cp .:$NDDSHOME/lib/java/nddsjava.jar cfcPublisher  <domain_id> <samples_to_send>
+ java -cp .:$NDDSHOME/lib/java/nddsjava.jar cfcSubscriber <domain_id> <sleep_periods>
 
 The applications accept up to two arguments:
 
@@ -89,8 +76,8 @@ The applications accept up to two arguments:
 While generating the output below, we used values that would capture the most 
 interesting behavior.
 This ouput it is from: 
-    java -cp .\;%nddshome%\class\nddsjava.jar cfcPublisher <domain_id> 4
-    java -cp .\;%nddshome%\class\nddsjava.jar cfcSubscriber <domain_id> 3
+    java -cp .\;%nddshome%\lib\java\nddsjava.jar cfcPublisher <domain_id> 4
+    java -cp .\;%nddshome%\lib\java\nddsjava.jar cfcSubscriber <domain_id> 3
     
 Publisher Output
 ================

--- a/examples/deadline_contentfilter/README.txt
+++ b/examples/deadline_contentfilter/README.txt
@@ -1,18 +1,17 @@
-================================================ Example Code -- Deadlines and Content Filtering================================================Concept-------In RTI Connext DDS, you can use the DEADLINE QoS to specify that you expect updates about a particular instance within a given period of time.
+================================================ Example Code -- Deadlines and Content Filtering================================================Concept-------In RTI Connext DDS, you can use the DEADLINE QoS to specify that you expect updates about a particular instance within a given period of time.
 
-This QoS is request-offered, meaning that the DataWriter offers a level of service, and the DataReader requests a level of service.  Request-offered QoS are like a contract between the DataWriter and the DataReader: the DataWriter is saying that it will provide a level of service, and the DataReader is saying it requires a level of service.  The offered level must be greater than or equal to the requested level, or there will be no communication between the DataWriter and the DataReader.  
+This QoS is request-offered, meaning that the DataWriter offers a level of service, and the DataReader requests a level of service.  Request-offered QoS are like a contract between the DataWriter and the DataReader: the DataWriteris saying that it will provide a level of service, and the DataReader is sayingit requires a level of service.  The offered level must be greater than or equal to the requested level, or there will be no communication between the DataWriter and the DataReader.  
 
-However, the middleware cannot enforce the DEADLINE contract, because that is subject to:
- 1) how often the application calls write()
- 2) whether the network loses packets
- 3) whether the reader application is filtering some of the data
+However, the middleware cannot enforce the DEADLINE contract, because that issubject to:
+ 1) how often the application calls write().
+ 2) whether the network loses packets.
+ 3) whether the reader application is filtering some of the data.
 
 So, the middleware is responsible for:
- 1) Notifying the DataWriter application if the DataWriter is not writing as often as it specified in its DEADLINE period
- 2) Notifying the DataReader application if data did not arrive within its DEADLINE period
+ 1) Notifying the DataWriter application if the DataWriter is not writing as    often as it specified in its DEADLINE period.
+ 2) Notifying the DataReader application if data did not arrive within its     DEADLINE period.
 
-This example shows:
-
-1) The DataWriter writing two instances, both of them fast enough to satisfy the DEADLINE period
-2) After 10 seconds, the DataReader uses a Content-Filtered Topic to filter out one of those instances.  The DataReader now gets notifications that it is not receiving that instance within the DEADLINE period, and prints out which instance is not being received on time.
-3) After 15 seconds, the DataWriter no longer writes one of the instances.  Now the DataWriter is notified that it is failing to meet its DEADLINE contract for that instance.
+Example Description-------------------
+1) The DataWriter writing two instances, both of them fast enough to satisfy the   DEADLINE period.
+2) After 10 seconds, the DataReader uses a Content-Filtered Topic to filter out   one of those instances.  The DataReader now gets notifications that it is not   receiving that instance within the DEADLINE period, and prints out which    instance is not being received on time.
+3) After 15 seconds, the DataWriter no longer writes one of the instances.  Now    the DataWriter is notified that it is failing to meet its DEADLINE contract    for that instance.

--- a/examples/deadline_contentfilter/c++/README.txt
+++ b/examples/deadline_contentfilter/c++/README.txt
@@ -1,51 +1,70 @@
+=================================================
+ Example Code -- Deadlines and Content Filtering
+=================================================
 
-Purpose
-=======
-PUBLISHER:
-The Publisher adopts a 1.5 second deadline, promising to write samples at least this fast. Note that deadlines apply to each instance individually. After 15 seconds, we stop writing to the 2nd instance, and we get the on_offered_deadline_missed callback.
+Building C++ Example
+====================
+Before compiling or running the example, make sure the environment variable 
+NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
-SUBSCRIBER:
-The Subscriber requests a 2 second deadline, and prints out the offending instance when this deadline is missed. Note the interaction with filtering. After 10 seconds, we set up a filter that ignores the 2nd instance. Even though the publisher is still sending samples at this point, the instance is flagged as missing its deadline.
+Run rtiddsgen with the -example option and the target architecture of your 
+choice (e.g., i86Win32VS2005 or i86Linux2.6gcc4.4.3). The RTI Connext Core 
+Libraries and Utilities Getting Started Guide describes this process in detail. 
+Follow the same procedure to generate the code and build the examples. Do not 
+use the -replace option.
 
-With a time-based filter, however, if the requested deadline is less than the minimum separation, the QoS is considered incompatible.
+On Windows systems (assuming you want to generate an example for 
+i86Win32VS2005) run:
 
-Building
-=======
+rtiddsgen -language C++ -example i86Win32VS2005 deadline_contentfilter.idl
 
-Before compiling or running the example, make sure the environment variable NDDSHOME is set to the directory where your version of RTI Data Distribution Service is installed.
+On UNIX systems (assuming you want to generate an example for 
+i86Linux2.6gcc4.4.3) run:
 
-Run rtiddsgen with the -example option and the target architecture of your choice (for example, i86Win32VS2010). The RTI Data Distribution Service Getting Started Guide describes this process in detail. Follow the same procedure to generate the code and build the examples. Do not use the -replace option.
+rtiddsgen -language C++ -example i86Linux2.6gcc4.4.3 deadline_contentfilter.idl
 
-After running rtiddsgen like this...
+You will see messages that look like this:
 
-C:\local\deadline_contentfilter\c++> rtiddsgen -language C++ -example i86Win32VS2005 deadline_contentfilter.idl
+File c:\local\deadline_contentfilter\c++\deadline_contentfilter_subscriber.cxx 
+already exists and will not be replaced with updated content. If you would like 
+to get a new file with the new content, either remove this file or 
+supply -replace option.File c:\local\deadline_contentfilter\c++\deadline_contentfilter_publisher.cxx 
+already exists and will not be replaced with updated content. If you would like 
+to get a new file with the new content, either remove this file or 
+supply -replace option.File c:\local\deadline_contentfilter\c++\USER_QOS_PROFILES.xml already exists 
+and will not be replaced with updated content. If you would like to get a new 
+file with the new content, either remove this file or supply -replace option.
 
-...you will see messages that look like this:
+This is normal and is only informing you that the subscriber/publisher code has
+not been replaced, which is fine since all the source files for the example are
+already provided.
 
-File c:\local\deadline_contentfilter\c++\deadline_contentfilter_subscriber.cxx already exists and will not be replaced with updated content. If you would like to get a new file with the new content, either remove this file or supply -replace option.File c:\local\deadline_contentfilter\c++\deadline_contentfilter_publisher.cxx already exists and will not be replaced with updated content. If you would like to get a new file with the new content, either remove this file or supply -replace option.File c:\local\deadline_contentfilter\c++\USER_QOS_PROFILES.xml already exists and will not be replaced with updated content. If you would like to get a new file with the new content, either remove this file or supply -replace option.
+Running C++ Example
+===================
+In two separate command prompt windows for the publisher and subscriber. Run
+the following commands from the example directory (this is necessary to ensure
+the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
-This is normal and is only informing you that the subscriber/publisher code has not been replaced, which is fine since all the source files for the example are already provided.
+On Windows systems run:
 
-Running
-=======
-In two separate command prompt windows for the publisher and subscriber, navigate to the objs/<arch> directory and run these commands:
-
-Windows systems:
-
-    * deadline_contentfilter_publisher.exe <domain#> 20
-    * deadline_contentfilter_subscriber.exe <domain#> 22
+objs\<arch_name>\deadline_contentfilter_publisher.exe  <domain_id> <samples_to_send>
+objs\<arch_name>\deadline_contentfilter_subscriber.exe <domain_id>  <sleep_periods> 
 
 UNIX systems:
 
-    * ./deadline_contentfilter_publisher <domain#> 20
-    * ./deadline_contentfilter_subscriber <domain#> 22
+./objs/<arch_name>/deadline_contentfilter_publisher  <domain_id> <samples_to_send>
+./objs/<arch_name>/deadline_contentfilter_subscriber <domain_id> <sleep_periods> 
 
-The applications accept two arguments:
+The applications accept up to two arguments:
 
-   1. The <domain #>. Both applications must use the same domain # in order to communicate. The default is 0.
-   2. How long the examples should run, measured in samples for the publisher and sleep periods for the subscriber. A value of '0' instructs the application to run forever; this is the default.
+   1. The <domain_id>. Both applications must use the same domain id in order 
+   to communicate. The default is 0.
+   2. How long the examples should run, measured in samples for the publisher 
+   and sleep periods for the subscriber. A value of '0' instructs the 
+   application to run forever; this is the default.
 
-While generating the output below, we used values that would capture the most interesting behavior.
+While generating the output below, we used values that would capture the most 
+interesting behavior.
 
 Publisher Output
 =============
@@ -53,4 +72,4 @@ Writing instance0, x = 1, y = 1Writing instance1, x = 1, y = 1Writing instance
 
 Subscriber Output
 =============
-@ t=2.84s, Instance0: <1,1>@ t=2.84s, Instance1: <1,1>@ t=3.84s, Instance0: <2,2>@ t=3.84s, Instance1: <2,2>@ t=4.84s, Instance0: <3,3>@ t=4.84s, Instance1: <3,3>@ t=5.84s, Instance0: <4,4>@ t=5.84s, Instance1: <4,4>@ t=6.84s, Instance0: <5,5>@ t=6.84s, Instance1: <5,5>@ t=7.84s, Instance0: <6,6>@ t=7.84s, Instance1: <6,6>@ t=8.84s, Instance0: <7,7>@ t=8.84s, Instance1: <7,7>@ t=9.84s, Instance0: <8,8>@ t=9.84s, Instance1: <8,8>Starting to filter out instance1@ t=10.84s, Instance0: <9,9>@ t=11.84s, Instance0: <10,10>Missed deadline @ t=11.86s on instance code = 1@ t=12.84s, Instance0: <11,11>@ t=13.84s, Instance0: <12,12>Missed deadline @ t=13.86s on instance code = 1@ t=14.84s, Instance0: <13,13>@ t=15.84s, Instance0: <14,14>Missed deadline @ t=15.86s on instance code = 1@ t=16.84s, Instance0: <15,15>@ t=17.84s, Instance0: <16,16>Missed deadline @ t=17.86s on instance code = 1Missed deadline @ t=19.86s on instance code = 1Missed deadline @ t=21.88s on instance code = 1
+@ t=2.84s, Instance0: <1,1>@ t=2.84s, Instance1: <1,1>@ t=3.84s, Instance0: <2,2>@ t=3.84s, Instance1: <2,2>@ t=4.84s, Instance0: <3,3>@ t=4.84s, Instance1: <3,3>@ t=5.84s, Instance0: <4,4>@ t=5.84s, Instance1: <4,4>@ t=6.84s, Instance0: <5,5>@ t=6.84s, Instance1: <5,5>@ t=7.84s, Instance0: <6,6>@ t=7.84s, Instance1: <6,6>@ t=8.84s, Instance0: <7,7>@ t=8.84s, Instance1: <7,7>@ t=9.84s, Instance0: <8,8>@ t=9.84s, Instance1: <8,8>Starting to filter out instance1@ t=10.84s, Instance0: <9,9>@ t=11.84s, Instance0: <10,10>Missed deadline @ t=11.86s on instance code = 1@ t=12.84s, Instance0: <11,11>@ t=13.84s, Instance0: <12,12>Missed deadline @ t=13.86s on instance code = 1@ t=14.84s, Instance0: <13,13>@ t=15.84s, Instance0: <14,14>Missed deadline @ t=15.86s on instance code = 1@ t=16.84s, Instance0: <15,15>@ t=17.84s, Instance0: <16,16>Missed deadline @ t=17.86s on instance code = 1Missed deadline @ t=19.86s on instance code = 1Missed deadline @ t=21.88s on instance code = 1

--- a/examples/deadline_contentfilter/c/README.txt
+++ b/examples/deadline_contentfilter/c/README.txt
@@ -1,53 +1,72 @@
+=================================================
+ Example Code -- Deadlines and Content Filtering
+=================================================
 
-Purpose
-=======
-PUBLISHER:
-The Publisher adopts a 1.5 second deadline, promising to write samples at least this fast. Note that deadlines apply to each instance individually. After 15 seconds, we stop writing to the 2nd instance, and we get the on_offered_deadline_missed callback.
+Building C Example
+==================
+Before compiling or running the example, make sure the environment variable 
+NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
-SUBSCRIBER:
-The Subscriber requests a 2 second deadline, and prints out the offending instance when this deadline is missed. Note the interaction with filtering. After 10 seconds, we set up a filter that ignores the 2nd instance. Even though the publisher is still sending samples at this point, the instance is flagged as missing its deadline.
+Run rtiddsgen with the -example option and the target architecture of your 
+choice (e.g., i86Win32VS2005 or i86Linux2.6gcc4.4.3). The RTI Connext Core 
+Libraries and Utilities Getting Started Guide describes this process in detail. 
+Follow the same procedure to generate the code and build the examples. Do not 
+use the -replace option.
 
-With a time-based filter, however, if the requested deadline is less than the minimum separation, the QoS is considered incompatible.
+On Windows systems (assuming you want to generate an example for 
+i86Win32VS2005) run:
 
-Building
-=======
+rtiddsgen -language C -example i86Win32VS2005 deadline_contentfilter.idl
 
-Before compiling or running the example, make sure the environment variable NDDSHOME is set to the directory where your version of RTI Data Distribution Service is installed.
+On UNIX systems (assuming you want to generate an example for 
+i86Linux2.6gcc4.4.3) run:
 
-Run rtiddsgen with the -example option and the target architecture of your choice (for example, i86Win32VS2005). The RTI Data Distribution Service Getting Started Guide describes this process in detail. Follow the same procedure to generate the code and build the examples. Do not use the -replace option.
+rtiddsgen -language C -example i86Linux2.6gcc4.4.3 deadline_contentfilter.idl
 
-After running rtiddsgen like this...
+You will see messages that look like this:
 
-C:\local\deadline_contentfilter\c> rtiddsgen -language C -example i86Win32VS2005 deadline_contentfilter.idl
+File C:\local\deadline_contentfilter\c\deadline_contentfilter_subscriber.c 
+already exists and will not be replaced with updated content. If you would like
+to get a new file with the new content, either remove this file or 
+supply -replace option.
+File C:\local\deadline_contentfilter\c\deadline_contentfilter_publisher.c 
+already exists and will not be replaced with updated content. If you would like
+to get a new file with the new content, either remove this file or 
+supply -replace option.
+File c:\local\deadline_contentfilter\c\USER_QOS_PROFILES.xml already exists 
+and will not be replaced with updated content. If you would like to get a new 
+file with the new content, either remove this file or supply -replace option.
 
-...you will see messages that look like this:
+This is normal and is only informing you that the subscriber/publisher code has 
+not been replaced, which is fine since all the source files for the example are 
+already provided.
 
-File C:\local\deadline_contentfilter\c\deadline_contentfilter_subscriber.c already exists and will not be replaced with updated content. If you would like to get a new file with the new content, either remove this file or supply -replace option.
-File C:\local\deadline_contentfilter\c\deadline_contentfilter_publisher.c already exists and will not be replaced with updated content. If you would like to get a new file with the new content, either remove this file or supply -replace option.
-File c:\local\deadline_contentfilter\c\USER_QOS_PROFILES.xml already exists and will not be replaced with updated content. If you would like to get a new file with the new content, either remove this file or supply -replace option.
+Running C Example
+=================
+In two separate command prompt windows for the publisher and subscriber. Run
+the following commands from the example directory (this is necessary to ensure
+the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
-This is normal and is only informing you that the subscriber/publisher code has not been replaced, which is fine since all the source files for the example are already provided.
+On Windows systems run:
 
-Running
-=======
-In two separate command prompt windows for the publisher and subscriber, navigate to the objs/<arch> directory and run these commands:
-
-Windows systems:
-
-    * deadline_contentfilter_publisher.exe <domain#> 13
-    * deadline_contentfilter_subscriber.exe <domain#> 15
+objs\<arch_name>\deadline_contentfilter_publisher.exe  <domain_id> <samples_to_send>
+objs\<arch_name>\deadline_contentfilter_subscriber.exe <domain_id>  <sleep_periods>
 
 UNIX systems:
 
-    * ./deadline_contentfilter_publisher <domain#> 13
-    * ./deadline_contentfilter_subscriber <domain#> 15
+./objs/<arch_name>/deadline_contentfilter_publisher  <domain_id> <samples_to_send>
+./objs/<arch_name>/deadline_contentfilter_subscriber <domain_id> <sleep_periods>
 
-The applications accept two arguments:
+The applications accept up to two arguments:
 
-   1. The <domain #>. Both applications must use the same domain # in order to communicate. The default is 0.
-   2. How long the examples should run, measured in samples for the publisher and sleep periods for the subscriber. A value of '0' instructs the application to run forever; this is the default.
-
-While generating the output below, we used values that would capture the most interesting behavior.
+   1. The <domain_id>. Both applications must use the same domain id in order 
+   to communicate. The default is 0.
+   2. How long the examples should run, measured in samples for the publisher 
+   and sleep periods for the subscriber. A value of '0' instructs the 
+   application to run forever; this is the default.
+   
+While generating the output below, we used values that would capture the most 
+interesting behavior.
 
 Publisher Output
 =============

--- a/examples/deadline_contentfilter/cs/README.txt
+++ b/examples/deadline_contentfilter/cs/README.txt
@@ -1,52 +1,73 @@
+=================================================
+ Example Code -- Deadline Content Filter Example
+=================================================
 
-Purpose
-=======
-PUBLISHER:
-The Publisher adopts a 1.5 second deadline, promising to write samples at least this fast. Note that deadlines apply to each instance individually. After 15 seconds, we stop writing to the 2nd instance, and we get the on_offered_deadline_missed callback.
+Building C# Example
+===================
+Before compiling or running the example, make sure the environment variable 
+NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
-SUBSCRIBER:
-The Subscriber requests a 2 second deadline, and prints out the offending instance when this deadline is missed. Note the interaction with filtering. After 10 seconds, we set up a filter that ignores the 2nd instance. Even though the publisher is still sending samples at this point, the instance is flagged as missing its deadline.
+Run rtiddsgen with the -example option and the target architecture of your 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
+Libraries and Utilities Getting Started Guide describes this process in detail. 
+Follow the same procedure to generate the code and build the examples. Do not 
+use the -replace option.
 
-With a time-based filter, however, if the requested deadline is less than the minimum separation, the QoS is considered incompatible.
+On Windows systems (assuming you want to generate an example for 
+i86Win32VS2010) run:
 
-Building
-=======
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable deadline_contentfilter.idl
 
-Before compiling or running the example, make sure the environment variable NDDSHOME is set to the directory where your version of RTI Data Distribution Service is installed.
+Note: If you are using Visual Studio Express add the -express option to the 
+command, i.e.,
 
-Run rtiddsgen with the -example option and the target architecture of your choice (for example, i86Win32dotnet2.0). The RTI Data Distribution Service Getting Started Guide describes this process in detail. Follow the same procedure to generate the code and build the examples. Do not use the -replace option.
-
-After running rtiddsgen like this...
-
-C:\local\deadline_contentfilter\cs> rtiddsgen -language C# -example i86Win32dotnet4.0 deadline_contentfilter.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable deadline_contentfilter.idl
 
 ...you will see messages that look like this:
 
-File C:\local\deadline_contentfilter\cs\deadline_contentfilter_subscriber.cxx already exists and will not be replaced with updated content. If you would like to get a new file with the new content, either remove this file or supply -replace option.
-File C:\local\deadline_contentfilter\cs\deadline_contentfilter_publisher.cxx already exists and will not be replaced with updated content. If you would like to get a new file with the new content, either remove this file or supply -replace option.
+File C:\local\deadline_contentfilter\cs\deadline_contentfilter_subscriber.cxx 
+already exists and will not be replaced with updated content. If you would like 
+to get a new file with the new content, either remove this file or 
+supply -replace option.
+File C:\local\deadline_contentfilter\cs\deadline_contentfilter_publisher.cxx 
+already exists and will not be replaced with updated content. If you would like
+to get a new file with the new content, either remove this file or 
+supply -replace option.
 
-This is normal and is only informing you that the subscriber/publisher code has not been replaced, which is fine since all the source files for the example are already provided.
+This is normal and is only informing you that the subscriber/publisher code has
+not been replaced, which is fine since all the source files for the example are
+already provided.
 
-Running
-=======
-In two separate command prompt windows for the publisher and subscriber, navigate to the objs/<arch> directory and run these commands:
+Rtiddsgen generates two solutions for Visual Studio C++ and C#, that you will 
+use to build the types and the C# example, respectively. First open  
+deadline_contentfilter_type-dotnet4.0.sln and build the solution. Once you've 
+done that, open deadline_contentfilter_example-csharp.sln and build the C# 
+example.
 
-Windows systems:
+Running C# Example
+==================
+In two separate command prompt windows for the publisher and subscriber. Run
+the following commands from the example directory (this is necessary to ensure
+the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
-    * deadline_contentfilter_publisher.exe <domain#> 13
-    * deadline_contentfilter_subscriber.exe <domain#> 15
+On Windows systems run:
 
-UNIX systems:
+bin\<build_type>-VS2010\deadline_contentfilter_publisher.exe  <domain_id> <samples_to_send>
+bin\<build_type>-VS2010\deadline_contentfilter_subscriber.exe <domain_id> <sleep_periods>
 
-    * ./deadline_contentfilter_publisher <domain#> 13
-    * ./deadline_contentfilter_subscriber <domain#> 15
+The applications accept up to two arguments:
 
-The applications accept two arguments:
+   1. The <domain_id>. Both applications must use the same domain id in order 
+   to communicate. The default is 0.
+   2. How long the examples should run, measured in samples for the publisher 
+   and sleep periods for the subscriber. A value of '0' instructs the 
+   application to run forever; this is the default.
 
-   1. The <domain #>. Both applications must use the same domain # in order to communicate. The default is 0.
-   2. How long the examples should run, measured in samples for the publisher and sleep periods for the subscriber. A value of '0' instructs the application to run forever; this is the default.
-
-While generating the output below, we used values that would capture the most interesting behavior.
+While generating the output below, we used values that would capture the most 
+interesting behavior.
+This ouput it is from: 
+    bin\<build_type>-VS2010\cfc_publisher.exe <domain_id> 13
+    bin\<build_type>-VS2010\cfc_subscriber.exe <domain_id> 15
 
 Publisher Output
 =============

--- a/examples/deadline_contentfilter/java/README.txt
+++ b/examples/deadline_contentfilter/java/README.txt
@@ -1,50 +1,76 @@
+=================================================
+ Example Code -- Deadline Content Filter Example
+=================================================
 
-Purpose
-=======
-PUBLISHER:
-The Publisher adopts a 1.5 second deadline, promising to write samples at least this fast. Note that deadlines apply to each instance individually. After 15 seconds, we stop writing to the 2nd instance, and we get the on_offered_deadline_missed callback.
+Building Java Example
+=====================
+Before compiling or running the example, make sure the environment variable 
+NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
-SUBSCRIBER:
-The Subscriber requests a 2 second deadline, and prints out the offending instance when this deadline is missed. Note the interaction with filtering. After 10 seconds, we set up a filter that ignores the 2nd instance. Even though the publisher is still sending samples at this point, the instance is flagged as missing its deadline.
+Run rtiddsgen with the -example option and the target architecture of your 
+choice (e.g., i86Win32VS2010 or i86Linux2.6gcc4.4.3). The RTI Connext Core 
+Libraries and Utilities Getting Started Guide describes this process in detail. 
+Follow the same procedure to generate the code and build the examples. Do not 
+use the -replace option.
 
-With a time-based filter, however, if the requested deadline is less than the minimum separation, the QoS is considered incompatible.
+On Windows systems run:
 
-Building
-=======
-Make sure you are using one of the relevant RTI Data Distribution Service versions, as specified at the top of the Solution.
+rtiddsgen -language Java -example i86Win32VS2010 deadline_contentfilter.idl
 
-Before compiling or running the example, make sure the environment variable NDDSHOME is set to the directory where your version of RTI Data Distribution Service is installed.
+On UNIX systems (assuming you want to generate an example for 
+i86Linux2.6gcc4.4.3) run:
 
-Run rtiddsgen with the -example option and the target architecture of your choice (for example, i86Win32VS2005). The RTI Data Distribution Service Getting Started Guide describes this process in detail. Follow the same procedure to generate the code and build the examples. Do not use the -replace option.
-
-After running rtiddsgen like this...
-
-C:\local\deadline_contentfilter\java> rtiddsgen -language Java -example i86Win32VS2005 deadline_contentfilter.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 deadline_contentfilter.idl
 
 ...you will see messages that look like this:
 
-File C:\local\deadline_contentfilter\java\deadline_contentfilterSubscriber.java already exists and will not be replaced with updated content. If you would like to get a new file with the new content, either remove this file or supply -replace option.
-File C:\local\deadline_contentfilter\java\deadline_contentfilterPublisher.java already exists and will not be replaced with updated content. If you would like to get a new file with the new content, either remove this file or supply -replace option.
+File C:\local\deadline_contentfilter\java\deadline_contentfilterSubscriber.java 
+already exists and will not be replaced with updated content. If you would like
+to get a new file with the new content, either remove this file or 
+supply -replace option.
+File C:\local\deadline_contentfilter\java\deadline_contentfilterPublisher.java 
+already exists and will not be replaced with updated content. If you would like 
+to get a new file with the new content, either remove this file or 
+supply -replace option.
 
-This is normal and is only informing you that the subscriber/publisher code has not been replaced, which is fine since all the source files for the example are already provided.
+This is normal and is only informing you that the subscriber/publisher code has
+not been replaced, which is fine since all the source files for the example are
+already provided.
 
-Before compiling in Java, make sure that the desired version of the javac compiler is in your PATH environment variable.
+Before compiling in Java, make sure that the desired version of the javac 
+compiler is in your PATH environment variable.
 
-Running
-=======
-Before running, make sure that the desired version of the java compiler is in your PATH environment variable.
+On Windows systems run:
 
-In two separate command prompt windows for the publisher and subscriber, run these commands:
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar *.java
 
-    * java -cp .\;%nddshome%\class\nddsjava.jar deadline_contentfilterPublisher <domain#> 13
-    * java -cp .\;%nddshome%\class\nddsjava.jar deadline_contentfilterSubscriber <domain#> 15
+On Unix systems (including Linux and MacOS X):
 
-The applications accept two arguments:
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar *.java
 
-   1. The <domain #>. Both applications must use the same domain # in order to communicate. The default is 0.
-   2. How long the examples should run, measured in samples for the publisher and sleep periods for the subscriber. A value of '0' instructs the application to run forever; this is the default.
 
-While generating the output below, we used values that would capture the most interesting behavior.
+Running Java Example
+====================
+In two separate command prompt windows for the publisher and subscriber. 
+Run the following commands from the example directory:
+
+On Windows systems run:
+
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar deadline_contentfilterPublisher  <domain_id> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar deadline_contentfilterSubscriber <domain_id> <sleep_periods>
+
+On Unix systems (including Linux and MacOS X) run:
+
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar deadline_contentfilterPublisher  <domain_id> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar deadline_contentfilterSubscriber <domain_id> <sleep_periods>
+
+The applications accept up to two arguments:
+
+   1. The <domain_id>. Both applications must use the same domain id in order 
+   to communicate. The default is 0.
+   2. How long the examples should run, measured in samples for the publisher 
+   and sleep periods for the subscriber. A value of '0' instructs the 
+   application to run forever; this is the default.
 
 Publisher Output
 =============

--- a/examples/dynamic_data_access_union_discriminator/Java/README.txt
+++ b/examples/dynamic_data_access_union_discriminator/Java/README.txt
@@ -13,35 +13,22 @@ compiler is in your PATH environment variable.
 
 In Windows systems run:
     
-    javac -classpath .;%NDDSHOME%\class\nddsjava.jar UnionExample.java
+    javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar UnionExample.java
     
 On Unix systems (including Linux and MacOS X) run:
 
-    javac -classpath .:$NDDSHOME/class/nddsjava.jar UnionExample.java
+    javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar UnionExample.java
 
 Running Java Example
 ====================
-
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
 
 Run the following command from the example directory to execute
 the application.
 
 On Windows Systems:
 
-    java -cp .;%NDDSHOME%\class\nddsjava.jar UnionExample
+    java -cp .;%NDDSHOME%\lib\java\nddsjava.jar UnionExample
 
 On UNIX systems:
 
-    java -cp .:$NDDSHOME/class/nddsjava.jar UnionExample
+    java -cp .:$NDDSHOME/lib/java/nddsjava.jar UnionExample

--- a/examples/dynamic_data_access_union_discriminator/cs/Hello-i86Win32VS2010.csproj
+++ b/examples/dynamic_data_access_union_discriminator/cs/Hello-i86Win32VS2010.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>dynamic_data_union_example</RootNamespace>
+    <AssemblyName>dynamic_data_union_example</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <FileAlignment>512</FileAlignment>
+    <ProjectGuid>{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug-VS2010\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release-VS2010\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nddsdotnet40">
+      <HintPath>$(NDDSHOME)\lib\i86Win32VS2010\nddsdotnet40.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="dynamic_data_union_example.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/examples/dynamic_data_access_union_discriminator/cs/Hello-i86Win32VS2010.sln
+++ b/examples/dynamic_data_access_union_discriminator/cs/Hello-i86Win32VS2010.sln
@@ -1,0 +1,22 @@
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual C# Express 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hello-i86Win32VS2010", "Hello-i86Win32VS2010.csproj", "{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Debug|x86 = Debug|x86
+		Release|Win32 = Release|Win32
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}.Debug|Win32.ActiveCfg = Debug|x86
+		{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}.Debug|Win32.Build.0 = Debug|x86
+		{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}.Debug|x86.ActiveCfg = Debug|x86
+		{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}.Release|Win32.ActiveCfg = Release|x86
+		{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}.Release|x86.ActiveCfg = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/examples/dynamic_data_access_union_discriminator/cs/README.txt
+++ b/examples/dynamic_data_access_union_discriminator/cs/README.txt
@@ -8,9 +8,11 @@ The example is contained in the dynamic_data_union_example.cs file. Before
 compiling or running the example, make sure the environment variable NDDSHOME is
 set to the directory where you installed RTI Connext DDS.
 
-The accompanying Visual Studio project called :
-    dynamic_data_union-i86Win32VS2010.dotnet4.0.sln  
-can be used to compile the application for Visual Studio 2010 using dotnet4.0.
+The accompanying Visual Studio projects called :
+    Hello-i86Win32dotnet4.0.sln and Hello-i86Win32VS2010.sln
+can be used to compile the application for Visual Studio 2010. Whether the NDDS
+version is higher or equal than 5.2.0, you have to use Hello-i86Win32VS2010.sln,
+else you have to use Hello-i86Win32dotnet4.0.sln.
 
 If you are using this method, build the solution in Visual Studio 2010 and 
 continue reading "Running C# Example" paragraph.

--- a/examples/dynamic_data_nested_structs/cs/Hello-i86Win32VS2010.csproj
+++ b/examples/dynamic_data_nested_structs/cs/Hello-i86Win32VS2010.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>dynamic_data_nested_structs</RootNamespace>
+    <AssemblyName>dynamic_data_nested_structs</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <FileAlignment>512</FileAlignment>
+    <ProjectGuid>{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug-VS2010\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release-VS2010\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nddsdotnet40">
+      <HintPath>$(NDDSHOME)\lib\i86Win32VS2010\nddsdotnet40.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="dynamic_data_nested_structs.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/examples/dynamic_data_nested_structs/cs/Hello-i86Win32VS2010.sln
+++ b/examples/dynamic_data_nested_structs/cs/Hello-i86Win32VS2010.sln
@@ -1,0 +1,22 @@
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual C# Express 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hello-i86Win32VS2010", "Hello-i86Win32VS2010.csproj", "{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Debug|x86 = Debug|x86
+		Release|Win32 = Release|Win32
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}.Debug|Win32.ActiveCfg = Debug|x86
+		{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}.Debug|Win32.Build.0 = Debug|x86
+		{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}.Debug|x86.ActiveCfg = Debug|x86
+		{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}.Release|Win32.ActiveCfg = Release|x86
+		{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}.Release|x86.ActiveCfg = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/examples/dynamic_data_nested_structs/cs/README.txt
+++ b/examples/dynamic_data_nested_structs/cs/README.txt
@@ -8,9 +8,11 @@ The example is contained in the dynamic_data_nested_structs.cs file. Before
 compiling or running the example, make sure the environment variable NDDSHOME is
 set to the directory where you installed RTI Connext DDS.
 
-The accompanying Visual Studio project called :
-    dynamic_data_union-i86Win32VS2010.dotnet4.0.sln  
-can be used to compile the application for Visual Studio 2010 using dotnet4.0.
+The accompanying Visual Studio projects called :
+    Hello-i86Win32dotnet4.0.sln and Hello-i86Win32VS2010.sln
+can be used to compile the application for Visual Studio 2010. Whether the NDDS
+version is higher or equal than 5.2.0, you have to use Hello-i86Win32VS2010.sln,
+else you have to use Hello-i86Win32dotnet4.0.sln.
 
 If you are using this method, build the solution in Visual Studio 2010 and 
 continue reading "Running C# Example" paragraph.

--- a/examples/dynamic_data_nested_structs/java/README.txt
+++ b/examples/dynamic_data_nested_structs/java/README.txt
@@ -4,7 +4,6 @@
 
 Building Java example
 =====================
-
 The example is contained in the DynamicDataNestedStruct.java file. Before 
 compiling or running the example, make sure the environment variable NDDSHOME is
 set to the directory where your version of RTI Connext is installed.
@@ -14,42 +13,21 @@ compiler is in your PATH environment variable.
 
 In Windows systems run:
     
-    javac -classpath .;%NDDSHOME%\class\nddsjava.jar DynamicDataNestedStruct.java
+    javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar DynamicDataNestedStruct.java
     
 On Unix systems (including Linux and MacOS X) run:
 
-    javac -classpath .:$NDDSHOME/class/nddsjava.jar DynamicDataNestedStruct.java
-    
-There is a makefile, called makefilei86Linux2 to compile easier this example
-on Unix systems.
-
-$ make -f makefilei86Linux2.6jdk ARCH=<arch_name>
-
+    javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar DynamicDataNestedStruct.java
+  
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Run the following command from the example directory to execute
-the application.
-
 On Windows Systems:
 
-    java -cp .;%NDDSHOME%\class\nddsjava.jar DynamicDataNestedStruct
+    java -cp .;%NDDSHOME%\lib\java\nddsjava.jar DynamicDataNestedStruct
 
 On UNIX systems:
 
-    java -cp .:$NDDSHOME/class/nddsjava.jar DynamicDataNestedStruct
+    java -cp .:$NDDSHOME/lib/java/nddsjava.jar DynamicDataNestedStruct
     
 Running the program produces the following output:
 

--- a/examples/dynamic_data_sequences/cs/Hello-i86Win32VS2010.csproj
+++ b/examples/dynamic_data_sequences/cs/Hello-i86Win32VS2010.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>dynamic_data_sequences</RootNamespace>
+    <AssemblyName>dynamic_data_sequences</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <FileAlignment>512</FileAlignment>
+    <ProjectGuid>{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug-VS2010\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release-VS2010\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nddsdotnet40">
+      <HintPath>$(NDDSHOME)\lib\i86Win32VS2010\nddsdotnet40.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="dynamic_data_sequences.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/examples/dynamic_data_sequences/cs/Hello-i86Win32VS2010.sln
+++ b/examples/dynamic_data_sequences/cs/Hello-i86Win32VS2010.sln
@@ -1,0 +1,22 @@
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual C# Express 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hello-i86Win32VS2010", "Hello-i86Win32VS2010.csproj", "{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Debug|x86 = Debug|x86
+		Release|Win32 = Release|Win32
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}.Debug|Win32.ActiveCfg = Debug|x86
+		{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}.Debug|Win32.Build.0 = Debug|x86
+		{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}.Debug|x86.ActiveCfg = Debug|x86
+		{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}.Release|Win32.ActiveCfg = Release|x86
+		{6BFA16EA-BE9E-C6B3-A46A-D65AD0E01659}.Release|x86.ActiveCfg = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/examples/dynamic_data_sequences/cs/README.txt
+++ b/examples/dynamic_data_sequences/cs/README.txt
@@ -8,9 +8,11 @@ The example is contained in the dynamic_data_sequences.cs file. Before
 compiling or running the example, make sure the environment variable NDDSHOME is
 set to the directory where you installed RTI Connext DDS.
 
-The accompanying Visual Studio project called :
-    dynamic_data_sequences-i86Win32VS2010.dotnet4.0.sln
-can be used to compile the application for Visual Studio 2010 using dotnet4.0.
+The accompanying Visual Studio projects called :
+    Hello-i86Win32dotnet4.0.sln and Hello-i86Win32VS2010.sln
+can be used to compile the application for Visual Studio 2010. Whether the NDDS
+version is higher or equal than 5.2.0, you have to use Hello-i86Win32VS2010.sln,
+else you have to use Hello-i86Win32dotnet4.0.sln.
 
 If you are using this method, build the solution in Visual Studio 2010 and 
 continue reading "Running C# Example" paragraph.

--- a/examples/dynamic_data_sequences/java/README.txt
+++ b/examples/dynamic_data_sequences/java/README.txt
@@ -13,35 +13,19 @@ compiler is in your PATH environment variable.
 
 In Windows systems run:
     
-    javac -classpath .;%NDDSHOME%\class\nddsjava.jar DynamicDataSequences.java
+    javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar DynamicDataSequences.java
     
 On Unix systems (including Linux and MacOS X) run:
 
-    javac -classpath .:$NDDSHOME/class/nddsjava.jar DynamicDataSequences.java
+    javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar DynamicDataSequences.java
 
 Running Java Example
 ====================
 
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Run the following command from the example directory to execute
-the application.
-
 On Windows Systems:
 
-    java -cp .;%NDDSHOME%\class\nddsjava.jar DynamicDataSequences
+    java -cp .;%NDDSHOME%\lib\java\nddsjava.jar DynamicDataSequences
 
 On UNIX systems:
 
-    java -cp .:$NDDSHOME/class/nddsjava.jar DynamicDataSequences
+    java -cp .:$NDDSHOME/lib/java/nddsjava.jar DynamicDataSequences

--- a/examples/dynamic_data_using_publisher_subscriber/cs/README.txt
+++ b/examples/dynamic_data_using_publisher_subscriber/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core Libraries and Utilities
+choice (e.g., i86Win32VS2010). The RTI Connext Core Libraries and Utilities
 Getting Started Guide describes this process in detail. Follow the same 
 procedure to generate the code and build the examples. Do not use the -replace 
 option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32dotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable Shapes.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable Shapes.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable Shapes.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable Shapes.idl
 
 ...you will see messages that look like this:
 
@@ -38,8 +38,8 @@ already provided.
 
 Rtiddsgen generates two solutions for Visual Studio C++ and C#, that you will 
 use to build the types and the C# example, respectively. First open  
-async_type-dotnet4.0.sln and build the solution. Once you've done that, open
-async_example-csharp.sln and build the C# example.
+Shapes_type-dotnet4.0.sln and build the solution. Once you've done that, open
+Shapes_example-csharp.sln and build the C# example.
 
 Running C++ Example
 ===================

--- a/examples/dynamic_data_using_publisher_subscriber/java/README.txt
+++ b/examples/dynamic_data_using_publisher_subscriber/java/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32jdk). The RTI Connext Core Libraries and Utilities Getting
-Started Guide describes this process in detail. 
+choice (e.g., i86Win32VS2010). The RTI Connext Core Libraries and Utilities 
+Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32jdk) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language Java -example i86Win32jdk Shapes.idl
+rtiddsgen -language Java -example i86Win32VS2010 Shapes.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk Shapes.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 Shapes.idl
 
 ...you will see messages that look like this:
 
@@ -41,11 +41,11 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar *.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar *.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar *.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar *.java
 
 
 Running Java Example
@@ -53,31 +53,18 @@ Running Java Example
 --------------------------------------------------------------------------------
                 PUBLISH/SUBSCRIBE IN COMMAND PROMPT
 --------------------------------------------------------------------------------
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory:
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar ShapeTypePublisher <domain_id> <sample #>
-java -cp .;%NDDSHOME%\class\nddsjava.jar ShapeTypeSubscriber <domain_id> <sample #>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar ShapeTypePublisher <domain_id> <sample #>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar ShapeTypeSubscriber <domain_id> <sample #>
 
 UNIX systems:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar ShapeTypePublisher <domain_id> <sample #>
-java -cp .:$NDDSHOME/class/nddsjava.jar ShapeTypeSubscriber <domain_id> <sample #>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar ShapeTypePublisher <domain_id> <sample #>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar ShapeTypeSubscriber <domain_id> <sample #>
 
 The applications accept up to two arguments:
 

--- a/examples/get_publishers/cs/README.txt
+++ b/examples/get_publishers/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32dotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable Foo.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable Foo.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable Foo.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable Foo.idl
 
 File C:\local\Foo\cs\Foo_publisher.cs already exists and will
 not be replaced with updated content. If you would like to get a new file with 

--- a/examples/get_publishers/java/README.txt
+++ b/examples/get_publishers/java/README.txt
@@ -15,12 +15,12 @@ use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk sequences.idl
+rtiddsgen -language Java -example i86Win32VS2010 Foo.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk Foo.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 Foo.idl
 
 You will see messages that look like this:
 
@@ -40,34 +40,21 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar Foo.java FooSeq.java FooTypeSupport.java FooTypeCode.java FooDataReader.java FooDataWriter.java FooSubscriber.java FooPublisher.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar Foo.java FooSeq.java FooTypeSupport.java FooTypeCode.java FooDataReader.java FooDataWriter.java FooSubscriber.java FooPublisher.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar Foo.java FooSeq.java FooTypeSupport.java FooTypeCode.java FooDataReader.java FooDataWriter.java FooSubscriber.java FooPublisher.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar Foo.java FooSeq.java FooTypeSupport.java FooTypeCode.java FooDataReader.java FooDataWriter.java FooSubscriber.java FooPublisher.java
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
 Run the following command from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar FooPublisher 
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar FooPublisher 
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar FooPublisher 
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar FooPublisher 

--- a/examples/keyed_data/cs/README.txt
+++ b/examples/keyed_data/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32VSdotnet4.0) run:
+i86Win32VSVS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable keys.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable keys.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable keys.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable keys.idl
 
 File C:\local\keyed_data\cs\keys_subscriber.cs already 
 exists and will not be replaced with updated content. If you would like to get a 

--- a/examples/keyed_data/java/README.txt
+++ b/examples/keyed_data/java/README.txt
@@ -15,12 +15,12 @@ use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk keys.idl
+rtiddsgen -language Java -example i86Win32VS2010 keys.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk keys.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 keys.idl
 
 
 File C:\local\keyed_data\java\keysSubscriber.java already exists and will
@@ -39,40 +39,27 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar keys.java keysSeq.java keysTypeSupport.java keysTypeCode.java keysDataReader.java keysDataWriter.java keysSubscriber.java keysPublisher.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar keys.java keysSeq.java keysTypeSupport.java keysTypeCode.java keysDataReader.java keysDataWriter.java keysSubscriber.java keysPublisher.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar keys.java keysSeq.java keysTypeSupport.java keysTypeCode.java keysDataReader.java keysDataWriter.java keysSubscriber.java keysPublisher.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar keys.java keysSeq.java keysTypeSupport.java keysTypeCode.java keysDataReader.java keysDataWriter.java keysSubscriber.java keysPublisher.java
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar keysPublisher  <domain_id> 16
-java -cp .;%NDDSHOME%\class\nddsjava.jar keysSubscriber <domain_id> 18
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar keysPublisher  <domain_id> 16
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar keysSubscriber <domain_id> 18
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar keysPublisher  <domain_id> 16
-java -cp .:$NDDSHOME/class/nddsjava.jar keysSubscriber <domain_id> 18
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar keysPublisher  <domain_id> 16
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar keysSubscriber <domain_id> 18
 
 The applications accept two arguments:
    1. The <domain_id>. Both applications must use the same domain id in order 

--- a/examples/keyed_data_advanced/cs/README.txt
+++ b/examples/keyed_data_advanced/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32VSdotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable keys.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable keys.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable keys.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable keys.idl
 
 File C:\local\keyed_data_advanced\cs\keys_subscriber.cs already 
 exists and will not be replaced with updated content. If you would like to get a 

--- a/examples/keyed_data_advanced/java/README.txt
+++ b/examples/keyed_data_advanced/java/README.txt
@@ -15,12 +15,12 @@ use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk keys.idl
+rtiddsgen -language Java -example i86Win32VS2010 keys.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk keys.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 keys.idl
 
 
 File C:\local\keyed_data_advanced\java\keysSubscriber.java already exists and will
@@ -39,40 +39,27 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar keys.java keysSeq.java keysTypeSupport.java keysTypeCode.java keysDataReader.java keysDataWriter.java keysSubscriber.java keysPublisher.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar keys.java keysSeq.java keysTypeSupport.java keysTypeCode.java keysDataReader.java keysDataWriter.java keysSubscriber.java keysPublisher.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar keys.java keysSeq.java keysTypeSupport.java keysTypeCode.java keysDataReader.java keysDataWriter.java keysSubscriber.java keysPublisher.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar keys.java keysSeq.java keysTypeSupport.java keysTypeCode.java keysDataReader.java keysDataWriter.java keysSubscriber.java keysPublisher.java
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar keysPublisher  <domain_id> 18
-java -cp .;%NDDSHOME%\class\nddsjava.jar keysSubscriber <domain_id> 20
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar keysPublisher  <domain_id> 18
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar keysSubscriber <domain_id> 20
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar keysPublisher  <domain_id> 18
-java -cp .:$NDDSHOME/class/nddsjava.jar keysSubscriber <domain_id> 20
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar keysPublisher  <domain_id> 18
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar keysSubscriber <domain_id> 20
 
 The applications accept two arguments:
    1. The <domain_id>. Both applications must use the same domain id in order 

--- a/examples/listeners/cs/README.txt
+++ b/examples/listeners/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32VSdotnet4.0) run:
+i86Win32VSVS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable listeners.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable listeners.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable listeners.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable listeners.idl
 
 File C:\local\listeners\cs\listeners_subscriber.cs already 
 exists and will not be replaced with updated content. If you would like to get a 

--- a/examples/listeners/java/README.txt
+++ b/examples/listeners/java/README.txt
@@ -15,12 +15,12 @@ use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk listeners.idl
+rtiddsgen -language Java -example i86Win32VS2010 listeners.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk listeners.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 listeners.idl
 
 You will see messages that look like this:
 
@@ -40,40 +40,27 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar listeners.java listenersSeq.java listenersTypeSupport.java listenersTypeCode.java listenersDataReader.java listenersDataWriter.java listenersSubscriber.java listenersPublisher.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar listeners.java listenersSeq.java listenersTypeSupport.java listenersTypeCode.java listenersDataReader.java listenersDataWriter.java listenersSubscriber.java listenersPublisher.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar listeners.java listenersSeq.java listenersTypeSupport.java listenersTypeCode.java listenersDataReader.java listenersDataWriter.java listenersSubscriber.java listenersPublisher.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar listeners.java listenersSeq.java listenersTypeSupport.java listenersTypeCode.java listenersDataReader.java listenersDataWriter.java listenersSubscriber.java listenersPublisher.java
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar listenersPublisher  <domain_id> <samples_to_send>
-java -cp .;%NDDSHOME%\class\nddsjava.jar listenersSubscriber <domain_id> <sleep_periods>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar listenersPublisher  <domain_id> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar listenersSubscriber <domain_id> <sleep_periods>
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar listenersPublisher  <domain_id> <samples_to_send>
-java -cp .:$NDDSHOME/class/nddsjava.jar listenersSubscriber <domain_id> <sleep_periods>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar listenersPublisher  <domain_id> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar listenersSubscriber <domain_id> <sleep_periods>
 
 
 The applications accept two arguments:

--- a/examples/multichannel/cs/README.txt
+++ b/examples/multichannel/cs/README.txt
@@ -10,20 +10,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32dotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable market_data.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable market_data.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable 
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable 
 market_data.idl
 
 ...you will see messages that look like this:

--- a/examples/multichannel/java/README.txt
+++ b/examples/multichannel/java/README.txt
@@ -8,19 +8,19 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32jdk or i86Linux2.6gcc4.6.3jdk). The RTI Connext Core 
+choice (e.g., i86Win32VS2010 or i86Linux2.6gcc4.6.3). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk market_data.idl
+rtiddsgen -language Java -example i86Win32VS2010 market_data.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.6.3jdk market_data.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.6.3 market_data.idl
 
 You will see messages that look like this:
 
@@ -43,39 +43,26 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar *.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar *.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar *.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar *.java
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-    java -cp .;%NDDSHOME%\class\nddsjava.jar market_dataPublisher <domain#> 400
-    java -cp .;%NDDSHOME%\class\nddsjava.jar market_dataSubscriber <domain#> 10
+    java -cp .;%NDDSHOME%\lib\java\nddsjava.jar market_dataPublisher <domain#> 400
+    java -cp .;%NDDSHOME%\lib\java\nddsjava.jar market_dataSubscriber <domain#> 10
 
 On Unix systems (including Linux and MacOS X) run:
-    java -cp .:$NDDSHOME/class/nddsjava.jar market_dataPublisher <domain#> 400
-    java -cp .:$NDDSHOME/class/nddsjava.jar market_dataSubscriber <domain#> 10
+    java -cp .:$NDDSHOME/lib/java/nddsjava.jar market_dataPublisher <domain#> 400
+    java -cp .:$NDDSHOME/lib/java/nddsjava.jar market_dataSubscriber <domain#> 10
 
    The applications accept up to two arguments:
 

--- a/examples/ordered_presentation/cs/README.txt
+++ b/examples/ordered_presentation/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32dotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable ordered.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable ordered.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable ordered.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable ordered.idl
 
 ...you will see messages that look like this:
 
@@ -55,8 +55,8 @@ the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-    bin\<build_type>-VS2010\async_publisher.exe  <domain_id> <samples_to_send>
-    bin\<build_type>-VS2010\async_subscriber.exe <domain_id> <sleep_periods>
+    bin\<build_type>-VS2010\ordered_publisher.exe  <domain_id> <samples_to_send>
+    bin\<build_type>-VS2010\ordered_subscriber.exe <domain_id> <sleep_periods>
 
 The applications accept up to two arguments:
 

--- a/examples/ordered_presentation/java/README.txt
+++ b/examples/ordered_presentation/java/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32jdk or i86Linux2.6gcc4.4.3jdk). The RTI Connext Core 
+choice (e.g., i86Win32VS2010 or i86Linux2.6gcc4.4.3). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32jdk) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language Java -example i86Win32jdk ordered.idl
+rtiddsgen -language Java -example i86Win32VS2010 ordered.idl
 
 On UNIX systems (assuming you want to generate an example for 
-i86Linux2.6gcc4.4.3jdk) run:
+i86Linux2.6gcc4.4.) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk ordered.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 ordered.idl
 
 You will see messages that look like this:
 
@@ -44,41 +44,28 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar *.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar *.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar *.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar *.java
 
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar orderedPublisher  <domain_id> <samples_to_send>
-java -cp .;%NDDSHOME%\class\nddsjava.jar orderedSubscriber <domain_id> <sleep_periods>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar orderedPublisher  <domain_id> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar orderedSubscriber <domain_id> <sleep_periods>
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar orderedPublisher  <domain_id> <samples_to_send>
-java -cp .:$NDDSHOME/class/nddsjava.jar orderedSubscriber <domain_id> <sleep_periods>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar orderedPublisher  <domain_id> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar orderedSubscriber <domain_id> <sleep_periods>
 
 The applications accept up to two arguments:
 

--- a/examples/partitions/cs/README.txt
+++ b/examples/partitions/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32VSdotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable partitions.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable partitions.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable partitions.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable partitions.idl
 
 File C:\local\partitions\cs\partitions_subscriber.cs already 
 exists and will not be replaced with updated content. If you would like to get a 
@@ -34,10 +34,10 @@ This is normal and is only informing you that the subscriber/publisher code has
 not been replaced, which is fine since all the source files for the example are
 already provided.
 
-Rtiddsgen generates two solutions for Visual Studio C++ and C#, that you will use to
-build the types and the C# example, respectively. First open  partitions_type-dotnet4.0.sln 
-and build the solution. Once you've done that, open partitions_example-csharp.sln and build
-the C# example.
+Rtiddsgen generates two solutions for Visual Studio C++ and C#, that you will 
+use to build the types and the C# example, respectively. First open  
+partitions_type-dotnet4.0.sln and build the solution. Once you've done that, 
+open partitions_example-csharp.sln and build the C# example.
 
 Running C# Example
 ===================

--- a/examples/partitions/java/README.txt
+++ b/examples/partitions/java/README.txt
@@ -15,12 +15,12 @@ use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk partitions.idl
+rtiddsgen -language Java -example i86Win32VS2010 partitions.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk partitions.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 partitions.idl
 
 You will see messages that look like this:
 
@@ -40,40 +40,27 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar partitions.java partitionsSeq.java partitionsTypeSupport.java partitionsTypeCode.java partitionsDataReader.java partitionsDataWriter.java partitionsSubscriber.java partitionsPublisher.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar partitions.java partitionsSeq.java partitionsTypeSupport.java partitionsTypeCode.java partitionsDataReader.java partitionsDataWriter.java partitionsSubscriber.java partitionsPublisher.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar partitions.java partitionsSeq.java partitionsTypeSupport.java partitionsTypeCode.java partitionsDataReader.java partitionsDataWriter.java partitionsSubscriber.java partitionsPublisher.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar partitions.java partitionsSeq.java partitionsTypeSupport.java partitionsTypeCode.java partitionsDataReader.java partitionsDataWriter.java partitionsSubscriber.java partitionsPublisher.java
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar partitionsPublisher  <domain_id> <samples_to_send>
-java -cp .;%NDDSHOME%\class\nddsjava.jar partitionsSubscriber <domain_id> <sleep_periods>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar partitionsPublisher  <domain_id> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar partitionsSubscriber <domain_id> <sleep_periods>
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar partitionsPublisher  <domain_id> <samples_to_send>
-java -cp .:$NDDSHOME/class/nddsjava.jar partitionsSubscriber <domain_id> <sleep_periods>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar partitionsPublisher  <domain_id> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar partitionsSubscriber <domain_id> <sleep_periods>
 
 
 The applications accept two arguments:

--- a/examples/persistent_storage/c++/README.txt
+++ b/examples/persistent_storage/c++/README.txt
@@ -76,7 +76,7 @@ Scenarios commands:
     Persistence Service Scenario
     1) Run persistence service (in the same folder that there are 
     persistence_service_configuration.xml): 
-        %NDDSHOME%\scripts\rtipersistenceservice.bat -cfgFile persistence_service_configuration.xml 
+        %NDDSHOME%\bin\rtipersistenceservice.bat -cfgFile persistence_service_configuration.xml 
             -cfgName <persistence_service_database|persistence_service_filesystem>
 
     2) objs\<arch_name>\hello_world_subscriber.exe
@@ -101,7 +101,7 @@ Scenarios commands:
     Persistence Service Scenario
     1) Run persistence service (in the same folder that there are 
     persistence_service_configuration.xml): 
-        %NDDSHOME%\scripts\rtipersistenceservice -cfgFile persistence_service_configuration.xml 
+        %NDDSHOME%\bin\rtipersistenceservice -cfgFile persistence_service_configuration.xml 
             -cfgName <persistence_service_database|persistence_service_filesystem>
 
     2) ./objs/<arch_name>/hello_world_subscriber

--- a/examples/persistent_storage/c/README.txt
+++ b/examples/persistent_storage/c/README.txt
@@ -72,7 +72,7 @@ documents for further details.
     Persistence Service Scenario
     1) Run persistence service (in the same folder that there are 
     persistence_service_configuration.xml): 
-        %NDDSHOME%\scripts\rtipersistenceservice.bat -cfgFile persistence_service_configuration.xml 
+        %NDDSHOME%\bin\rtipersistenceservice.bat -cfgFile persistence_service_configuration.xml 
             -cfgName <persistence_service_database|persistence_service_filesystem>
 
     2) objs\<arch_name>\hello_world_subscriber.exe
@@ -97,7 +97,7 @@ documents for further details.
     Persistence Service Scenario
     1) Run persistence service (in the same folder that there are 
     persistence_service_configuration.xml): 
-        %NDDSHOME%\scripts\rtipersistenceservice -cfgFile persistence_service_configuration.xml 
+        %NDDSHOME%\bin\rtipersistenceservice -cfgFile persistence_service_configuration.xml 
             -cfgName <persistence_service_database|persistence_service_filesystem>
 
     2) ./objs/<arch_name>/hello_world_subscriber

--- a/examples/persistent_storage/cs/README.txt
+++ b/examples/persistent_storage/cs/README.txt
@@ -9,20 +9,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32dotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable hello_world.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable hello_world.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable hello_world.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable hello_world.idl
 
 You will see messages that look like this:
 
@@ -81,7 +81,7 @@ Scenarios commands:
     Persistence Service Scenario
     1) Run persistence service (in the same folder that there are 
     persistence_service_configuration.xml): 
-        %NDDSHOME%\scripts\rtipersistenceservice.bat -cfgFile persistence_service_configuration.xml 
+        %NDDSHOME%\bin\rtipersistenceservice.bat -cfgFile persistence_service_configuration.xml 
             -cfgName <persistence_service_database|persistence_service_filesystem>
 
     2) bin\<build_type>-VS2010\hello_world_subscriber.exe

--- a/examples/persistent_storage/java/README.txt
+++ b/examples/persistent_storage/java/README.txt
@@ -8,19 +8,19 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32jdk or i86Linux2.6gcc4.4.3jdk). The RTI Connext Core 
+choice (e.g., i86Win32VS2010 or i86Linux2.6gcc4.4.3). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk hello_world.idl
+rtiddsgen -language Java -example i86Win32VS2010 hello_world.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk hello_world.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 hello_world.idl
 
 You will see messages that look like this:
 
@@ -45,28 +45,15 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar *.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar *.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar *.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar *.java
 
 Running C Example
 =================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, use two separate command prompts for publisher and subscriber. Run the 
+In two separate command prompts for publisher and subscriber. Run the 
 following commands from the example directory (this is necessary to ensure the
 application loads the QoS defined in USER_QOS_PROFILES.xml):
 
@@ -84,53 +71,53 @@ Scenarios commands:
 
 ** On Windows systems run:
     Durable Writer History scenario
-    1) java -cp .;%NDDSHOME%\class\nddsjava.jar hello_worldSubscriber
-    2) java -cp .;%NDDSHOME%\class\nddsjava.jar hello_worldPublisher -sample_count 5 -initial_value 0 -dwh 1 
-    3) java -cp .;%NDDSHOME%\class\nddsjava.jar hello_worldSubscriber
-    4) java -cp .;%NDDSHOME%\class\nddsjava.jar hello_worldPublisher -sample_count 5 -initial_value 5 -dwh 1
+    1) java -cp .;%NDDSHOME%\lib\java\nddsjava.jar hello_worldSubscriber
+    2) java -cp .;%NDDSHOME%\lib\java\nddsjava.jar hello_worldPublisher -sample_count 5 -initial_value 0 -dwh 1 
+    3) java -cp .;%NDDSHOME%\lib\java\nddsjava.jar hello_worldSubscriber
+    4) java -cp .;%NDDSHOME%\lib\java\nddsjava.jar hello_worldPublisher -sample_count 5 -initial_value 5 -dwh 1
 
     Durable Reader State Scenario
-    1) java -cp .;%NDDSHOME%\class\nddsjava.jar hello_worldSubscriber -drs 1
-    2) java -cp .;%NDDSHOME%\class\nddsjava.jar hello_worldPublisher -sample_count 5 -initial_value 0 -sleep 60 
+    1) java -cp .;%NDDSHOME%\lib\java\nddsjava.jar hello_worldSubscriber -drs 1
+    2) java -cp .;%NDDSHOME%\lib\java\nddsjava.jar hello_worldPublisher -sample_count 5 -initial_value 0 -sleep 60 
     3) stop hello_worldSubscriber
-    4) java -cp .;%NDDSHOME%\class\nddsjava.jar hello_worldSubscriber
-    5) java -cp .;%NDDSHOME%\class\nddsjava.jar hello_worldSubscriber -drs 1
+    4) java -cp .;%NDDSHOME%\lib\java\nddsjava.jar hello_worldSubscriber
+    5) java -cp .;%NDDSHOME%\lib\java\nddsjava.jar hello_worldSubscriber -drs 1
 
 
     Persistence Service Scenario
     1) Run persistence service (in the same folder that there are 
     persistence_service_configuration.xml): 
-        %NDDSHOME%\scripts\rtipersistenceservice.bat -cfgFile persistence_service_configuration.xml 
+        %NDDSHOME%\bin\rtipersistenceservice.bat -cfgFile persistence_service_configuration.xml 
             -cfgName <persistence_service_database|persistence_service_filesystem>
 
-    2) java -cp .;%NDDSHOME%\class\nddsjava.jar hello_worldSubscriber
-    3) java -cp .;%NDDSHOME%\class\nddsjava.jar hello_worldPublisher -sample_count 5 -initial_value 0
-    4) java -cp .;%NDDSHOME%\class\nddsjava.jar hello_worldSubscriber 
+    2) java -cp .;%NDDSHOME%\lib\java\nddsjava.jar hello_worldSubscriber
+    3) java -cp .;%NDDSHOME%\lib\java\nddsjava.jar hello_worldPublisher -sample_count 5 -initial_value 0
+    4) java -cp .;%NDDSHOME%\lib\java\nddsjava.jar hello_worldSubscriber 
 
 ** On UNIX systems run:
     Durable Writer History scenario
-    1) java -cp .:$NDDSHOME/class/nddsjava.jar hello_worldSubscriber
-    2) java -cp .:$NDDSHOME/class/nddsjava.jar hello_worldPublisher -sample_count 5 -initial_value 0 -dwh 1 
-    3) java -cp .:$NDDSHOME/class/nddsjava.jar hello_worldSubscriber
-    4) java -cp .:$NDDSHOME/class/nddsjava.jar hello_worldPublisher -sample_count 5 -initial_value 5 -dwh 1
+    1) java -cp .:$NDDSHOME/lib/java/nddsjava.jar hello_worldSubscriber
+    2) java -cp .:$NDDSHOME/lib/java/nddsjava.jar hello_worldPublisher -sample_count 5 -initial_value 0 -dwh 1 
+    3) java -cp .:$NDDSHOME/lib/java/nddsjava.jar hello_worldSubscriber
+    4) java -cp .:$NDDSHOME/lib/java/nddsjava.jar hello_worldPublisher -sample_count 5 -initial_value 5 -dwh 1
 
     Durable Reader State Scenario
-    1) java -cp .:$NDDSHOME/class/nddsjava.jar hello_worldSubscriber -drs 1
-    2) java -cp .:$NDDSHOME/class/nddsjava.jar hello_worldPublisher -sample_count 5 -initial_value 0 -sleep 60 
+    1) java -cp .:$NDDSHOME/lib/java/nddsjava.jar hello_worldSubscriber -drs 1
+    2) java -cp .:$NDDSHOME/lib/java/nddsjava.jar hello_worldPublisher -sample_count 5 -initial_value 0 -sleep 60 
     3) stop hello_worldSubscriber
-    4) java -cp .:$NDDSHOME/class/nddsjava.jar hello_worldSubscriber
-    5) java -cp .:$NDDSHOME/class/nddsjava.jar hello_worldSubscriber -drs 1
+    4) java -cp .:$NDDSHOME/lib/java/nddsjava.jar hello_worldSubscriber
+    5) java -cp .:$NDDSHOME/lib/java/nddsjava.jar hello_worldSubscriber -drs 1
 
 
     Persistence Service Scenario
     1) Run persistence service (in the same folder that there are 
     persistence_service_configuration.xml): 
-        %NDDSHOME%\scripts\rtipersistenceservice -cfgFile persistence_service_configuration.xml 
+        %NDDSHOME%\bin\rtipersistenceservice -cfgFile persistence_service_configuration.xml 
             -cfgName <persistence_service_database|persistence_service_filesystem>
 
-    2) java -cp .:$NDDSHOME/class/nddsjava.jar hello_worldSubscriber
-    3) java -cp .:$NDDSHOME/class/nddsjava.jar hello_worldPublisher -sample_count 5 -initial_value 0
-    4) java -cp .:$NDDSHOME/class/nddsjava.jar hello_worldSubscriber 
+    2) java -cp .:$NDDSHOME/lib/java/nddsjava.jar hello_worldSubscriber
+    3) java -cp .:$NDDSHOME/lib/java/nddsjava.jar hello_worldPublisher -sample_count 5 -initial_value 0
+    4) java -cp .:$NDDSHOME/lib/java/nddsjava.jar hello_worldSubscriber 
 
 The applications accepts different arguments:
     hello_worldSubscriber:  

--- a/examples/polling_querycondition/cs/README.txt
+++ b/examples/polling_querycondition/cs/README.txt
@@ -8,15 +8,15 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32VSdotnet4.0) run:
+i86Win32VSVS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 querycondition.idl
+rtiddsgen -language C# -example i86Win32VS2010 querycondition.idl
 
 File C:\local\polling_querycondition\cs\querycondition_subscriber.cs already 
 exists and will not be replaced with updated content. If you would like to get a 

--- a/examples/polling_querycondition/java/README.txt
+++ b/examples/polling_querycondition/java/README.txt
@@ -8,19 +8,19 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32jdk or i86Linux2.6gcc4.4.3jdk). The RTI Connext Core 
+choice (e.g., i86Win32VS2010 or i86Linux2.6gcc4.4.3). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk querycondition.idl
+rtiddsgen -language Java -example i86Win32VS2010 querycondition.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk querycondition.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 querycondition.idl
 
 You will see messages that look like this:
 
@@ -40,40 +40,27 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar querycondition.java queryconditionSeq.java queryconditionTypeSupport.java queryconditionTypeCode.java queryconditionDataReader.java queryconditionDataWriter.java queryconditionSubscriber.java queryconditionPublisher.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar querycondition.java queryconditionSeq.java queryconditionTypeSupport.java queryconditionTypeCode.java queryconditionDataReader.java queryconditionDataWriter.java queryconditionSubscriber.java queryconditionPublisher.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar querycondition.java queryconditionSeq.java queryconditionTypeSupport.java queryconditionTypeCode.java queryconditionDataReader.java queryconditionDataWriter.java queryconditionSubscriber.java queryconditionPublisher.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar querycondition.java queryconditionSeq.java queryconditionTypeSupport.java queryconditionTypeCode.java queryconditionDataReader.java queryconditionDataWriter.java queryconditionSubscriber.java queryconditionPublisher.java
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar queryconditionPublisher  <domain_id> <samples_to_send>
-java -cp .;%NDDSHOME%\class\nddsjava.jar queryconditionSubscriber <domain_id> <sleep_periods>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar queryconditionPublisher  <domain_id> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar queryconditionSubscriber <domain_id> <sleep_periods>
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar queryconditionPublisher  <domain_id> <samples_to_send>
-java -cp .:$NDDSHOME/class/nddsjava.jar queryconditionSubscriber <domain_id> <sleep_periods>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar queryconditionPublisher  <domain_id> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar queryconditionSubscriber <domain_id> <sleep_periods>
 
 
 The applications accept two arguments:

--- a/examples/polling_read/cs/README.txt
+++ b/examples/polling_read/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32dotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable poll.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable poll.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable poll.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable poll.idl
 
 You will see messages that look like this:
 

--- a/examples/polling_read/java/README.txt
+++ b/examples/polling_read/java/README.txt
@@ -8,7 +8,7 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32jdk or i86Linux2.6gcc4.4.3jdk). The RTI Connext Core 
+choice (e.g., i86Win32VS2010 or i86Linux2.6gcc4.4.3). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
@@ -16,12 +16,12 @@ use the -replace option.
 On Windows systems (assuming you want to generate an example for 
 i86Win32VS2005) run:
 
-rtiddsgen -language Java -example i86Win32jdk poll.idl
+rtiddsgen -language Java -example i86Win32VS2010 poll.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk poll.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 poll.idl
 
 You will see messages that look like this:
 
@@ -41,43 +41,29 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar poll.java pollSeq.java pollTypeSupport.java pollTypeCode.java pollDataReader.java pollDataWriter.java pollSubscriber.java pollPublisher.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar poll.java pollSeq.java pollTypeSupport.java pollTypeCode.java pollDataReader.java pollDataWriter.java pollSubscriber.java pollPublisher.java
 
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar poll.java pollSeq.java pollTypeSupport.java pollTypeCode.java pollDataReader.java pollDataWriter.java pollSubscriber.java pollPublisher.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar poll.java pollSeq.java pollTypeSupport.java pollTypeCode.java pollDataReader.java pollDataWriter.java pollSubscriber.java pollPublisher.java
 
 
 Running Java Example
 ====================
-
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber, 
+In two separate command prompt windows for the publisher and subscriber, 
 run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar pollPublisher  <domain_id> <samples_to_send>
-java -cp .;%NDDSHOME%\class\nddsjava.jar pollSubscriber <domain_id> <sleep_periods>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar pollPublisher  <domain_id> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar pollSubscriber <domain_id> <sleep_periods>
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar pollPublisher  <domain_id> <samples_to_send>
-java -cp .:$NDDSHOME/class/nddsjava.jar pollSubscriber <domain_id> <sleep_periods>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar pollPublisher  <domain_id> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar pollSubscriber <domain_id> <sleep_periods>
 
 The applications accept two arguments:
    1. The <domain_id>. Both applications must use the same domain ID in order to

--- a/examples/property_qos/README.txt
+++ b/examples/property_qos/README.txt
@@ -2,29 +2,36 @@
 Example Code - Using the Property QoS
 =====================================
 
-
 Concept
 -------
+The Property QosPolicy is used to specify name/value pairs of data and attach
+them to an entity, such as a DomainParticipant. 
 
-The Property QosPolicy is used to specify name/value pairs of data and attach them to an entity, such as a DomainParticipant. 
+Some values can only be set through properties, such as the properties that
+enable and configure the Monitor library. Other values can be set in multiple
+ways, such as built-in transport properties, which can be enabled with 
+properties, or by creating TransportProperty structures. 
 
-Some values can only be set through properties, such as the properties that enable and configure the Monitor library. Other values can be set in multiple ways, such as built-in transport properties, which can be enabled with properties, or by creating TransportProperty structures. 
+For the second case, setting the properties using the Property QoS is much 
+easier.  An example of the steps required to change the transport properties 
+without the Property QoS:
 
-For the second case, setting the properties using the Property QoS is much easier.  An example of the steps required to change the transport properties without the Property QoS:
-
-
-1. Change the factory entity's QoS to create its children disabled
-2. Create the entity 
-2. Get its transport properties
-3. Change its transport properties
-4. Enable the entity
+  1. Change the factory entity's QoS to create its children disabled
+  2. Create the entity 
+  3. Get its transport properties
+  4. Change its transport properties
+  5. Enable the entity
 
 Example Description
 -------------------
-The attached example code shows how to use the Property QosPolicy to modify the send and receive socket buffer transport properties. It shows this three ways:
-1. Using the XML QoS file to set the Property QoS policy
-2. Setting the Property QoS policy in code.
-3. Changing these values in code without the Property QoS Policy (the code refers to this as the "classic" method), so you can see the difference.
+The attached example code shows how to use the Property QosPolicy to modify the
+send and receive socket buffer transport properties. It shows this three ways:
+  1. Using the XML QoS file to set the Property QoS policy
+  2. Setting the Property QoS policy in code.
+  3. Changing these values in code without the Property QoS Policy (the code 
+     refers to this as the "classic" method), so you can see the difference.
 
 
-Note that the C# example is slightly different, because it does not set the transport properties in code.  This cannot be done in C# using the transport APIs, and must be done through the Property QoS Policy in code or XML.
+Note that the C# example is slightly different, because it does not set the 
+transport properties in code.  This cannot be done in C# using the transport 
+APIs, and must be done through the Property QoS Policy in code or XML.

--- a/examples/property_qos/c++/README.txt
+++ b/examples/property_qos/c++/README.txt
@@ -4,42 +4,67 @@ Example code: Using Property QoS
 
 Building C++ Example
 ====================
+Before compiling or running the example, make sure the environment variable 
+NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
-Before compiling or running the example, make sure the environment variable NDDSHOME is set to the directory where your version of RTI Data Distribution Service is installed.
+Run rtiddsgen with the -example option and the target architecture of your 
+choice (e.g., i86Win32VS2005 or i86Linux2.6gcc4.4.3). The RTI Connext Core 
+Libraries and Utilities Getting Started Guide describes this process in detail. 
+Follow the same procedure to generate the code and build the examples. Do not 
+use the -replace option.
 
-Run rtiddsgen with the -example option and the target architecture of your choice (for example, i86Win32VS2010). The RTI Connext DDS Getting Started Guide describes this process in detail. Follow the same procedure to generate the code and build the examples. Do not use the -replace option.
+On Windows systems (assuming you want to generate an example for 
+i86Win32VS2005) run:
 
-After running rtiddsgen like this...
+rtiddsgen -language C++ -example i86Win32VS2005 numbers.idl
 
-C:\local\property_qos\c++> rtiddsgen -language C++ -example i86Win32VS2010 numbers.idl
+On UNIX systems (assuming you want to generate an example for 
+i86Linux2.6gcc4.4.3) run:
 
-...you will see messages that look like this:
+rtiddsgen -language C++ -example i86Linux2.6gcc4.4.3 numbers.idl
 
-File C:\local\property_qos\c++\numbers_subscriber.cxx already exists and will not be replaced with updated content. If you would like to get a new file with the new content, either remove this file or supply -replace option.
-File C:\local\property_qos\c++\numbers_publisher.cxx already exists and will not be replaced with updated content. If you would like to get a new file with the new content, either remove this file or supply -replace option.
+You will see messages that look like this:
 
-This is normal and is only informing you that the subscriber/publisher code has not been replaced, which is fine since all the source files for the example are already provided.
+File C:\local\property_qos\c++\numbers_subscriber.cxx already exists and will 
+not be replaced with updated content. If you would like to get a new file with 
+the new content, either remove this file or supply -replace option.
+File C:\local\property_qos\c++\numbers_publisher.cxx already exists and will not
+be replaced with updated content. If you would like to get a new file with the
+new content, either remove this file or supply -replace option.
+File C:\local\property_qos\c\USER_QOS_PROFILES.xml already exists and will not
+be replaced with updated content. If you would like to get a new file with the
+new content, either remove this file or supply -replace option.
+
+This is normal and is only informing you that the subscriber/publisher code has 
+not been replaced, which is fine since all the source files for the example are
+already provided.
 
 Running
 =======
-In two separate command prompt windows for the publisher and subscriber, navigate to the objs/<arch> directory and run these commands:
+In two separate command prompt windows for the publisher and subscriber. Run
+the following commands from the example directory (this is necessary to ensure
+the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
-Windows systems:
+On Windows systems run:
 
-    * numbers_publisher.exe <domain#> 4
-    * numbers_subscriber.exe <domain#> 4
+objs\<arch_name>\numbers_publisher.exe  <domain_id> <samples_to_send>
+objs\<arch_name>\numbers_subscriber.exe <domain_id>  <sleep_periods> 
 
 UNIX systems:
 
-    * ./numbers_publisher <domain#> 4
-    * ./numbers_subscriber <domain#> 4
+./objs/<arch_name>/numbers_publisher  <domain_id> <samples_to_send>
+./objs/<arch_name>/numbers_subscriber <domain_id> <sleep_periods> 
 
-The applications accept two arguments:
+The applications accept up to two arguments:
 
-   1. The <domain #>. Both applications must use the same domain # in order to communicate. The default is 0.
-   2. How long the examples should run, measured in samples for the publisher and sleep periods for the subscriber. A value of '0' instructs the application to run forever; this is the default.
+   1. The <domain_id>. Both applications must use the same domain id in order 
+   to communicate. The default is 0.
+   2. How long the examples should run, measured in samples for the publisher 
+   and sleep periods for the subscriber. A value of '0' instructs the 
+   application to run forever; this is the default.
 
-While generating the output below, we used values that would capture the most interesting behavior.
+While generating the output below, we used values that would capture the most 
+interesting behavior.
 
 Publisher Output
 ================

--- a/examples/property_qos/c/README.txt
+++ b/examples/property_qos/c/README.txt
@@ -4,43 +4,67 @@ Example code: Using Property QoS
 
 Building C Example
 ==================
-Make sure you are using one of the relevant RTI Data Distribution Service versions, as specified at the top of the Solution.
+Before compiling or running the example, make sure the environment variable 
+NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
-Before compiling or running the example, make sure the environment variable NDDSHOME is set to the directory where your version of RTI Data Distribution Service is installed.
+Run rtiddsgen with the -example option and the target architecture of your 
+choice (e.g., i86Win32VS2005 or i86Linux2.6gcc4.4.3). The RTI Connext Core 
+Libraries and Utilities Getting Started Guide describes this process in detail. 
+Follow the same procedure to generate the code and build the examples. Do not 
+use the -replace option.
 
-Run rtiddsgen with the -example option and the target architecture of your choice (for example, i86Win32VS2010). The RTI Data Distribution Service Getting Started Guide describes this process in detail. Follow the same procedure to generate the code and build the examples. Do not use the -replace option.
+On Windows systems (assuming you want to generate an example for 
+i86Win32VS2005) run:
 
-After running rtiddsgen like this...
+rtiddsgen -language C -example i86Win32VS2005 numbers.idl
 
-C:\local\property_qos\c> rtiddsgen -language C -example i86Win32VS2010 numbers.idl
+On UNIX systems (assuming you want to generate an example for 
+i86Linux2.6gcc4.4.3) run:
 
-...you will see messages that look like this:
+rtiddsgen -language C -example i86Linux2.6gcc4.4.3 numbers.idl
 
-File C:\local\property_qos\c\numbers_subscriber.c already exists and will not be replaced with updated content. If you would like to get a new file with the new content, either remove this file or supply -replace option.
-File C:\local\property_qos\c\numbers_publisher.c already exists and will not be replaced with updated content. If you would like to get a new file with the new content, either remove this file or supply -replace option.
+You will see messages that look like this:
 
-This is normal and is only informing you that the subscriber/publisher code has not been replaced, which is fine since all the source files for the example are already provided.
+File C:\local\property_qos\c\numbers_subscriber.c already exists and will not be
+replaced with updated content. If you would like to get a new file with the new
+content, either remove this file or supply -replace option.
+File C:\local\property_qos\c\numbers_publisher.c already exists and will not be
+replaced with updated content. If you would like to get a new file with the new
+content, either remove this file or supply -replace option.
+File C:\local\property_qos\c\USER_QOS_PROFILES.xml already exists and will not
+be replaced with updated content. If you would like to get a new file with the
+new content, either remove this file or supply -replace option.
+
+This is normal and is only informing you that the subscriber/publisher code has
+not been replaced, which is fine since all the source files for the example are
+already provided.
 
 Running C Example
 =================
-In two separate command prompt windows for the publisher and subscriber, navigate to the objs/<arch> directory and run these commands:
+In two separate command prompt windows for the publisher and subscriber. Run
+the following commands from the example directory (this is necessary to ensure
+the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
-Windows systems:
+On Windows systems run:
 
-    * numbers_publisher.exe <domain#> 4
-    * numbers_subscriber.exe <domain#> 4
+objs\<arch_name>\numbers_publisher.exe  <domain_id> <samples_to_send>
+objs\<arch_name>\numbers_subscriber.exe <domain_id>  <sleep_periods>
 
 UNIX systems:
 
-    * ./numbers_publisher <domain#> 4
-    * ./numbers_subscriber <domain#> 4
+./objs/<arch_name>/numbers_publisher  <domain_id> <samples_to_send>
+./objs/<arch_name>/numbers_subscriber <domain_id> <sleep_periods>
 
-The applications accept two arguments:
+The applications accept up to two arguments:
 
-   1. The <domain #>. Both applications must use the same domain # in order to communicate. The default is 0.
-   2. How long the examples should run, measured in samples for the publisher and sleep periods for the subscriber. A value of '0' instructs the application to run forever; this is the default.
-
-While generating the output below, we used values that would capture the most interesting behavior.
+   1. The <domain_id>. Both applications must use the same domain id in order 
+   to communicate. The default is 0.
+   2. How long the examples should run, measured in samples for the publisher 
+   and sleep periods for the subscriber. A value of '0' instructs the 
+   application to run forever; this is the default.
+   
+While generating the output below, we used values that would capture the most 
+interesting behavior.
 
 Publisher Output
 ================

--- a/examples/property_qos/cs/README.txt
+++ b/examples/property_qos/cs/README.txt
@@ -8,18 +8,29 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core Libraries and Utilities 
+choice (e.g., i86Win32VS2010). The RTI Connext Core Libraries and Utilities 
 Getting Started Guide describes this process in detail. Follow the same 
 procedure to generate the code and build the examples. Do not use the -replace
 option.
+On Windows systems (assuming you want to generate an example for 
+i86Win32VS2010) run:
 
-On Windows systems (assuming you want to generate an example for i86Win32VSdotnet4.0) run:
-rtiddsgen -language C# -example i86Win32dotnet4.0 numbers.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable numbers.idl
+
+Note: If you are using Visual Studio Express add the -express option to the 
+command, i.e.,
+
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable numbers.idl
+
+...you will see messages that look like this:
 
 File C:\local\property_qos\cs\numbers_subscriber.cs already 
 exists and will not be replaced with updated content. If you would like to get a 
 new file with the new content, either remove this file or supply -replace option.
 File C:\local\property_qos\cs\numbers_publisher.cs already 
+exists and will not be replaced with updated content. If you would like to get a 
+new file with the new content, either remove this file or supply -replace option.
+File C:\local\property_qos\cs\USER_QOS_PROFILES.xml already 
 exists and will not be replaced with updated content. If you would like to get a 
 new file with the new content, either remove this file or supply -replace option.
 

--- a/examples/property_qos/java/README.txt
+++ b/examples/property_qos/java/README.txt
@@ -4,40 +4,75 @@ Example code: Using Property QoS
 
 Building Java Example
 =====================
-Make sure you are using one of the relevant RTI Data Distribution Service versions, as specified at the top of the Solution.
+Before compiling or running the example, make sure the environment variable 
+NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
-Before compiling or running the example, make sure the environment variable NDDSHOME is set to the directory where your version of RTI Data Distribution Service is installed.
+Run rtiddsgen with the -example option and the target architecture of your 
+choice (e.g., i86Win32VS2010). The RTI Connext Core Libraries and Utilities 
+Getting Started Guide describes this process in detail. 
+Follow the same procedure to generate the code and build the examples. Do not 
+use the -replace option.
 
-Run rtiddsgen with the -example option and the target architecture of your choice (for example, i86Win32VS2005). The RTI Data Distribution Service Getting Started Guide describes this process in detail. Follow the same procedure to generate the code and build the examples. Do not use the -replace option.
+On Windows systems (assuming you want to generate an example for 
+i86Win32VS2010) run:
 
-After running rtiddsgen like this...
+rtiddsgen -language Java -example i86Win32VS2010 numbers.idl
 
-C:\local\property_qos\java> rtiddsgen -language Java -example i86Win32VS2005 numbers.idl
+On UNIX systems (assuming you want to generate an example for 
+i86Linux2.6gcc4.4.3) run:
+
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 numbers.idl
 
 ...you will see messages that look like this:
 
-File C:\local\property_qos\java\numbers_subscriber.java already exists and will not be replaced with updated content. If you would like to get a new file with the new content, either remove this file or supply -replace option.
-File C:\local\property_qos\java\numbers_publisher.java already exists and will not be replaced with updated content. If you would like to get a new file with the new content, either remove this file or supply -replace option.
+File C:\local\property_qos\java\numbers_subscriber.java already exists and will
+not be replaced with updated content. If you would like to get a new file with
+the new content, either remove this file or supply -replace option.
+File C:\local\property_qos\java\numbers_publisher.java already exists and will 
+not be replaced with updated content. If you would like to get a new file with 
+the new content, either remove this file or supply -replace option.
+File C:\local\property_qos\java\USER_QOS_PROFILES.xml already exists and will 
+not be replaced with updated content. If you would like to get a new file with 
+the new content, either remove this file or supply -replace option.
 
-This is normal and is only informing you that the subscriber/publisher code has not been replaced, which is fine since all the source files for the example are already provided.
+This is normal and is only informing you that the subscriber/publisher code has
+not been replaced, which is fine since all the source files for the example are
+already provided.
 
-Before compiling in Java, make sure that the desired version of the javac compiler is in your PATH environment variable.
+Before compiling in Java, make sure that the desired version of the javac 
+compiler is in your PATH environment variable.
+
+On Windows systems run:
+
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar *.java
+
+On Unix systems (including Linux and MacOS X):
+
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar *.java
 
 Running Java Example
 ====================
-Before running, make sure that the desired version of the java compiler is in your PATH environment variable.
+In two separate command prompt windows for the publisher and subscriber. 
+Run the following commands from the example directory (this is necessary to 
+ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
-In two separate command prompt windows for the publisher and subscriber, run these commands:
+On Windows systems run:
 
-    * java -cp .\;%nddshome%\class\nddsjava.jar numbersPublisher <domain#> 4
-    * java -cp .\;%nddshome%\class\nddsjava.jar numbersSubscriber <domain#> 4
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar numbersPublisher  <domain_id> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar numbersSubscriber <domain_id> <sleep_periods>
 
-The applications accept two arguments:
+On Unix systems (including Linux and MacOS X) run:
 
-   1. The <domain #>. Both applications must use the same domain # in order to communicate. The default is 0.
-   2. How long the examples should run, measured in samples for the publisher and sleep periods for the subscriber. A value of '0' instructs the application to run forever; this is the default.
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar numbersPublisher  <domain_id> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar numbersSubscriber <domain_id> <sleep_periods>
 
-While generating the output below, we used values that would capture the most interesting behavior.
+The applications accept up to two arguments:
+
+   1. The <domain_id>. Both applications must use the same domain id in order 
+   to communicate. The default is 0.
+   2. How long the examples should run, measured in samples for the publisher 
+   and sleep periods for the subscriber. A value of '0' instructs the 
+   application to run forever; this is the default.
 
 Publisher Output
 ================

--- a/examples/routing_service_file_adapter/c/README.txt
+++ b/examples/routing_service_file_adapter/c/README.txt
@@ -3,7 +3,7 @@
 ===========================================
 
 Building C Example
-=============
+==================
 Before compiling or running the example, make sure the environment variable 
 NDDSHOME is set to the directory where your version of RTI Connext DDS is 
 installed.
@@ -24,7 +24,7 @@ libraries, you will need to add that directory to your Path, if you are using
 Windows, or your LD_LIBRARY_PATH if you are using most of Unix-like systems.
 
 Running C Example
-=============
+=================
 
 Before running the example, take a look at file_bridge.xml. It defines the different
 settings to load and configure the adapter. You will need to specify on it the path 

--- a/examples/time_based_filter/cs/README.txt
+++ b/examples/time_based_filter/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32dotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable tbf.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable tbf.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable tbf.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable tbf.idl
 
 ...you will see messages that look like this:
 

--- a/examples/time_based_filter/java/README.txt
+++ b/examples/time_based_filter/java/README.txt
@@ -8,19 +8,19 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32VS2005 or i86Linux2.6gcc4.4.3). The RTI Connext Core 
+choice (e.g., i86Win32VS2010 or i86Linux2.6gcc4.4.3). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk tbf.idl
+rtiddsgen -language Java -example i86Win32VS2010 tbf.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk tbf.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 tbf.idl
 
 
 File C:\local\time_based_filter\java\tbfSubscriber.java already exists and will
@@ -39,40 +39,27 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar tbf.java tbfSeq.java tbfTypeSupport.java tbfTypeCode.java tbfDataReader.java tbfDataWriter.java tbfSubscriber.java tbfPublisher.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar tbf.java tbfSeq.java tbfTypeSupport.java tbfTypeCode.java tbfDataReader.java tbfDataWriter.java tbfSubscriber.java tbfPublisher.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar tbf.java tbfSeq.java tbfTypeSupport.java tbfTypeCode.java tbfDataReader.java tbfDataWriter.java tbfSubscriber.java tbfPublisher.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar tbf.java tbfSeq.java tbfTypeSupport.java tbfTypeCode.java tbfDataReader.java tbfDataWriter.java tbfSubscriber.java tbfPublisher.java
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar tbfPublisher  <domain_id> <samples_to_send>
-java -cp .;%NDDSHOME%\class\nddsjava.jar tbfSubscriber <domain_id> <sleep_periods>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar tbfPublisher  <domain_id> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar tbfSubscriber <domain_id> <sleep_periods>
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar tbfPublisher  <domain_id> <samples_to_send>
-java -cp .:$NDDSHOME/class/nddsjava.jar tbfSubscriber <domain_id> <sleep_periods>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar tbfPublisher  <domain_id> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar tbfSubscriber <domain_id> <sleep_periods>
 
 
 The applications accept two arguments:

--- a/examples/using_qos_profiles/cs/README.txt
+++ b/examples/using_qos_profiles/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32dotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable profiles.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable profiles.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable profiles.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable profiles.idl
 
 ...you will see messages that look like this:
 

--- a/examples/using_qos_profiles/java/README.txt
+++ b/examples/using_qos_profiles/java/README.txt
@@ -8,19 +8,19 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32jdk or i86Linux2.6gcc4.4.3jdk). The RTI Connext Core 
+choice (e.g., i86Win32VS2010 or i86Linux2.6gcc4.4.3). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk profiles.idl
+rtiddsgen -language Java -example i86Win32VS2010 profiles.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk profiles.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 profiles.idl
 
 You will see messages that look like this:
 
@@ -40,13 +40,13 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar profiles.java profilesSeq.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar profiles.java profilesSeq.java
  profilesTypeSupport.java profilesTypeCode.java profilesDataReader.java 
  profilesDataWriter.java profilesSubscriber.java profilesPublisher.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar profiles.java profilesSeq.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar profiles.java profilesSeq.java
  profilesTypeSupport.java profilesTypeCode.java profilesDataReader.java 
  profilesDataWriter.java profilesSubscriber.java waitsetsPublisher.java
 
@@ -56,35 +56,22 @@ my_custom_qos_profiles.xml in the directory you will run your application from.
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar profilesPublisher  <domain_id> 
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar profilesPublisher  <domain_id> 
     <samples_to_send>
-java -cp .;%NDDSHOME%\class\nddsjava.jar profilesSubscriber <domain_id> 
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar profilesSubscriber <domain_id> 
     <sleep_periods>
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar profilesPublisher  <domain_id> 
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar profilesPublisher  <domain_id> 
     <samples_to_send>
-java -cp .:$NDDSHOME/class/nddsjava.jar profilesSubscriber <domain_id> 
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar profilesSubscriber <domain_id> 
     <sleep_periods>
 
 

--- a/examples/using_sequences/cs/README.txt
+++ b/examples/using_sequences/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32dotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable sequences.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable sequences.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable sequences.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable sequences.idl
 
 ...you will see messages that look like this:
 

--- a/examples/using_sequences/java/README.txt
+++ b/examples/using_sequences/java/README.txt
@@ -15,12 +15,12 @@ use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk sequences.idl
+rtiddsgen -language Java -example i86Win32VS2010 sequences.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk sequences.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 sequences.idl
 
 You will see messages that look like this:
 
@@ -40,40 +40,27 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar MAX_SEQUENCE_LEN.java sequences.java sequencesSeq.java sequencesTypeSupport.java sequencesTypeCode.java sequencesDataReader.java sequencesDataWriter.java sequencesSubscriber.java sequencesPublisher.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar MAX_SEQUENCE_LEN.java sequences.java sequencesSeq.java sequencesTypeSupport.java sequencesTypeCode.java sequencesDataReader.java sequencesDataWriter.java sequencesSubscriber.java sequencesPublisher.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar MAX_SEQUENCE_LEN.java sequences.java sequencesSeq.java sequencesTypeSupport.java sequencesTypeCode.java sequencesDataReader.java sequencesDataWriter.java sequencesSubscriber.java sequencesPublisher.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar MAX_SEQUENCE_LEN.java sequences.java sequencesSeq.java sequencesTypeSupport.java sequencesTypeCode.java sequencesDataReader.java sequencesDataWriter.java sequencesSubscriber.java sequencesPublisher.java
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar sequencesPublisher  <domain_id> <samples_to_send>
-java -cp .;%NDDSHOME%\class\nddsjava.jar sequencesSubscriber <domain_id> <sleep_periods>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar sequencesPublisher  <domain_id> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar sequencesSubscriber <domain_id> <sleep_periods>
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar sequencesPublisher  <domain_id> <samples_to_send>
-java -cp .:$NDDSHOME/class/nddsjava.jar sequencesSubscriber <domain_id> <sleep_periods>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar sequencesPublisher  <domain_id> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar sequencesSubscriber <domain_id> <sleep_periods>
 
 
 The applications accept two arguments:

--- a/examples/using_typecodes/cs/README.txt
+++ b/examples/using_typecodes/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32dotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable msg.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable msg.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable msg.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable msg.idl
 
 You will see messages that look like this:
 

--- a/examples/using_typecodes/java/README.txt
+++ b/examples/using_typecodes/java/README.txt
@@ -15,12 +15,12 @@ use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk msg.idl
+rtiddsgen -language Java -example i86Win32VS2010 msg.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk msg.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 msg.idl
 
 You will see messages that look like this:
 
@@ -39,40 +39,27 @@ Before compiling in Java, make sure that the desired version of the javac
 compiler is in your PATH environment variable.
 
 On Windows systems run:
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar enumeration.java enumerationSeq.java enumerationTypeSupport.java enumerationTypeCode.java nested2.java nested2Seq.java nested2TypeSupport.java nested2TypeCode.java alias_target.java alias_targetSeq.java alias_targetTypeSupport.java alias_targetTypeCode.java alias_oneTypeCode.java alias_twoTypeCode.java msg.java msgSeq.java msgTypeSupport.java msgTypeCode.java msgDataReader.java msgDataWriter.java msgSubscriber.java msgPublisher.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar enumeration.java enumerationSeq.java enumerationTypeSupport.java enumerationTypeCode.java nested2.java nested2Seq.java nested2TypeSupport.java nested2TypeCode.java alias_target.java alias_targetSeq.java alias_targetTypeSupport.java alias_targetTypeCode.java alias_oneTypeCode.java alias_twoTypeCode.java msg.java msgSeq.java msgTypeSupport.java msgTypeCode.java msgDataReader.java msgDataWriter.java msgSubscriber.java msgPublisher.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar enumeration.java enumerationSeq.java enumerationTypeSupport.java enumerationTypeCode.java nested2.java nested2Seq.java nested2TypeSupport.java nested2TypeCode.java alias_target.java alias_targetSeq.java alias_targetTypeSupport.java alias_targetTypeCode.java alias_oneTypeCode.java alias_twoTypeCode.java msg.java msgSeq.java msgTypeSupport.java msgTypeCode.java msgDataReader.java msgDataWriter.java msgSubscriber.java msgPublisher.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar enumeration.java enumerationSeq.java enumerationTypeSupport.java enumerationTypeCode.java nested2.java nested2Seq.java nested2TypeSupport.java nested2TypeCode.java alias_target.java alias_targetSeq.java alias_targetTypeSupport.java alias_targetTypeCode.java alias_oneTypeCode.java alias_twoTypeCode.java msg.java msgSeq.java msgTypeSupport.java msgTypeCode.java msgDataReader.java msgDataWriter.java msgSubscriber.java msgPublisher.java
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar msgPublisher  <domain_id> <samples_to_send>
-java -cp .;%NDDSHOME%\class\nddsjava.jar msgSubscriber <domain_id> <sleep_periods>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar msgPublisher  <domain_id> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar msgSubscriber <domain_id> <sleep_periods>
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar msgPublisher  <domain_id> <samples_to_send>
-java -cp .:$NDDSHOME/class/nddsjava.jar msgSubscriber <domain_id> <sleep_periods>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar msgPublisher  <domain_id> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar msgSubscriber <domain_id> <sleep_periods>
 
 
 The applications accept two arguments:

--- a/examples/waitset_query_cond/cs/README.txt
+++ b/examples/waitset_query_cond/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32dotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable waitset_query_cond.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable waitset_query_cond.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable waitset_query_cond.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable waitset_query_cond.idl
 
 ...you will see messages that look like this:
 

--- a/examples/waitset_query_cond/java/README.txt
+++ b/examples/waitset_query_cond/java/README.txt
@@ -15,12 +15,12 @@ use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk waitset_query_cond.idl
+rtiddsgen -language Java -example i86Win32VS2010 waitset_query_cond.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk waitset_query_cond.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 waitset_query_cond.idl
 
 You will see messages that look like this:
 
@@ -45,41 +45,28 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar *.java 
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar *.java 
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar *.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar *.java
 
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar waitset_query_condPublisher  <domain_id> <samples_to_send>
-java -cp .;%NDDSHOME%\class\nddsjava.jar waitset_query_condSubscriber <domain_id> <sleep_periods>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar waitset_query_condPublisher  <domain_id> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar waitset_query_condSubscriber <domain_id> <sleep_periods>
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar waitset_query_condPublisher  <domain_id> <samples_to_send>
-java -cp .:$NDDSHOME/class/nddsjava.jar waitset_query_condSubscriber <domain_id> <sleep_periods>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar waitset_query_condPublisher  <domain_id> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar waitset_query_condSubscriber <domain_id> <sleep_periods>
 
 
 The applications accept up to two arguments:

--- a/examples/waitset_status_cond/cs/README.txt
+++ b/examples/waitset_status_cond/cs/README.txt
@@ -8,15 +8,22 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32VSdotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 waitset_statuscond.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable waitset_statuscond.idl
+
+Note: If you are using Visual Studio Express add the -express option to the 
+command, i.e.,
+
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable waitset_statuscond.idl
+
+...you will see messages that look like this:
 
 File C:\local\waitset_status_cond\cs\waitset_statuscond_subscriber.cs already 
 exists and will not be replaced with updated content. If you would like to get a 
@@ -29,6 +36,11 @@ This is normal and is only informing you that the subscriber/publisher code has
 not been replaced, which is fine since all the source files for the example are
 already provided.
 
+Rtiddsgen generates two solutions for Visual Studio C++ and C#, that you will 
+use to build the types and the C# example, respectively. First open  
+waitset_statuscond_type-dotnet4.0.sln and build the solution. Once you've done 
+that, open waitset_statuscond_example-csharp.sln and build the C# example.
+
 Running CS Example
 ===================
 In two separate command prompt windows for the publisher and subscriber. Run
@@ -39,7 +51,6 @@ On Windows systems run:
 
 bin\<build_type>-VS2010\waitset_statuscond_publisher.exe  <domain_id> <samples_to_send>
 bin\<build_type>-VS2010\waitset_statuscond_subscriber.exe <domain_id> <sleep_periods>
-
 
 The applications accept up to three arguments:
 

--- a/examples/waitset_status_cond/java/README.txt
+++ b/examples/waitset_status_cond/java/README.txt
@@ -8,19 +8,19 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32jdk or i86Linux2.6gcc4.4.3jdk). The RTI Connext Core 
+choice (e.g., i86Win32VS2010 or i86Linux2.6gcc4.4.3). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk waitset_statuscond.idl
+rtiddsgen -language Java -example i86Win32VS2010 waitset_statuscond.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk waitset_statuscond.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 waitset_statuscond.idl
 
 You will see messages that look like this:
 
@@ -40,40 +40,27 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar waitset_statuscond.java waitset_statuscondSeq.java waitset_statuscondTypeSupport.java waitset_statuscondTypeCode.java waitset_statuscondDataReader.java waitset_statuscondDataWriter.java waitset_statuscondSubscriber.java waitset_statuscondPublisher.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar waitset_statuscond.java waitset_statuscondSeq.java waitset_statuscondTypeSupport.java waitset_statuscondTypeCode.java waitset_statuscondDataReader.java waitset_statuscondDataWriter.java waitset_statuscondSubscriber.java waitset_statuscondPublisher.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar waitset_statuscond.java waitset_statuscondSeq.java waitset_statuscondTypeSupport.java waitset_statuscondTypeCode.java waitset_statuscondDataReader.java waitset_statuscondDataWriter.java waitset_statuscondSubscriber.java waitset_statuscondPublisher.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar waitset_statuscond.java waitset_statuscondSeq.java waitset_statuscondTypeSupport.java waitset_statuscondTypeCode.java waitset_statuscondDataReader.java waitset_statuscondDataWriter.java waitset_statuscondSubscriber.java waitset_statuscondPublisher.java
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar waitset_statuscondPublisher  <domain_id> <samples_to_send>
-java -cp .;%NDDSHOME%\class\nddsjava.jar waitset_statuscondSubscriber <domain_id> <sleep_periods>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar waitset_statuscondPublisher  <domain_id> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar waitset_statuscondSubscriber <domain_id> <sleep_periods>
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar waitset_statuscondPublisher  <domain_id> <samples_to_send>
-java -cp .:$NDDSHOME/class/nddsjava.jar waitset_statuscondSubscriber <domain_id> <sleep_periods>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar waitset_statuscondPublisher  <domain_id> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar waitset_statuscondSubscriber <domain_id> <sleep_periods>
 
 
 The applications accept two arguments:

--- a/examples/waitsets/cs/README.txt
+++ b/examples/waitsets/cs/README.txt
@@ -8,20 +8,20 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32dotnet4.0). The RTI Connext Core 
+choice (e.g., i86Win32VS2010). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems (assuming you want to generate an example for 
-i86Win32dotnet4.0) run:
+i86Win32VS2010) run:
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -ppDisable waitsets.idl
+rtiddsgen -language C# -example i86Win32VS2010 -ppDisable waitsets.idl
 
 Note: If you are using Visual Studio Express add the -express option to the 
 command, i.e.,
 
-rtiddsgen -language C# -example i86Win32dotnet4.0 -express -ppDisable waitsets.idl
+rtiddsgen -language C# -example i86Win32VS2010 -express -ppDisable waitsets.idl
 
 ...you will see messages that look like this:
 

--- a/examples/waitsets/java/README.txt
+++ b/examples/waitsets/java/README.txt
@@ -8,19 +8,19 @@ Before compiling or running the example, make sure the environment variable
 NDDSHOME is set to the directory where your version of RTI Connext is installed.
 
 Run rtiddsgen with the -example option and the target architecture of your 
-choice (e.g., i86Win32VS2005 or i86Linux2.6gcc4.4.3). The RTI Connext Core 
+choice (e.g., i86Win32VS2010 or i86Linux2.6gcc4.4.3). The RTI Connext Core 
 Libraries and Utilities Getting Started Guide describes this process in detail. 
 Follow the same procedure to generate the code and build the examples. Do not 
 use the -replace option.
 
 On Windows systems run:
 
-rtiddsgen -language Java -example i86Win32jdk waitsets.idl
+rtiddsgen -language Java -example i86Win32VS2010 waitsets.idl
 
 On UNIX systems (assuming you want to generate an example for 
 i86Linux2.6gcc4.4.3) run:
 
-rtiddsgen -language Java -example i86Linux2.6gcc4.4.3jdk waitsets.idl
+rtiddsgen -language Java -example i86Linux2.6gcc4.4.3 waitsets.idl
 
 You will see messages that look like this:
 
@@ -40,40 +40,27 @@ compiler is in your PATH environment variable.
 
 On Windows systems run:
 
-javac -classpath .;%NDDSHOME%\class\nddsjava.jar waitsets.java waitsetsSeq.java waitsetsTypeSupport.java waitsetsTypeCode.java waitsetsDataReader.java waitsetsDataWriter.java waitsetsSubscriber.java waitsetsPublisher.java
+javac -classpath .;%NDDSHOME%\lib\java\nddsjava.jar waitsets.java waitsetsSeq.java waitsetsTypeSupport.java waitsetsTypeCode.java waitsetsDataReader.java waitsetsDataWriter.java waitsetsSubscriber.java waitsetsPublisher.java
 
 On Unix systems (including Linux and MacOS X):
 
-javac -classpath .:$NDDSHOME/class/nddsjava.jar waitsets.java waitsetsSeq.java waitsetsTypeSupport.java waitsetsTypeCode.java waitsetsDataReader.java waitsetsDataWriter.java waitsetsSubscriber.java waitsetsPublisher.java
+javac -classpath .:$NDDSHOME/lib/java/nddsjava.jar waitsets.java waitsetsSeq.java waitsetsTypeSupport.java waitsetsTypeCode.java waitsetsDataReader.java waitsetsDataWriter.java waitsetsSubscriber.java waitsetsPublisher.java
 
 Running Java Example
 ====================
-Before running, make sure that the native Java libraries on which RTI Connext
-depends are in your environment path (or library path). To add Java libraries 
-to your environment...
-
-On Windows systems run: 
-set PATH=%NDDSHOME%\lib\i86Win32jdk;%PATH%
-
-On Unix systems except MacOS X (assuming you are using Bash) run:
-export LD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$LD_LIBRARY_PATH
-
-On MacOSX (assuming your are using Bash) run:
-export DYLD_LIBRARY_PATH=$NDDSHOME/lib/<platform_name>jdk:$DYLD_LIBRARY_PATH
-
-Then, in two separate command prompt windows for the publisher and subscriber. 
+In two separate command prompt windows for the publisher and subscriber. 
 Run the following commands from the example directory (this is necessary to 
 ensure the application loads the QoS defined in USER_QOS_PROFILES.xml):
 
 On Windows systems run:
 
-java -cp .;%NDDSHOME%\class\nddsjava.jar waitsetsPublisher  <domain_id> <samples_to_send>
-java -cp .;%NDDSHOME%\class\nddsjava.jar waitsetsSubscriber <domain_id> <sleep_periods>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar waitsetsPublisher  <domain_id> <samples_to_send>
+java -cp .;%NDDSHOME%\lib\java\nddsjava.jar waitsetsSubscriber <domain_id> <sleep_periods>
 
 On Unix systems (including Linux and MacOS X) run:
 
-java -cp .:$NDDSHOME/class/nddsjava.jar waitsetsPublisher  <domain_id> <samples_to_send>
-java -cp .:$NDDSHOME/class/nddsjava.jar waitsetsSubscriber <domain_id> <sleep_periods>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar waitsetsPublisher  <domain_id> <samples_to_send>
+java -cp .:$NDDSHOME/lib/java/nddsjava.jar waitsetsSubscriber <domain_id> <sleep_periods>
 
 
 The applications accept two arguments:

--- a/examples/writing_data_lua/README.txt
+++ b/examples/writing_data_lua/README.txt
@@ -5,8 +5,7 @@
 Concept
 -------
 This example is generating data and writing it over DDS using Lua.  This 
-requires the RTI Prototyper with Lua 5.1.0, which is shipped with RTI Connext 
-DDS 5.1.0.
+example uses RTI Connext DDS 5.2.0.
 
 This is interesting for two reasons:
 1. This shows how to create simple DDS applications for prototyping or
@@ -52,14 +51,14 @@ In two separate command prompt windows for the sender and receiver. Run
 the following commands from the example directory:
 
  - For the sender run:
-Windows: %NDDSHOME%\scripts\rtiddsprototyper -cfgFile prototyper_config.xml -luaFile temperature.lua
-Linux: $NDDSHOME%\scripts\rtiddsprototyper -cfgFile prototyper_config.xml -luaFile temperature.lua
+Windows: %NDDSHOME%\bin\rtiddsprototyper -cfgFile prototyper_config.xml -luaFile temperature.lua
+Linux: $NDDSHOME%\bin\rtiddsprototyper -cfgFile prototyper_config.xml -luaFile temperature.lua
 
-One time you run the sender, you have to type 0 in order to pick a sender.
+Once you run the sender, you have to type 0 in order to pick a sender.
 
  - For the receiver run:
-Windows: %NDDSHOME%\scripts\rtiddsprototyper -cfgFile prototyper_config.xml
-Linux: $NDDSHOME%\scripts\rtiddsprototyper -cfgFile prototyper_config.xml
+Windows: %NDDSHOME%\bin\rtiddsprototyper -cfgFile prototyper_config.xml
+Linux: $NDDSHOME%\bin\rtiddsprototyper -cfgFile prototyper_config.xml
 
 Type 1 to create a default receiver (it is not defined in any .lua file). 
 

--- a/resources/scripts/compile_dynamic_data_unix.pl
+++ b/resources/scripts/compile_dynamic_data_unix.pl
@@ -20,17 +20,37 @@ $NDDS_VERSION = $ARGV[1];
 $ARCH = $ARGV[2];
 
 $NDDS_HOME = "";
+
+# Check whether the version is greater or equal than 5.2.0
+$IS_NEW_DIR_STRUCTURE = 0;
+if ($NDDS_VERSION ge "5.2.0") {
+    $IS_NEW_DIR_STRUCTURE = 1;
+} 
+
 # This variable is the NDDSHOME environment variable
 # If NDDSHOME is defined, leave it as is, else it is defined by default
 if (defined $ENV{'NDDSHOME'}) {
     $NDDS_HOME = $ENV{'NDDSHOME'};
 }
 else { 
-    $NDDS_HOME = $ENV{'RTI_TOOLSDRIVE'} . "/local/preship/ndds/ndds." . 
-                        $NDDS_VERSION;
+    if ($IS_NEW_DIR_STRUCTURE) {
+        $NDDS_HOME = $ENV{'RTI_TOOLSDRIVE'} . "/local/preship/ndds/ndds." . 
+                            $NDDS_VERSION . "/unlicensed/rti_connext_dds-" . 
+                            $NDDS_VERSION;
+    } else {
+        $NDDS_HOME = $ENV{'RTI_TOOLSDRIVE'} . "/local/preship/ndds/ndds." . 
+                            $NDDS_VERSION;
+    }
     print "CAUTION: NDDSHOME is not defined, by default we set to\n\t" . 
-          "$RTI_TOOLDRIVE/local/preship/ndds/ndds.{VERSION}\n";
+        "$NDDS_HOME\n";
 }
+
+# check wheter NDDS_HOME directoy exists
+if (!-d $NDDS_HOME) {
+    print "ERROR: The default NDDSHOME directory doesn't exists: $NDDS_HOME";
+    exit (1);
+}
+
 # set NDDSHOME
 $ENV{'NDDSHOME'} = $NDDS_HOME;
 
@@ -40,22 +60,38 @@ if (!defined $ENV{'JAVAHOME'}) {
     $ENV{'JAVAHOME'} = $ENV{'RTI_TOOLSDRIVE'} . "/local/applications/Java/" . 
         "PLATFORMSDK/linux/jdk1.7.0_04";
     print "CAUTION: JAVAHOME is not defined, by default we set to\n\t" . 
-       "$RTI_TOOLDRIVE/local/applications/Java/PLATFORMSDK/win32/jdk1.7.0_04\n";
+       "$ENV{'JAVAHOME'}\n";
 
 }
 
 $ENV{'PATH'} = $ENV{'JAVAHOME'} . "/bin:" . $ENV{'PATH'};
 
+# set the scripts folder to the PATH
+if ($IS_NEW_DIR_STRUCTURE) {
+    $ENV{'PATH'} = $ENV{'NDDSHOME'} . "/bin:" . $ENV{'PATH'};
+} else {
+    $ENV{'PATH'} = $ENV{'NDDSHOME'} . "/scripts:" . $ENV{'PATH'};
+}
+
 # set LD_LIBRARY_PATH
-# C/C++ architecture
-$ENV{'LD_LIBRARY_PATH'} = $ENV{'NDDSHOME'} . "/lib/" . $ARCH . ":" . 
-                            $ENV{'LD_LIBRARY_PATH'};
-# Java Architecture
-$ENV{'LD_LIBRARY_PATH'} = $ENV{'NDDSHOME'} . "/lib/" . $ARCH . "jdk:" . 
-                            $ENV{'LD_LIBRARY_PATH'};                           
+if ($IS_NEW_DIR_STRUCTURE) {
+    # C/C++/C# architecture
+    $ENV{'LD_LIBRARY_PATH'} = $ENV{'NDDSHOME'} . "/lib/" . $ARCH . ":" . 
+        $ENV{'LD_LIBRARY_PATH'};
+    # Java Architecture
+    $ENV{'LD_LIBRARY_PATH'} = $ENV{'NDDSHOME'} . "/lib/java:" . 
+        $ENV{'LD_LIBRARY_PATH'};  
+} else {
+    # C/C++/C# architecture
+    $ENV{'LD_LIBRARY_PATH'} = $ENV{'NDDSHOME'} . "/lib/" . $ARCH . ":" . 
+        $ENV{'LD_LIBRARY_PATH'};
+    # Java Architecture
+    $ENV{'LD_LIBRARY_PATH'} = $ENV{'NDDSHOME'} . "/lib/" . $ARCH . "jdk:" . 
+        $ENV{'LD_LIBRARY_PATH'};                           
+}
 
 
-# This function runs the makefile generated with the rtiddsgen 
+# This function runs the makefile for building 
 #   input parameter (they are used in the construction of the makefile name):
 #       $architecture: the arechitecture which the example are going to be built
 #       $language: this is the language which is going to be used to compile
@@ -77,8 +113,7 @@ sub call_makefile {
         $make_string = "make -f makefile_Foo_" . $architecture;
     }
 
-    #change to the directory where the example is (where the rtiddsgen has been
-    # executed) to run the makefile
+    #change to the directory where the makefile is
     chdir $path;
     
     system $make_string;

--- a/resources/scripts/compile_dynamic_data_unix.pl
+++ b/resources/scripts/compile_dynamic_data_unix.pl
@@ -106,8 +106,13 @@ sub call_makefile {
     
     my ($make_string) = "";
     if ($language eq "Java") {
-        $make_string = "javac -classpath .:\"\$NDDSHOME\"/class/nddsjava.jar " . 
-                        "*.java";
+        if ($IS_NEW_DIR_STRUCTURE) {
+            $make_string = "javac -classpath .:\"\$NDDSHOME\"/lib/java/" . 
+                        "nddsjava.jar *.java";
+        } else {
+            $make_string = "javac -classpath .:\"\$NDDSHOME\"/class/" . 
+                        "nddsjava.jar *.java";
+        }
         print $make_string . "\n";
     } else {
         $make_string = "make -f makefile_Foo_" . $architecture;

--- a/resources/scripts/compile_dynamic_data_windows.pl
+++ b/resources/scripts/compile_dynamic_data_windows.pl
@@ -36,11 +36,11 @@ if (defined $ENV{'NDDSHOME'}) {
 else { 
     if ($IS_NEW_DIR_STRUCTURE) {
         $NDDS_HOME = $ENV{'RTI_TOOLSDRIVE'} . "/local/preship/ndds/ndds." . 
-                            $NDDS_VERSION . "/unlicensed/rticonnext_dds-" . 
+                            $NDDS_VERSION . "/unlicensed/rti_connext_dds-" . 
                             $NDDS_VERSION;
         print "CAUTION: NDDSHOME is not defined, by default we set to\n\t" . 
               "%RTI_TOOLSDRIVE%/local/preship/ndds/ndds.$NDDS_VERSION/" . 
-              "/unlicensed/rticonnext_dds-$NDDS_VERSION\n";
+              "/unlicensed/rti_connext_dds-$NDDS_VERSION\n";
     } else {
         $NDDS_HOME = $ENV{'RTI_TOOLSDRIVE'} . "/local/preship/ndds/ndds." . 
                             $NDDS_VERSION;
@@ -48,6 +48,13 @@ else {
               "%RTI_TOOLSDRIVE%/local/preship/ndds/ndds.$NDDS_VERSION\n";
     }
 }
+
+# check wheter NDDS_HOME directoy exists
+if (!-d $NDDS_HOME) {
+    print "ERROR: The default NDDSHOME directory doesn't exists: $NDDS_HOME";
+    exit (1);
+}
+
 #set NDDSHOME
 $ENV{'NDDSHOME'} = unix_path($NDDS_HOME);
 

--- a/resources/scripts/compile_dynamic_data_windows.pl
+++ b/resources/scripts/compile_dynamic_data_windows.pl
@@ -38,15 +38,12 @@ else {
         $NDDS_HOME = $ENV{'RTI_TOOLSDRIVE'} . "/local/preship/ndds/ndds." . 
                             $NDDS_VERSION . "/unlicensed/rti_connext_dds-" . 
                             $NDDS_VERSION;
-        print "CAUTION: NDDSHOME is not defined, by default we set to\n\t" . 
-              "%RTI_TOOLSDRIVE%/local/preship/ndds/ndds.$NDDS_VERSION/" . 
-              "/unlicensed/rti_connext_dds-$NDDS_VERSION\n";
     } else {
         $NDDS_HOME = $ENV{'RTI_TOOLSDRIVE'} . "/local/preship/ndds/ndds." . 
                             $NDDS_VERSION;
-        print "CAUTION: NDDSHOME is not defined, by default we set to\n\t" . 
-              "%RTI_TOOLSDRIVE%/local/preship/ndds/ndds.$NDDS_VERSION\n";
     }
+    print "CAUTION: NDDSHOME is not defined, by default we set to\n\t" . 
+        "$NDDS_HOME\n";
 }
 
 # check wheter NDDS_HOME directoy exists
@@ -85,8 +82,7 @@ if (!defined $ENV{'JAVAHOME'}) {
     $ENV{'JAVAHOME'} = $ENV{'RTI_TOOLSDRIVE'} . "/local/applications/Java/" . 
         "PLATFORMSDK/win32/jdk1.7.0_04";
     print "CAUTION: JAVAHOME is not defined, by default we set to\n\t" . 
-        "%RTI_TOOLSDRIVE%/local/applications/Java/PLATFORMSDK/win32/" . 
-        "jdk1.7.0_04\n";
+        "$ENV{'JAVAHOME'}\n";
 }
 
 $ENV{'PATH'} = $ENV{'JAVAHOME'} . "/bin;" . $ENV{'PATH'};
@@ -127,12 +123,22 @@ sub call_compiler {
         $compile_string = "msbuild " . $VS_SOLUTION_NAME_C;
     }
     elsif ($language eq "Java") {
-        $compile_string = "javac -classpath .;\"%NDDSHOME%\"\\class\\" . 
-                          "nddsjava.jar *.java";
-        
+        if ($IS_NEW_DIR_STRUCTURE) {
+            $compile_string = "javac -classpath .;\"%NDDSHOME%\"\\lib\\java\\" . 
+                              "nddsjava.jar *.java";
+        } else {
+            $compile_string = "javac -classpath .;\"%NDDSHOME%\"\\class\\" . 
+                              "nddsjava.jar *.java";
+            
+        }
         print $compile_string . "\n";
     } elsif ($language eq "C#") {
-        $compile_string = "msbuild " . $VS_SOLUTION_NAME_CS;
+        if ($IS_NEW_DIR_STRUCTURE) {
+            #using the new dis structure, we use the same project name than C
+            $compile_string = "msbuild " . $VS_SOLUTION_NAME_C;
+        } else {
+            $compile_string = "msbuild " . $VS_SOLUTION_NAME_CS;
+        }
     }
 
     # we need to swap the directory where the makefile is

--- a/resources/scripts/compile_unix.pl
+++ b/resources/scripts/compile_unix.pl
@@ -44,15 +44,12 @@ else {
         $NDDS_HOME = $ENV{'RTI_TOOLSDRIVE'} . "/local/preship/ndds/ndds." . 
                             $NDDS_VERSION . "/unlicensed/rti_connext_dds-" . 
                             $NDDS_VERSION;
-        print "CAUTION: NDDSHOME is not defined, by default we set to\n\t" . 
-              "%RTI_TOOLSDRIVE%/local/preship/ndds/ndds.$NDDS_VERSION" . 
-              "/unlicensed/rti_connext_dds-$NDDS_VERSION\n";
     } else { 
         $NDDS_HOME = $ENV{'RTI_TOOLSDRIVE'} . "/local/preship/ndds/ndds." . 
                             $NDDS_VERSION;
-        print "CAUTION: NDDSHOME is not defined, by default we set to\n\t" . 
-              "$RTI_TOOLSDRIVE/local/preship/ndds/ndds.$NDDS_VERSION\n";
     }
+    print "CAUTION: NDDSHOME is not defined, by default we set to\n\t" . 
+        "$NDDS_HOME\n";
 }
 
 # check wheter NDDS_HOME directoy exists
@@ -66,7 +63,7 @@ $ENV{'NDDSHOME'} = $NDDS_HOME;
 
 # set the scripts folder to the PATH
 if ($IS_NEW_DIR_STRUCTURE) {
-    $ENV{'PATH'} = $ENV{'NDDSHOME'} . "/bin;" . $ENV{'PATH'};
+    $ENV{'PATH'} = $ENV{'NDDSHOME'} . "/bin:" . $ENV{'PATH'};
 } else {
     $ENV{'PATH'} = $ENV{'NDDSHOME'} . "/scripts:" . $ENV{'PATH'};
 }
@@ -77,8 +74,7 @@ if (!defined $ENV{'JAVAHOME'}) {
     $ENV{'JAVAHOME'} = $ENV{'RTI_TOOLSDRIVE'} . "/local/applications/Java/" . 
         "PLATFORMSDK/linux/jdk1.7.0_04";
     print "CAUTION: JAVAHOME is not defined, by default we set to\n\t" . 
-      "$RTI_TOOLSDRIVE/local/applications/Java/PLATFORMSDK/linux/jdk1.7.0_04\n";
-
+      "$ENV{'JAVAHOME'}\n";
 }
 
 $ENV{'PATH'} = $ENV{'JAVAHOME'} . "/bin:" . $ENV{'PATH'};

--- a/resources/scripts/compile_windows.pl
+++ b/resources/scripts/compile_windows.pl
@@ -36,6 +36,7 @@ if ($NDDS_VERSION ge "5.2.0") {
     $IS_NEW_DIR_STRUCTURE = 1;
 } 
 
+$NDDS_HOME = "";
 # This variable is the NDDSHOME environment variable
 # If NDDSHOME is defined, leave it as is, else it is defined by default
 if (defined $ENV{'NDDSHOME'}) {
@@ -44,11 +45,11 @@ if (defined $ENV{'NDDSHOME'}) {
 else { 
     if ($IS_NEW_DIR_STRUCTURE) {
         $NDDS_HOME = $ENV{'RTI_TOOLSDRIVE'} . "/local/preship/ndds/ndds." . 
-                            $NDDS_VERSION . "/unlicensed/rticonnext_dds-" . 
+                            $NDDS_VERSION . "/unlicensed/rti_connext_dds-" . 
                             $NDDS_VERSION;
         print "CAUTION: NDDSHOME is not defined, by default we set to\n\t" . 
               "%RTI_TOOLSDRIVE%/local/preship/ndds/ndds.$NDDS_VERSION" . 
-              "/unlicensed/rticonnext_dds-$NDDS_VERSION\n";
+              "/unlicensed/rti_connext_dds-$NDDS_VERSION\n";
     } else {
         
         $NDDS_HOME = $ENV{'RTI_TOOLSDRIVE'} . "/local/preship/ndds/ndds." . 
@@ -61,7 +62,7 @@ else {
 
 # check wheter NDDS_HOME directoy exists
 if (!-d $NDDS_HOME) {
-    print "ERROR: The default NDDSHOME directory doesn't exists.";
+    print "ERROR: The default NDDSHOME directory doesn't exists: $NDDS_HOME";
     exit (1);
 }
 

--- a/resources/scripts/compile_windows.pl
+++ b/resources/scripts/compile_windows.pl
@@ -207,8 +207,13 @@ sub call_compiler {
     } 
     # if the language is Java, all the files will be compiled with *.java
     elsif ($LANGUAGE eq "Java") {
-        $compile_string = "javac -classpath .;\"%NDDSHOME%\"\\lib\\java\\" . 
-                          "nddsjava.jar *.java";
+        if ($IS_NEW_DIR_STRUCTURE) {
+            $compile_string = "javac -classpath .;\"%NDDSHOME%\"\\lib\\java\\" . 
+                              "nddsjava.jar *.java";
+        } else {
+            $compile_string = "javac -classpath .;\"%NDDSHOME%\"\\class\\" . 
+                              "nddsjava.jar *.java";
+        }
         print $compile_string . "\n";
     } 
     # if the language is C# we create the compile string for visual studio C# 

--- a/resources/scripts/compile_windows.pl
+++ b/resources/scripts/compile_windows.pl
@@ -47,17 +47,13 @@ else {
         $NDDS_HOME = $ENV{'RTI_TOOLSDRIVE'} . "/local/preship/ndds/ndds." . 
                             $NDDS_VERSION . "/unlicensed/rti_connext_dds-" . 
                             $NDDS_VERSION;
-        print "CAUTION: NDDSHOME is not defined, by default we set to\n\t" . 
-              "%RTI_TOOLSDRIVE%/local/preship/ndds/ndds.$NDDS_VERSION" . 
-              "/unlicensed/rti_connext_dds-$NDDS_VERSION\n";
     } else {
         
         $NDDS_HOME = $ENV{'RTI_TOOLSDRIVE'} . "/local/preship/ndds/ndds." . 
                             $NDDS_VERSION;
-        
-        print "CAUTION: NDDSHOME is not defined, by default we set to\n\t" . 
-              "%RTI_TOOLSDRIVE%/local/preship/ndds/ndds.$NDDS_VERSION\n";
     }
+    print "CAUTION: NDDSHOME is not defined, by default we set to\n\t" . 
+        "$NDDS_HOME\n";
 }
 
 # check wheter NDDS_HOME directoy exists
@@ -105,8 +101,7 @@ if (!defined $ENV{'JAVAHOME'}) {
     $ENV{'JAVAHOME'} = $ENV{'RTI_TOOLSDRIVE'} . "/local/applications/Java/" . 
         "PLATFORMSDK/win32/jdk1.7.0_04";
     print "CAUTION: JAVAHOME is not defined, by default we set to\n\t" . 
-        "%RTI_TOOLSDRIVE%/local/applications/Java/PLATFORMSDK/win32/" . 
-        "jdk1.7.0_04\n";
+        "$ENV{'JAVAHOME'}\n";
 }
 
 $ENV{'PATH'} = $ENV{'JAVAHOME'} . "/bin;" . $ENV{'PATH'};


### PR DESCRIPTION
Updated the examples in order to use 5.2.0 version: 
    - The building scripts have been adapted for using the New Directory Structure (now they use the corresponding Directory Structure depending of the version)
    - The readme files have been updated (java & C#) in order to match with the new architectures names for these programming languages.
    - The Dynamic Data examples have got a new VS project for C# which use the New Directory Structure. The project is called: Hello-i86Win32VS2010. (The building scripts can decide which project uses depending of its version).
    - Review the readme files in all the examples (in order to fix 80 characters per line, follow the same common pattern...)
