### PR TITLE
Added clang-format linting for header files too (Closes #257)

### DIFF
--- a/resources/travis/linux_format.py
+++ b/resources/travis/linux_format.py
@@ -255,7 +255,7 @@ if __name__ == "__main__":
 
     # Clang-format
     if "clang-format" not in args.disabled_linters:
-        clang_format_suffix_list = {".c", ".cxx"}
+        clang_format_suffix_list = {".h", ".hxx", ".c", ".cxx"}
         clang_format_cmd = ["git", "clang-format", "--diff"]
         clang_format_filtered_file_list = filter_files(
             file_list, clang_format_suffix_list


### PR DESCRIPTION
Fixes #257. This pull request add linting for header files (C/C++).