### PR TITLE
#280 Replace break with continue in C and C++ Polling Read examples

### DIFF
--- a/examples/connext_dds/polling_read/c++/poll_subscriber.cxx
+++ b/examples/connext_dds/polling_read/c++/poll_subscriber.cxx
@@ -224,7 +224,7 @@ extern "C" int subscriber_main(int domainId, int sample_count)
         } else if (retcode != DDS_RETCODE_OK) {
             // Is an error
             printf("take error: %d\n", retcode);
-            break;
+            continue;
         }
 
         int len = 0;

--- a/examples/connext_dds/polling_read/c/poll_subscriber.c
+++ b/examples/connext_dds/polling_read/c/poll_subscriber.c
@@ -240,7 +240,7 @@ static int subscriber_main(int domainId, int sample_count)
         } else if (retcode != DDS_RETCODE_OK) {
             /* Is an error */
             printf("take error: %d\n", retcode);
-            break;
+            continue;
         }
 
         sum = 0;


### PR DESCRIPTION
### Summary

This pull request replaces a break with a  continue statement in the C and C++ Polling examples. The purpose of this change is to avoid, as reported in #208, exiting no data is read.

### Details and comments

The change only affects the C and C++ examples, as the rest follow a different logic.
