### PR TITLE
Feature/record 1119

### DIFF
--- a/examples/recording_service/pluggable_storage/c/README.md
+++ b/examples/recording_service/pluggable_storage/c/README.md
@@ -74,8 +74,8 @@ cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture>
 cmake --build .
 ```
 
-> **Note**: 
-> 
+> **Note**:
+>
 > When using a multi-configuration generator, make sure you specify
 > the `--config` parameter in your call to `cmake --build .`. In general,
 > it's a good practice to always provide it.

--- a/examples/recording_service/pluggable_storage/c/README.md
+++ b/examples/recording_service/pluggable_storage/c/README.md
@@ -74,6 +74,12 @@ cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture>
 cmake --build .
 ```
 
+> **Note**: 
+> 
+> When using a multi-configuration generator, make sure you specify
+> the `--config` parameter in your call to `cmake --build .`. In general,
+> it's a good practice to always provide it.
+
 In case you are using Windows x64, you have to add the option -A in the cmake
 command as follow:
 

--- a/examples/recording_service/pluggable_storage/cpp/README.md
+++ b/examples/recording_service/pluggable_storage/cpp/README.md
@@ -74,8 +74,8 @@ cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture>
 cmake --build .
 ```
 
-> **Note**: 
-> 
+> **Note**:
+>
 > When using a multi-configuration generator, make sure you specify
 > the `--config` parameter in your call to `cmake --build .`. In general,
 > it's a good practice to always provide it.

--- a/examples/recording_service/pluggable_storage/cpp/README.md
+++ b/examples/recording_service/pluggable_storage/cpp/README.md
@@ -74,6 +74,12 @@ cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture>
 cmake --build .
 ```
 
+> **Note**: 
+> 
+> When using a multi-configuration generator, make sure you specify
+> the `--config` parameter in your call to `cmake --build .`. In general,
+> it's a good practice to always provide it.
+
 In case you are using Windows x64, you have to add the option -A in the cmake
 command as follow:
 

--- a/examples/recording_service/service_admin/cpp/README.md
+++ b/examples/recording_service/service_admin/cpp/README.md
@@ -54,8 +54,8 @@ cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture> ..
 cmake --build .
 ```
 
-> **Note**: 
-> 
+> **Note**:
+>
 > When using a multi-configuration generator, make sure you specify
 > the `--config` parameter in your call to `cmake --build .`. In general,
 > it's a good practice to always provide it.

--- a/examples/recording_service/service_admin/cpp/README.md
+++ b/examples/recording_service/service_admin/cpp/README.md
@@ -54,6 +54,12 @@ cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture> ..
 cmake --build .
 ```
 
+> **Note**: 
+> 
+> When using a multi-configuration generator, make sure you specify
+> the `--config` parameter in your call to `cmake --build .`. In general,
+> it's a good practice to always provide it.
+
 This will produce a binary directory (*build*) where the `Requester` application
 can be found. The XML files in the source directory are also copied over to this
 binary directory so that *Recording Service* can be run directly from this

--- a/examples/recording_service/service_as_lib/cpp/README.md
+++ b/examples/recording_service/service_as_lib/cpp/README.md
@@ -64,8 +64,8 @@ cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture>
 cmake --build .
 ```
 
-> **Note**: 
-> 
+> **Note**:
+>
 > When using a multi-configuration generator, make sure you specify
 > the `--config` parameter in your call to `cmake --build .`. In general,
 > it's a good practice to always provide it.
@@ -111,7 +111,7 @@ cmake -DCONNEXTDDS_DIR=<connext dir>
 ## Running the Example
 
 When running the example, make sure that the Routing Service Library
-(_librtiroutingservice.so_ on Linux, _librtiroutingservice.dylib_ on Mac, 
+(_librtiroutingservice.so_ on Linux, _librtiroutingservice.dylib_ on Mac,
 _rtiroutingservice.dll_ on Windows) is accessible in the current dynamic library
 loading path (e.g. `LD_LIBRARY_PATH` on Linux).
 

--- a/examples/recording_service/service_as_lib/cpp/README.md
+++ b/examples/recording_service/service_as_lib/cpp/README.md
@@ -59,16 +59,22 @@ Build the example code by running the following command:
 ```sh
 mkdir build
 cd build
-cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture> \
+cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture>
       -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON ..
 cmake --build .
 ```
+
+> **Note**: 
+> 
+> When using a multi-configuration generator, make sure you specify
+> the `--config` parameter in your call to `cmake --build .`. In general,
+> it's a good practice to always provide it.
 
 In case you are using Windows x64, you have to add the option -A in the cmake
 command as follow:
 
 ```sh
-cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture> \
+cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture>
       -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON .. -A x64
 ```
 
@@ -103,6 +109,11 @@ cmake -DCONNEXTDDS_DIR=<connext dir>
 ```
 
 ## Running the Example
+
+When running the example, make sure that the Routing Service Library
+(_librtiroutingservice.so_ on Linux, _librtiroutingservice.dylib_ on Mac, 
+_rtiroutingservice.dll_ on Windows) is accessible in the current dynamic library
+loading path (e.g. `LD_LIBRARY_PATH` on Linux).
 
 The following command-line parameters are expected by the application:
 


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.

:white_check_mark: I have updated the documentation accordingly.
:white_check_mark: I have read the CONTRIBUTING document.
-->

### Summary

See [RECORD-1119](http://jira:8085/browse/RECORD-1119).

### Details and comments

The idea is to make sure we provide a note for users to use the `--config` switch with `cmake` when they're using multi-configuration generators. Also making sure we document the need to set the `LD_LIBRARY_PATH` variable when running the `service_as_lib` example.