### PR TITLE
[WIP] Add logging to find_package

### DIFF
--- a/resources/cmake/FindRTIConnextDDS.cmake
+++ b/resources/cmake/FindRTIConnextDDS.cmake
@@ -275,6 +275,20 @@ function(connextdds_verbose message)
     message(VERBOSE ${message})
 endfunction()
 
+
+function(connextdds_log_xml XML_NAME XML)
+    string(REPLACE "\n"
+           ";" lines
+           ${XML})
+
+    message(VERBOSE "~~~~~~~START ${XML_NAME}~~~~~~~")
+    foreach(line ${lines})
+        message(VERBOSE "\t${line}")
+    endforeach()
+    message(VERBOSE "~~~~~~~FINISH ${XML_NAME}~~~~~~~")
+
+endfunction()
+
 #####################################################################
 # Preconditions Check                                               #
 #####################################################################
@@ -516,7 +530,8 @@ function(connextdds_check_component_field_version
     rti_versions_file
     rti_architectures)
     connextdds_debug("connextdds_check_component_field_version called")
-    connextdds_debug("================================================")
+    connextdds_debug(
+        "====================================================================")
     connextdds_debug("\tfield_name: ${field_name}")
     connextdds_debug("\trti_architectures: [${${rti_architectures}}]")
     connextdds_verbose("Checking version for ${field_name}")
