### PR TITLE
Feature/record 1121

### DIFF
--- a/examples/recording_service/service_admin/cpp/Requester.cxx
+++ b/examples/recording_service/service_admin/cpp/Requester.cxx
@@ -363,7 +363,7 @@ int main(int argc, char *argv[])
          */
         ArgumentsParser args_parser(argc, argv);
         Application requester_app(args_parser);
-    } catch (std::runtime_error &ex) {
+    } catch (std::exception &ex) {
         std::cerr << ex.what() << std::endl;
         return EXIT_FAILURE;
     }

--- a/examples/recording_service/service_admin/cpp/Requester.hpp
+++ b/examples/recording_service/service_admin/cpp/Requester.hpp
@@ -10,6 +10,7 @@
  * use or inability to use the software.
  */
 
+#include <dds/core/types.hpp>
 #include <dds/core/External.hpp>
 #include <dds/domain/domainfwd.hpp>
 #include <rti/request/Requester.hpp>


### PR DESCRIPTION
We need to add a catch in the main for a dds::core::Exception. Without it, if the profiles are not found the application aborts.

```c
int main(int argc, char *argv[])
{
       try {
              /*
              * The main method is quite simple. We have a class that is a
              * command-line interpreter (ArgumentsParser) for the main application
              * class (Application). This class will produce a command request with
              * the given command-line parameters and wait for any replies. It will
              * then exit. This can be understand as a one-shot application,
              * producing just one service administration request.
              */
              ArgumentsParser args_parser(argc, argv);
              Application requester_app(args_parser);
       }
       catch (dds::core::Exception &ex) {
              // here if qos profiles are not found
              std::cerr << ex.what() << std::endl;
              return EXIT_FAILURE;
       }
       catch (std::runtime_error &ex) {
              std::cerr << ex.what() << std::endl;
              return EXIT_FAILURE;
       }
       return EXIT_SUCCESS;
}
```

Internal ticket: [RECORD-1121](https://jira.rti.com/browse/RECORD-1121).