### PR TITLE
Improve flat_data_api example to show optionality

### DIFF
--- a/examples/connext_dds/flat_data_api/c++11/CameraImage_publisher.cxx
+++ b/examples/connext_dds/flat_data_api/c++11/CameraImage_publisher.cxx
@@ -27,7 +27,8 @@ void build_data_sample(CameraImageBuilder &builder, int seed)
 
     if (seed % 3 == 0) {
         // All fields in a mutable FlatData type are in effect optional. For
-        // illustration purposes, we will omit the resolution field in some samples
+        // illustration purposes, we will omit the resolution field in some
+        // samples
         auto resolution_offset = builder.add_resolution();
         resolution_offset.height(100);
         resolution_offset.width(200);

--- a/examples/connext_dds/flat_data_api/c++11/CameraImage_publisher.cxx
+++ b/examples/connext_dds/flat_data_api/c++11/CameraImage_publisher.cxx
@@ -25,9 +25,13 @@ void build_data_sample(CameraImageBuilder &builder, int seed)
 {
     builder.add_format(Format::RGB);
 
-    auto resolution_offset = builder.add_resolution();
-    resolution_offset.height(100);
-    resolution_offset.width(200);
+    if (seed % 3 == 0) {
+        // All fields in a mutable FlatData type are in effect optional. For
+        // illustration purposes, we will omit the resolution field in some samples
+        auto resolution_offset = builder.add_resolution();
+        resolution_offset.height(100);
+        resolution_offset.width(200);
+    }
 
     auto string_builder = builder.build_source();
     string_builder.set_string("CAM-1");

--- a/examples/connext_dds/flat_data_api/c++11/CameraImage_subscriber.cxx
+++ b/examples/connext_dds/flat_data_api/c++11/CameraImage_subscriber.cxx
@@ -72,17 +72,17 @@ int process_data(dds::sub::DataReader<CameraImage> &reader)
         count++;
         auto root = sample.data().root();
 
-        // Print the source name. We assume the publisher always sets this field;
-        // if not, root.source().is_null() is true, and get_string() will throw
-        // an exception
+        // Print the source name. We assume the publisher always sets this
+        // field; if not, root.source().is_null() is true, and get_string() will
+        // throw an exception
         std::cout << root.source().get_string() << ": ";
 
         // Print the field resolution. In this case we assume the publisher may
         // decide not to send this field
         auto resolution = root.resolution();
         if (!resolution.is_null()) {
-            std::cout << "(Resolution: " << resolution.height()
-                      << " x " << resolution.width() << ") ";
+            std::cout << "(Resolution: " << resolution.height() << " x "
+                      << resolution.width() << ") ";
         }
 
         // print_average_pixel_simple(sample.data()); // Method 1

--- a/examples/connext_dds/flat_data_api/c++11/CameraImage_subscriber.cxx
+++ b/examples/connext_dds/flat_data_api/c++11/CameraImage_subscriber.cxx
@@ -72,7 +72,19 @@ int process_data(dds::sub::DataReader<CameraImage> &reader)
         count++;
         auto root = sample.data().root();
 
+        // Print the source name. We assume the publisher always sets this field;
+        // if not, root.source().is_null() is true, and get_string() will throw
+        // an exception
         std::cout << root.source().get_string() << ": ";
+
+        // Print the field resolution. In this case we assume the publisher may
+        // decide not to send this field
+        auto resolution = root.resolution();
+        if (!resolution.is_null()) {
+            std::cout << "(Resolution: " << resolution.height()
+                      << " x " << resolution.width() << ") ";
+        }
+
         // print_average_pixel_simple(sample.data()); // Method 1
         print_average_pixel_fast(sample.data());  // Method 2
         std::cout << std::endl;

--- a/examples/connext_dds/flat_data_api/c++98/CameraImage_publisher.cxx
+++ b/examples/connext_dds/flat_data_api/c++98/CameraImage_publisher.cxx
@@ -83,6 +83,7 @@ bool build_data_sample(CameraImageBuilder &builder, int seed)
         if (!resolution_offset.width(200)) {
             return false;
         }
+    }
 
     rti::flat::StringBuilder string_builder = builder.build_source();
     if (string_builder.check_failure()) {
@@ -97,7 +98,6 @@ bool build_data_sample(CameraImageBuilder &builder, int seed)
     string_builder.finish();
     if (string_builder.check_failure()) {
         return false;
-    }
     }
 
     // Method 1 - Build the pixel sequence element by element

--- a/examples/connext_dds/flat_data_api/c++98/CameraImage_publisher.cxx
+++ b/examples/connext_dds/flat_data_api/c++98/CameraImage_publisher.cxx
@@ -70,16 +70,19 @@ bool build_data_sample(CameraImageBuilder &builder, int seed)
         return false;
     }
 