@@ -525,7 +540,7 @@ function(connextdds_check_component_field_version
     set(field_section_regex "<${field_name}>.*</${field_name}>")
     string(REGEX MATCH ${field_section_regex} field_xml "${rti_versions_file}")
 
-    connextdds_debug("Component info:\n ${field_xml}")
+    connextdds_log_xml("Component info:" "${field_xml}")
 
     # Check all the architectures defined in the component
     foreach(architecture IN LISTS ${rti_architectures})
@@ -542,7 +557,7 @@ function(connextdds_check_component_field_version
             "</version>")
         string(REGEX MATCH ${field_arch_regex} field_arch "${field_xml}")
         if(field_arch)
-            connextdds_debug("Field arch:\n ${field_xml}")
+            connextdds_log_xml("Field arch:" "${field_arch}")
             break()
         endif()
     endforeach()
@@ -558,7 +573,7 @@ function(connextdds_check_component_field_version
     set(field_version_regex
         "<version>[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+(\\.[0-9]+)?)?</version>")
     string(REGEX MATCH ${field_version_regex} field_version "${field_arch}")
-    connextdds_debug("Component version tag:\n ${field_version}")
+    connextdds_log_xml("Component version tag:" "${field_version}")
 
     if(NOT field_version)
         set(rtiversion_error TRUE PARENT_SCOPE)
@@ -575,7 +590,8 @@ function(connextdds_check_component_field_version
         ${field_version_number_regex}
         field_version_number
         ${field_version})
-    connextdds_debug("Component version: ${field_version_number}")
+
+    connextdds_log_xml("Component version:" "${field_version_number}")
 
     if(NOT field_version_number)
         set(rtiversion_error TRUE PARENT_SCOPE)
@@ -603,7 +619,8 @@ function(connextdds_check_component_field_version
     else()
         connextdds_verbose("${field_name} version.........OK")
     endif()
-    connextdds_debug("================================================")
+    connextdds_debug(
+        "====================================================================")
 endfunction()
 
 # This method searches the libraries indicated in `library_names` under
@@ -630,7 +647,8 @@ function(get_all_library_variables
     library_names
     result_var_name)
     connextdds_debug("get_all_library_variables called")
-    connextdds_debug("================================================")
+    connextdds_debug(
+        "====================================================================")
     connextdds_debug("\tlibrary_names: ${library_names}")
     connextdds_debug("\tresult_var_name: ${result_var_name}")
 
@@ -706,7 +724,8 @@ function(get_all_library_variables
 
     set(${result_var_name}_LIBRARIES
         ${result_var_name}_LIBRARIES_${build_mode}_${link_mode})
-    connextdds_debug("================================================")
+    connextdds_debug(
+        "====================================================================")
 endfunction()
 
 #####################################################################

--- a/resources/cmake/FindRTIConnextDDS.cmake
+++ b/resources/cmake/FindRTIConnextDDS.cmake
@@ -265,6 +265,17 @@
 #
 
 #####################################################################
+# Logging Functions                                                  #
+#####################################################################
+function(connextdds_debug message)
+    message(DEBUG ${message})
+endfunction()
+
+function(connextdds_verbose message)
+    message(VERBOSE ${message})
+endfunction()
+
+#####################################################################
 # Preconditions Check                                               #
 #####################################################################
 #
@@ -273,13 +284,17 @@
 # default installation directories.
 
 if(NOT CONNEXTDDS_DIR)
+    connextdds_verbose("CONNEXTDDS_DIR not specified")
+
     # Is a patch
     if(PACKAGE_FIND_VERSION_COUNT EQUAL 4)
         set(folder_version
             "${PACKAGE_FIND_VERSION_MAJOR}.${PACKAGE_FIND_VERSION_MINOR}.${PACKAGE_FIND_VERSION_PATCH}")
+        connextdds_debug("The required ConnextDDS version is a patch")
     else()
         set(folder_version ${RTIConnextDDS_FIND_VERSION})
     endif()
+    connextdds_verbose("ConnextDDS version ${folder_version}")
 
     if (CMAKE_HOST_SYSTEM_NAME MATCHES "Linux")
         set(connextdds_root_hints
@@ -296,6 +311,7 @@ if(NOT CONNEXTDDS_DIR)
             "/Applications/rti_connext_dds-${folder_version}")
     endif()
 
+    connextdds_debug("Root hints: ${connextdds_root_hints}")
 endif()
 
 # We require having an rti_versions file under the installation directory
@@ -319,6 +335,7 @@ set(codegen_name "rtiddsgen")
 if(WIN32)
     set(codegen_name "${codegen_name}.bat")
 endif()
+connextdds_debug("Codegen script ${codegen_name}")
 
 find_path(RTICODEGEN_DIR
     NAME "${codegen_name}"
@@ -337,15 +354,21 @@ else()
         "Path to RTI Codegen")
 
     # Execute RTI Code Generator to get the version
+    connextdds_debug("Get the Codegen version: '${RTICODEGEN} -version'")
     execute_process(COMMAND ${RTICODEGEN} -version
         OUTPUT_VARIABLE codegen_version_string)
+    connextdds_debug("Command output:")
+    connextdds_debug("${codegen_version_string}")
 
     string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+"
         RTICODEGEN_VERSION "${codegen_version_string}")
+    connextdds_verbose("Codegen version: ${RTICODEGEN_VERSION}")
 endif()
 
 # Find RTI Connext DDS architecture if CONNEXTDDS_ARCH is unset
 if(NOT DEFINED CONNEXTDDS_ARCH)
+    connextdds_verbose("CONNEXTDDS_ARCH was not provided")
+    connextdds_verbose("CONNEXTDDS_ARCH trying to guess the RTI Architecture")
 
     # Guess the RTI Connext DDS architecture
     if(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
@@ -353,9 +376,11 @@ if(NOT DEFINED CONNEXTDDS_ARCH)
             major_version
             ${CMAKE_CXX_COMPILER_VERSION})
         set(version_compiler "${major_version}.0")
+        connextdds_debug("Compiler version: ${version_compiler}")
 
         string(REGEX REPLACE "^([0-9]+)\\.([0-9]+).*$" "\\1"
             kernel_version "${CMAKE_SYSTEM_VERSION}")
+        connextdds_debug("Kernel version: ${kernel_version}")
 
         set(guessed_architecture
              "x64Darwin${kernel_version}${version_compiler}")
@@ -363,7 +388,6 @@ if(NOT DEFINED CONNEXTDDS_ARCH)
     elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")
         if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86")
             set(connextdds_host_arch "i86Win32")
-
         elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "AMD64")
             set(connextdds_host_arch "x64Win64")
 
@@ -371,10 +395,12 @@ if(NOT DEFINED CONNEXTDDS_ARCH)
             message(FATAL_ERROR
                 "${CMAKE_HOST_SYSTEM} is not supported as host architecture")
         endif()
+        connextdds_debug("Host architecture: ${connextdds_host_arch}")
 
         string(REGEX MATCH "[0-9][0-9][0-9][0-9]"
              vs_year
              "${CMAKE_GENERATOR}")
+        connextdds_debug("Visual Studio year: ${vs_year}")
         set(guessed_architecture "${connextdds_host_arch}VS${vs_year}")
     elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux")
         if(CMAKE_COMPILER_VERSION VERSION_EQUAL "4.6.3")
@@ -385,6 +411,8 @@ if(NOT DEFINED CONNEXTDDS_ARCH)
                 "${CMAKE_SYSTEM_VERSION}")
         endif()
 
+        connextdds_debug("Kernel version: ${kernel_version}")
+
         if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64")
             set(connextdds_host_arch "x64Linux")
 
@@ -392,15 +420,18 @@ if(NOT DEFINED CONNEXTDDS_ARCH)
             set(connextdds_host_arch "i86Linux")
         endif()
 
+        connextdds_debug("Host architecture: ${connextdds_host_arch}")
         set(guessed_architecture
-            "${connextdds_host_arch}${kernel_version}gcc${CMAKE_COMPILER_VERSION}")
+            "${connextdds_host_arch}${kernel_version}gcc${CMAKE_C_COMPILER_VERSION}")
     endif()
 
