### PR TITLE
Feature/record 1120

### DIFF
--- a/examples/recording_service/pluggable_storage/c/CMakeLists.txt
+++ b/examples/recording_service/pluggable_storage/c/CMakeLists.txt
@@ -21,6 +21,14 @@ if(NOT BUILD_SHARED_LIBS)
     message(FATAL_ERROR ${msg})
 endif()
 
+if(NOT CMAKE_BUILD_TYPE)
+    set(msg
+        "Not specifying CMAKE_BUILD_TYPE can lead to undefined behaviour and "
+        "is not supported for this example. Please provide a valid value for "
+        "the CMAKE_BUILD_TYPE parameter")
+    message(FATAL_ERROR ${msg})
+endif()
+
 if(CONNEXTDDS_IMPORTED_TARGETS_DEBUG)
     set(msg
         "You have selected to build the library in debug mode. It's recommended "

--- a/examples/recording_service/pluggable_storage/c/README.md
+++ b/examples/recording_service/pluggable_storage/c/README.md
@@ -69,8 +69,8 @@ Build the example code by running the following command:
 ```bash
 mkdir build
 cd build
-cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture> \
-        -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON ..
+cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture>
+      -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON ..
 cmake --build .
 ```
 
@@ -78,8 +78,8 @@ In case you are using Windows x64, you have to add the option -A in the cmake
 command as follow:
 
 ```bash
-cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture> \
-        -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON .. -A x64
+cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture>
+      -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON .. -A x64
 ```
 
 **Cross-compilation**.
@@ -102,7 +102,8 @@ Then you can call CMake like this:
 
 ```bash
 cmake -DCONNEXTDDS_DIR=<connext dir> -DCMAKE_TOOLCHAIN_FILE=<toolchain file created above>
-      -DCMAKE_BUILD_TYPE=Release -DCONNEXTDDS_ARCH=<connext architecture> ..
+      -DCONNEXTDDS_ARCH=<connext architecture>
+      -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON ..
 ```
 
 ## Running the C example (Recorder storage writer)
@@ -123,7 +124,8 @@ folder (where the storage writer plugin shared library has been created).
 
 ```bash
 cd build
-<connext dir>/bin/rtirecordingservice -cfgFile ../pluggable_storage_example.xml -cfgName C_StorageExample -domainIdBase <your domain ID>
+<connext dir>/bin/rtirecordingservice -cfgFile ../pluggable_storage_example.xml 
+        -cfgName C_StorageExample -domainIdBase <your domain ID>
 ```
 
 After running this command, you will see the following output:
@@ -160,7 +162,8 @@ folder (where the storage reader plugin shared library has been created).
 
 ```bash
 cd build
-<connext dir>/bin/rtireplayservice -cfgFile ../pluggable_replay_example.xml -cfgName C_ReaderExample -domainIdBase <your domain ID>
+<connext dir>/bin/rtireplayservice -cfgFile ../pluggable_replay_example.xml 
+        -cfgName C_ReaderExample -domainIdBase <your domain ID>
 ```
 
 You should see the samples in the file being published and received by the

--- a/examples/recording_service/pluggable_storage/c/README.md
+++ b/examples/recording_service/pluggable_storage/c/README.md
@@ -102,7 +102,7 @@ Then you can call CMake like this:
 
 ```bash
 cmake -DCONNEXTDDS_DIR=<connext dir> -DCMAKE_TOOLCHAIN_FILE=<toolchain file created above>
-        -DCONNEXTDDS_ARCH=<connext architecture> ..
+      -DCMAKE_BUILD_TYPE=Release -DCONNEXTDDS_ARCH=<connext architecture> ..
 ```
 
 ## Running the C example (Recorder storage writer)

--- a/examples/recording_service/pluggable_storage/c/README.md
+++ b/examples/recording_service/pluggable_storage/c/README.md
@@ -124,7 +124,7 @@ folder (where the storage writer plugin shared library has been created).
 
 ```bash
 cd build
-<connext dir>/bin/rtirecordingservice -cfgFile ../pluggable_storage_example.xml 
+<connext dir>/bin/rtirecordingservice -cfgFile ../pluggable_storage_example.xml
         -cfgName C_StorageExample -domainIdBase <your domain ID>
 ```
 
@@ -162,7 +162,7 @@ folder (where the storage reader plugin shared library has been created).
 
 ```bash
 cd build
-<connext dir>/bin/rtireplayservice -cfgFile ../pluggable_replay_example.xml 
+<connext dir>/bin/rtireplayservice -cfgFile ../pluggable_replay_example.xml
         -cfgName C_ReaderExample -domainIdBase <your domain ID>
 ```
 

--- a/examples/recording_service/pluggable_storage/cpp/CMakeLists.txt
+++ b/examples/recording_service/pluggable_storage/cpp/CMakeLists.txt
@@ -21,6 +21,14 @@ if(NOT BUILD_SHARED_LIBS)
     message(FATAL_ERROR ${msg})
 endif()
 
+if(NOT CMAKE_BUILD_TYPE)
+    set(msg
+        "Not specifying CMAKE_BUILD_TYPE can lead to undefined behaviour and "
+        "is not supported for this example. Please provide a valid value for "
+        "the CMAKE_BUILD_TYPE parameter")
+    message(FATAL_ERROR ${msg})
+endif()
+
 if(CONNEXTDDS_IMPORTED_TARGETS_DEBUG)
     set(msg
         "You have selected to build the library in debug mode. It's recommended "

--- a/examples/recording_service/pluggable_storage/cpp/README.md
+++ b/examples/recording_service/pluggable_storage/cpp/README.md
@@ -69,8 +69,8 @@ Build the example code by running the following command:
 ```bash
 mkdir build
 cd build
-cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture> \
-        -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON ..
+cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture>
+      -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON ..
 cmake --build .
 ```
 
@@ -78,8 +78,8 @@ In case you are using Windows x64, you have to add the option -A in the cmake
 command as follow:
 
 ```bash
-cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture> \
-        -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON .. -A x64
+cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture>
+      -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON .. -A x64
 ```
 
 **Cross-compilation**.
@@ -102,7 +102,8 @@ Then you can call CMake like this:
 
 ```bash
 cmake -DCONNEXTDDS_DIR=<connext dir> -DCMAKE_TOOLCHAIN_FILE=<toolchain file created above>
-      -DCMAKE_BUILD_TYPE=Release -DCONNEXTDDS_ARCH=<connext architecture> ..
+      -DCONNEXTDDS_ARCH=<connext architecture>
+      -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON ..
 ```
 
 ## Running the C++ example (Recorder storage writer)
@@ -123,7 +124,8 @@ folder (where the storage writer plugin shared library has been created).
 
 ```bash
 cd build
-<connext dir>/bin/rtirecordingservice -cfgFile ../pluggable_storage_example.xml -cfgName CppFileWriterExample -domainIdBase <your domain ID>
+<connext dir>/bin/rtirecordingservice -cfgFile ../pluggable_storage_example.xml 
+        -cfgName CppFileWriterExample -domainIdBase <your domain ID>
 ```
 
 After running this command, you will see the following output:
@@ -160,7 +162,8 @@ folder (where the storage reader plugin shared library has been created).
 
 ```bash
 cd build
-<connext dir>/bin/rtireplayservice -cfgFile ../pluggable_replay_example.xml -cfgName CppFileReaderExample -domainIdBase <your domain ID>
+<connext dir>/bin/rtireplayservice -cfgFile ../pluggable_replay_example.xml 
+        -cfgName CppFileReaderExample -domainIdBase <your domain ID>
 ```
 
 You should see the samples in the file being published and received by the

--- a/examples/recording_service/pluggable_storage/cpp/README.md
+++ b/examples/recording_service/pluggable_storage/cpp/README.md
@@ -124,7 +124,7 @@ folder (where the storage writer plugin shared library has been created).
 
 ```bash
 cd build
-<connext dir>/bin/rtirecordingservice -cfgFile ../pluggable_storage_example.xml 
+<connext dir>/bin/rtirecordingservice -cfgFile ../pluggable_storage_example.xml
         -cfgName CppFileWriterExample -domainIdBase <your domain ID>
 ```
 
@@ -162,7 +162,7 @@ folder (where the storage reader plugin shared library has been created).
 
 ```bash
 cd build
-<connext dir>/bin/rtireplayservice -cfgFile ../pluggable_replay_example.xml 
+<connext dir>/bin/rtireplayservice -cfgFile ../pluggable_replay_example.xml
         -cfgName CppFileReaderExample -domainIdBase <your domain ID>
 ```
 

--- a/examples/recording_service/pluggable_storage/cpp/README.md
+++ b/examples/recording_service/pluggable_storage/cpp/README.md
@@ -102,7 +102,7 @@ Then you can call CMake like this:
 
 ```bash
 cmake -DCONNEXTDDS_DIR=<connext dir> -DCMAKE_TOOLCHAIN_FILE=<toolchain file created above>
-        -DCONNEXTDDS_ARCH=<connext architecture> ..
+      -DCMAKE_BUILD_TYPE=Release -DCONNEXTDDS_ARCH=<connext architecture> ..
 ```
 
 ## Running the C++ example (Recorder storage writer)

--- a/examples/recording_service/service_as_lib/cpp/CMakeLists.txt
+++ b/examples/recording_service/service_as_lib/cpp/CMakeLists.txt
@@ -19,6 +19,14 @@ if(NOT BUILD_SHARED_LIBS)
     message(FATAL_ERROR ${msg})
 endif()
 
+if(NOT CMAKE_BUILD_TYPE)
+    set(msg
+        "Not specifying CMAKE_BUILD_TYPE can lead to undefined behaviour and "
+        "is not supported for this example. Please provide a valid value for "
+        "the CMAKE_BUILD_TYPE parameter")
+    message(FATAL_ERROR ${msg})
+endif()
+
 if(CONNEXTDDS_IMPORTED_TARGETS_DEBUG)
     set(msg
         "You have selected to build the library in debug mode. It's recommended "

--- a/examples/recording_service/service_as_lib/cpp/README.md
+++ b/examples/recording_service/service_as_lib/cpp/README.md
@@ -60,7 +60,7 @@ Build the example code by running the following command:
 mkdir build
 cd build
 cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture> \
-        -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON ..
+      -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON ..
 cmake --build .
 ```
 
@@ -69,7 +69,7 @@ command as follow:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture> \
-        -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON .. -A x64
+      -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON .. -A x64
 ```
 
 This will produce a binary directory (*build*) where the `ServiceAsLibExample`
@@ -96,9 +96,10 @@ set(CMAKE_CXX_COMPILER "${toolchain_path}/bin/arm-linux-gnueabihf-g++")
 Then you can call CMake like this:
 
 ```sh
-cmake -DCONNEXTDDS_DIR=<connext dir> \
-      -DCMAKE_TOOLCHAIN_FILE=<toolchain file created above> \
-      -DCONNEXTDDS_ARCH=<connext architecture> ..
+cmake -DCONNEXTDDS_DIR=<connext dir>
+      -DCMAKE_TOOLCHAIN_FILE=<toolchain file created above>
+      -DCONNEXTDDS_ARCH=<connext architecture> 
+      -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON ..
 ```
 
 ## Running the Example

--- a/examples/recording_service/service_as_lib/cpp/README.md
+++ b/examples/recording_service/service_as_lib/cpp/README.md
@@ -98,7 +98,7 @@ Then you can call CMake like this:
 ```sh
 cmake -DCONNEXTDDS_DIR=<connext dir>
       -DCMAKE_TOOLCHAIN_FILE=<toolchain file created above>
-      -DCONNEXTDDS_ARCH=<connext architecture> 
+      -DCONNEXTDDS_ARCH=<connext architecture>
       -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON ..
 ```
 


### PR DESCRIPTION
The example library generated was build without the CMAKE_BUILD_TYPE flag. This was causing the library to be release, but it was linked against the debug libraries in Connext. During runtime, the release libraries of Connext were used. This leads to unexpected behaviour. In that case it was leading to a crash (invalid pointer).

We should require that the user sets the CMAKE_BUILD_TYPE flag when using cmake to build the examples.

Internal issue: [RECORD-1120](https://jira.rti.com/browse/RECORD-1120).