-    ResolutionOffset resolution_offset = builder.add_resolution();
-    if (resolution_offset.is_null()) {
-        return false;
-    }
-    if (!resolution_offset.height(100)) {
-        return false;
-    }
-    if (!resolution_offset.width(200)) {
-        return false;
-    }
+    if (seed % 3 == 0) {
+        // All fields in a mutable FlatData type are in effect optional. For
+        // illustration purposes, we will omit the resolution field in some samples
+        ResolutionOffset resolution_offset = builder.add_resolution();
+        if (resolution_offset.is_null()) {
+            return false;
+        }
+        if (!resolution_offset.height(100)) {
+            return false;
+        }
+        if (!resolution_offset.width(200)) {
+            return false;
+        }
 
     rti::flat::StringBuilder string_builder = builder.build_source();
     if (string_builder.check_failure()) {
@@ -94,6 +97,7 @@ bool build_data_sample(CameraImageBuilder &builder, int seed)
     string_builder.finish();
     if (string_builder.check_failure()) {
         return false;
+    }
     }
 
     // Method 1 - Build the pixel sequence element by element

--- a/examples/connext_dds/flat_data_api/c++98/CameraImage_publisher.cxx
+++ b/examples/connext_dds/flat_data_api/c++98/CameraImage_publisher.cxx
@@ -72,7 +72,8 @@ bool build_data_sample(CameraImageBuilder &builder, int seed)
 
     if (seed % 3 == 0) {
         // All fields in a mutable FlatData type are in effect optional. For
-        // illustration purposes, we will omit the resolution field in some samples
+        // illustration purposes, we will omit the resolution field in some
+        // samples
         ResolutionOffset resolution_offset = builder.add_resolution();
         if (resolution_offset.is_null()) {
             return false;

--- a/examples/connext_dds/flat_data_api/c++98/CameraImage_subscriber.cxx
+++ b/examples/connext_dds/flat_data_api/c++98/CameraImage_subscriber.cxx
@@ -203,7 +203,21 @@ void CameraImageListener::on_data_available(DDSDataReader *reader)
                 return;
             }
 
-            std::cout << root.source().get_string() << ": ";
+            // Print the source name
+            rti::flat::StringOffset source = root.source();
+            if (!source.is_null()) {
+                std::cout << root.source().get_string() << ": ";
+            } else {
+                std::cout << "(Unknown source)" << ": ";
+            }
+
+            // Print the field resolution (if it was published)
+            ResolutionOffset resolution = root.resolution();
+            if (!resolution.is_null()) {
+                std::cout << "(Resolution: " << resolution.height()
+                        << " x " << resolution.width() << ") ";
+            }
+
             // print_average_pixel_simple(data_seq[i]); // Method 1
             print_average_pixel_fast(data_seq[i]);  // Method 2
             std::cout << std::endl;

--- a/examples/connext_dds/flat_data_api/c++98/CameraImage_subscriber.cxx
+++ b/examples/connext_dds/flat_data_api/c++98/CameraImage_subscriber.cxx
@@ -208,14 +208,14 @@ void CameraImageListener::on_data_available(DDSDataReader *reader)
             if (!source.is_null()) {
                 std::cout << root.source().get_string() << ": ";
             } else {
-                std::cout << "(Unknown source)" << ": ";
+                std::cout << "(Unknown source): ";
             }
 
             // Print the field resolution (if it was published)
             ResolutionOffset resolution = root.resolution();
             if (!resolution.is_null()) {
-                std::cout << "(Resolution: " << resolution.height()
-                        << " x " << resolution.width() << ") ";
+                std::cout << "(Resolution: " << resolution.height() << " x "
+                          << resolution.width() << ") ";
             }
 
             // print_average_pixel_simple(data_seq[i]); // Method 1


### PR DESCRIPTION

<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.

:white_check_mark: I have updated the documentation accordingly.
:white_check_mark: I have read the CONTRIBUTING document.
-->

### Summary
Small changes to the publisher and subscriber to show that all members in an optional flatdata type are optional


### Details and comments
The publisher now omits the resolution field in some samples to demonstrate that all fields are optional. The subscriber now prints the resolution field if it exits. 

In the C++98 example, the subscriber now checks if the source member is present. Before, if it wasn't present the example may have crashed. In the C++11 example that's not necessary; if the source field doesn't exist, the example fails with an exception.