+    connextdds_verbose("Guessed RTI architecture: ${guessed_architecture}")
 
     if(DEFINED ENV{CONNEXTDDS_ARCH})
         set(CONNEXTDDS_ARCH $ENV{CONNEXTDDS_ARCH})
     elseif(EXISTS "${CONNEXTDDS_DIR}/lib/${guessed_architecture}")
         set(CONNEXTDDS_ARCH "${guessed_architecture}")
+        connextdds_debug("${CONNEXTDDS_DIR}/lib/${guessed_architecture} exists")
     else()
         # If CONNEXTDDS_ARCH is unspecified, the module tries uses the first
         # architecture installed by looking under $CONNEXTDDS_DIR/lib.
@@ -484,9 +515,17 @@ function(connextdds_check_component_field_version
     field_name
     rti_versions_file
     rti_architectures)
+    connextdds_debug("connextdds_check_component_field_version called")
+    connextdds_debug("================================================")
+    connextdds_debug("\tfield_name: ${field_name}")
+    connextdds_debug("\trti_architectures: [${${rti_architectures}}]")
+    connextdds_verbose("Checking version for ${field_name}")
+
     # Get the component info
     set(field_section_regex "<${field_name}>.*</${field_name}>")
     string(REGEX MATCH ${field_section_regex} field_xml "${rti_versions_file}")
+
+    connextdds_debug("Component info:\n ${field_xml}")
 
     # Check all the architectures defined in the component
     foreach(architecture IN LISTS ${rti_architectures})
@@ -503,6 +542,7 @@ function(connextdds_check_component_field_version
             "</version>")
         string(REGEX MATCH ${field_arch_regex} field_arch "${field_xml}")
         if(field_arch)
+            connextdds_debug("Field arch:\n ${field_xml}")
             break()
         endif()
     endforeach()
