### PR TITLE
Fix not skipping C++11 folders on non supported platforms

### DIFF
--- a/resources/scripts/compile_unix.pl
+++ b/resources/scripts/compile_unix.pl
@@ -223,6 +223,9 @@ sub process_all_files {
         # cs subdirectory
         next if $register eq "."  or  $register eq ".." or $register eq "cs";
 
+        # Skip C++11 if the platform does not support it.
+        next if $register eq "c++11" and !$IS_CPP11_SUPPORTED;
+
         my $file = "$folder/$register";
         $file = unix_path($file);
 
@@ -246,7 +249,7 @@ sub process_all_files {
                 $LANGUAGE = "C++";
             } elsif ($register eq "c++03") {
                 $LANGUAGE = "C++03";
-            } elsif ($register eq "c++11" && $IS_CPP11_SUPPORTED) {
+            } elsif ($register eq "c++11") {
                 $LANGUAGE = "C++11";
             } elsif ($register eq "java") {
                 $LANGUAGE = "Java";

--- a/resources/scripts/compile_windows.pl
+++ b/resources/scripts/compile_windows.pl
@@ -260,6 +260,9 @@ sub process_all_files {
     foreach $register (@files) {
         next if $register eq "."  or  $register eq "..";
 
+        # Skip C++11 if the platform does not support it.
+        next if $register eq "c++11" and !$IS_CPP11_SUPPORTED;
+
         my $file = "$folder/$register";
         $file = unix_path($file);
 
@@ -283,7 +286,7 @@ sub process_all_files {
                 $LANGUAGE = "C++";
             } elsif ($register eq "c++03") {
                 $LANGUAGE = "C++03";
-            } elsif ($register eq "c++11" && $IS_CPP11_SUPPORTED) {
+            } elsif ($register eq "c++11") {
                 $LANGUAGE = "C++11";
             } elsif ($register eq "cs") {
                 $LANGUAGE = "C#";


### PR DESCRIPTION
The previous PR was not skipping the folder since it was just not setting the language, and the C++11 examples were trying to be compiled in C++.

Now it skips the folders named *c++11* if the platform does not support that language.