### PR TITLE
Enable C++11 compilation on supported platforms only

### DIFF
--- a/resources/scripts/compile_unix.pl
+++ b/resources/scripts/compile_unix.pl
@@ -24,6 +24,16 @@ $NDDS_VERSION = $ARGV[1];
 # This variable is the architecture name
 $ARCH = $ARGV[2];
 
+# Check if C++11 is supported in this platform
+$PLATF_OS_NAME = substr $ARCH, 3, 6;
+$PLATF_VERSION =  substr $ARCH, 3;
+$IS_CPP11_SUPPORTED = 0;
+if ($PLATF_OS_NAME eq "Darwin" || $PLATF_VERSION eq "Linux3gcc4.8.2") {
+    $IS_CPP11_SUPPORTED = 1;
+}
+print $IS_CPP11_SUPPORTED;
+exit;
+
 # $TOP_DIRECTORY is the directory where you have executed the script
 $TOP_DIRECTORY = cwd();
 
@@ -238,6 +248,8 @@ sub process_all_files {
                 $LANGUAGE = "C++";
             } elsif ($register eq "c++03") {
                 $LANGUAGE = "C++03";
+            } elsif ($register eq "c++11" && $IS_CPP11_SUPPORTED) {
+                $LANGUAGE = "C++11";
             } elsif ($register eq "java") {
                 $LANGUAGE = "Java";
             }

--- a/resources/scripts/compile_unix.pl
+++ b/resources/scripts/compile_unix.pl
@@ -31,8 +31,6 @@ $IS_CPP11_SUPPORTED = 0;
 if ($PLATF_OS_NAME eq "Darwin" || $PLATF_VERSION eq "Linux3gcc4.8.2") {
     $IS_CPP11_SUPPORTED = 1;
 }
-print $IS_CPP11_SUPPORTED;
-exit;
 
 # $TOP_DIRECTORY is the directory where you have executed the script
 $TOP_DIRECTORY = cwd();

--- a/resources/scripts/compile_windows.pl
+++ b/resources/scripts/compile_windows.pl
@@ -28,7 +28,7 @@ $ARCH = $ARGV[2];
 
 # Check if C++11 is supported in this platform
 $PLATFORM_VERSION   = substr $ARCH, 10, 4;
-$IS_CPP11_SUPPORTED = ($PLATFORM_VERSION >= 2013) ? 1 : 0;
+$IS_CPP11_SUPPORTED = ($PLATFORM_VERSION >= 2012) ? 1 : 0;
 
 # $TOP_DIRECTORY is the directory where you have executed the script
 $TOP_DIRECTORY = cwd();

--- a/resources/scripts/compile_windows.pl
+++ b/resources/scripts/compile_windows.pl
@@ -26,6 +26,10 @@ $NDDS_VERSION = $ARGV[1];
 # This variable is the architecture name
 $ARCH = $ARGV[2];
 
+# Check if C++11 is supported in this platform
+$PLATFORM_VERSION   = substr $ARCH, 10, 4;
+$IS_CPP11_SUPPORTED = ($PLATFORM_VERSION >= 2013) ? 1 : 0;
+
 # $TOP_DIRECTORY is the directory where you have executed the script
 $TOP_DIRECTORY = cwd();
 
@@ -279,7 +283,7 @@ sub process_all_files {
                 $LANGUAGE = "C++";
             } elsif ($register eq "c++03") {
                 $LANGUAGE = "C++03";
-            } elsif ($register eq "c++11") {
+            } elsif ($register eq "c++11" && $IS_CPP11_SUPPORTED) {
                 $LANGUAGE = "C++11";
             } elsif ($register eq "cs") {
                 $LANGUAGE = "C#";


### PR DESCRIPTION
I have added some variables to check if the platform (passed as argument) supports C++11 and, in that case, allow to compile the examples in that language too.

This fix issues with the current CI agents.