@@ -518,6 +558,7 @@ function(connextdds_check_component_field_version
     set(field_version_regex
         "<version>[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+(\\.[0-9]+)?)?</version>")
     string(REGEX MATCH ${field_version_regex} field_version "${field_arch}")
+    connextdds_debug("Component version tag:\n ${field_version}")
 
     if(NOT field_version)
         set(rtiversion_error TRUE PARENT_SCOPE)
@@ -534,6 +575,7 @@ function(connextdds_check_component_field_version
         ${field_version_number_regex}
         field_version_number
         ${field_version})
+    connextdds_debug("Component version: ${field_version_number}")
 
     if(NOT field_version_number)
         set(rtiversion_error TRUE PARENT_SCOPE)
@@ -548,6 +590,7 @@ function(connextdds_check_component_field_version
         # set it here in the scope of the caller to store the value that has
         # been detected.
         set(RTICONNEXTDDS_VERSION ${field_version_number} PARENT_SCOPE)
+        connextdds_verbose("Found ConnextDDS version: ${field_version_number}")
     elseif(NOT RTICONNEXTDDS_VERSION STREQUAL field_version_number)
         # Otherwise, if the detected version is inconsistent with the previous
         # value of RTICONNEXTDDS_VERSION, we throw an error.
@@ -557,7 +600,10 @@ function(connextdds_check_component_field_version
             "${RTICONNEXTDDS_VERSION}")
         message(WARNING ${warning})
         set(rtiversion_error TRUE PARENT_SCOPE)
+    else()
+        connextdds_verbose("${field_name} version.........OK")
     endif()
+    connextdds_debug("================================================")
 endfunction()
 
 # This method searches the libraries indicated in `library_names` under
@@ -583,6 +629,10 @@ endfunction()
 function(get_all_library_variables
     library_names
     result_var_name)
+    connextdds_debug("get_all_library_variables called")
+    connextdds_debug("================================================")
+    connextdds_debug("\tlibrary_names: ${library_names}")
+    connextdds_debug("\tresult_var_name: ${result_var_name}")
 
     set(mode_library_found TRUE)
     set(${result_var_name}_FOUND TRUE PARENT_SCOPE)
@@ -602,6 +652,8 @@ function(get_all_library_variables
                 else()
                     set(name "${name}")
                 endif()
+                connextdds_debug(
+                    "\t\t[${build_mode}/${link_mode}]Library name: ${name}")
 
                 find_library(lib${library_name}_${build_mode}_${link_mode}
                     NAMES
@@ -628,13 +680,12 @@ function(get_all_library_variables
             string(TOUPPER ${build_mode} upper_build_mode)
 
             if(${mode_library_found})
-                set(${result_var_name}_LIBRARIES_${upper_build_mode}_${upper_link_mode}
-                    ${libraries} PARENT_SCOPE)
-                set(${result_var_name}_LIBRARIES_${upper_build_mode}_${upper_link_mode}_FOUND
-                    TRUE PARENT_SCOPE)
+                set(lib_var "${result_var_name}_LIBRARIES_${upper_build_mode}_${upper_link_mode}")
+                set(${lib_var} ${libraries} PARENT_SCOPE)
+                connextdds_debug("\t${lib_var} = ${libraries}")
+                set(${lib_var}_FOUND TRUE PARENT_SCOPE)
             else()
-                set(${result_var_name}_LIBRARIES_${upper_build_mode}_${upper_link_mode}_FOUND
-                    FALSE PARENT_SCOPE)
+                set(${lib_var}_FOUND FALSE PARENT_SCOPE)
                 set(${result_var_name}_FOUND FALSE PARENT_SCOPE)
             endif()
             unset(lib${library_name}_${build_mode}_${link_mode} CACHE)
@@ -655,6 +706,7 @@ function(get_all_library_variables
 
     set(${result_var_name}_LIBRARIES
         ${result_var_name}_LIBRARIES_${build_mode}_${link_mode})
+    connextdds_debug("================================================")
 endfunction()
 
 #####################################################################


### PR DESCRIPTION
### Summary
CMake 3.15 added a cool new feature ([release notes](https://cmake.org/cmake/help/v3.15/release/3.15.html)):
> The message() command learned new types: NOTICE, VERBOSE, DEBUG and TRACE.

I am using this new feature in the FindPackage script for ConnextDDS.

### Details and comments
I implemented a function in order to wrapper the functionality. Why? This is something new in CMake 3.15 but I can make it work on previous releases (or something similar) using the macro and some logic.

The idea is to make easier to debug issues when we are looking for our libraries.