### PR TITLE
rticommunity#283: Add the certificate generation infrastructure needed by security examples

### DIFF
--- a/resources/cert/cert.mk
+++ b/resources/cert/cert.mk
@@ -1,0 +1,29 @@
+######################################################################
+# (c) Copyright, Real-Time Innovations, 2020.  All rights reserved.
+# No duplications, whole or partial, manual or electronic, may be made
+# without express written permission.  Any such copies, or
+# revisions thereof, must display this notice unaltered.
+# This code contains trade secrets of Real-Time Innovations, Inc.
+#
+# Makefile utilities to generate example PKIs and certificates
+#
+########################################################################
+
+# Makefile utilities
+
+%.pki:
+	mkdir -p ca/private ca/database ca/newCerts
+	chmod 700 ca/private
+	touch ca/database/$*Index
+	echo 01 > ca/database/$*Crlnumber
+
+clean: cleanTmpFiles
+	-$(RM) -r ca/private ca/database ca/newCerts ca/*.pem ca/*.crl
+	-$(RM) identities/*.pem
+
+cleanTmpFiles:
+	-$(RM) ca/private/*Param ca/database/* ca/newCerts/* ca/*.csr
+	-$(RM) identities/*.csr identities/*Param
+
+.PHONY: all %.pki clean cleanTmpFiles
+.PRECIOUS:

--- a/resources/cert/ecdsa01/ca/ecdsa01RootCa.cnf
+++ b/resources/cert/ecdsa01/ca/ecdsa01RootCa.cnf
@@ -1,0 +1,88 @@
+#
+# OpenSSL ecdsa01RootCa Certificate Authority configuration file.
+
+####################################################################
+[ ca ]
+default_ca      = CA_default                   # The default ca section
+
+
+####################################################################
+[ CA_default ]
+name            = ecdsa01RootCa                # Name of the certificate
+
+certs           = ca/certs                     # Where the issued certs are kept
+crl_dir         = ca/crl                       # Where the issued crl are kept
+database        = ca/database/${name}Index     # Database index file
+unique_subject  = no                           # Set to 'no' to allow creation of
+                                               # several ctificates with same subject.
+
+new_certs_dir   = ca/newCerts                  # Where a copy of the issued certs are kept
+certificate     = ca/${name}Cert.pem           # The CA certificate
+serial          = ca/database/${name}Serial    # The current serial number
+crlnumber       = ca/database/${name}Crlnumber # The current crl number
+                                               # must be commented out to leave a V1 CRL
+crl             = ca/${name}.crl               # The current CRL
+private_key     = ca/private/${name}Key.pem    # The private key
+RANDFILE        = ca/private/.rand             # private random number file
+
+#x509_extensions = usr_cert                     # The extentions to add to the cert
+
+# Comment out the following two lines for the "traditional" (and highly broken) format.
+name_opt        = ca_default                   # Subject Name options
+cert_opt        = ca_default                   # Certificate field options
+
+# Extension copying option: use with caution.
+#copy_extensions = copy
+
+# Extensions to add to a CRL. Note: Netscape communicator chokes on V2 CRLs
+# so this is commented out by default to leave a V1 CRL.
+# crlnumber must also be commented out to leave a V1 CRL.
+#crl_extensions         = crl_ext
+
+default_days           = 365                   # how long to certify for
+default_crl_days       = 30                    # how long before next CRL
+default_md             = sha256                # which md to use.
+preserve               = no                    # keep passed DN ordering
+
+# A few difference way of specifying how similar the request should look
+# For type CA, the listed attributes must be the same, and the optional
+# and supplied fields are just that
+policy                  = policy_match
+
+# For the CA policy
+[ policy_match ]
+countryName             = match
+stateOrProvinceName     = match
+organizationName        = match
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+# For the 'anything' policy
+# At this point in time, you must list all acceptable 'object' types.
+[ policy_anything ]
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+[ req ]
+prompt                  = no
+distinguished_name      = req_distinguished_name
+
+[ req_distinguished_name ]
+countryName             = US
+stateOrProvinceName     = CA
+localityName            = Santa Clara
+0.organizationName      = Real Time Innovations
+
+commonName              = ${CA_default::name}
+emailAddress            = ${CA_default::name}@rti.com
+
+[ v3_ca ]
+# Extensions for a typical CA (`man x509v3_config`).
+basicConstraints = CA:true
+

--- a/resources/cert/ecdsa01/identities/ecdsa01Peer01.cnf
+++ b/resources/cert/ecdsa01/identities/ecdsa01Peer01.cnf
@@ -1,0 +1,10 @@
+prompt                     = no
+distinguished_name         = req_distinguished_name
+
+[ req_distinguished_name ]
+countryName                = US
+stateOrProvinceName        = CA
+localityName               = Santa Clara
+organizationName           = Real Time Innovations
+commonName                 = ecdsa01Peer01
+emailAddress               = ecdsa01Peer01@rti.com

--- a/resources/cert/ecdsa01/identities/ecdsa01Peer02.cnf
+++ b/resources/cert/ecdsa01/identities/ecdsa01Peer02.cnf
@@ -1,0 +1,10 @@
+prompt                     = no
+distinguished_name         = req_distinguished_name
+
+[ req_distinguished_name ]
+countryName                = US
+stateOrProvinceName        = CA
+localityName               = Santa Clara
+organizationName           = Real Time Innovations
+commonName                 = ecdsa01Peer02
+emailAddress               = ecdsa01Peer02@rti.com

--- a/resources/cert/ecdsa01/makefile
+++ b/resources/cert/ecdsa01/makefile
@@ -1,0 +1,67 @@
+######################################################################
+# (c) Copyright, Real-Time Innovations, 2020.  All rights reserved.
+# No duplications, whole or partial, manual or electronic, may be made
+# without express written permission.  Any such copies, or
+# revisions thereof, must display this notice unaltered.
+# This code contains trade secrets of Real-Time Innovations, Inc.
+#
+# Makefile to create example certificates and keys
+#
+########################################################################
+
+# Definitions
+
+OPENSSL := openssl
+
+INTERMEDIATE_DAYS      = 1825 # 5 years, no leap days
+ROOT_DAYS              = 1825 # 5 years, no leap days
+PEER_DAYS              = 730  # 2 years, no leap days
+
+
+PKI_PREFIX = ecdsa01
+
+ROOT_CA_NAME           = $(PKI_PREFIX)RootCa
+
+ROOT_CA                = ca/$(ROOT_CA_NAME)
+
+PEER01    = identities/$(PKI_PREFIX)Peer01
+PEER02    = identities/$(PKI_PREFIX)Peer02
+
+CERTIFICATE_LIST = \
+				   $(ROOT_CA)Cert.pem \
+				   $(PEER01)Cert.pem \
+				   $(PEER02)Cert.pem
+
+
+# Certificate generation
+
+all: $(ROOT_CA_NAME).pki
+	$(MAKE) cert
+
+cert: $(CERTIFICATE_LIST)
+
+include ../cert.mk
+
+
+# CA certificates
+
+# RootCa is self-signed
+$(ROOT_CA)Cert.pem:
+	$(OPENSSL) ecparam -name prime256v1 -out ca/private/$(ROOT_CA_NAME)Param
+	$(OPENSSL) req -nodes -x509 -days $(ROOT_DAYS) -text -sha256 -newkey ec:ca/private/$(ROOT_CA_NAME)Param -keyout ca/private/$(ROOT_CA_NAME)Key.pem -out $(ROOT_CA)Cert.pem -config $(ROOT_CA).cnf
+
+
+# Peer certificates
+
+# RootCa signs Peer01Cert
+$(PEER01)Cert.pem: $(ROOT_CA)Cert.pem
+	$(OPENSSL) ecparam -name prime256v1 -out $(PEER01)Param
+	$(OPENSSL) req -nodes -new -newkey ec:$(PEER01)Param -config $(PEER01).cnf -keyout $(PEER01)Key.pem -out $(PEER01).csr
+	$(OPENSSL) ca -batch -create_serial -config $(ROOT_CA).cnf -days $(PEER_DAYS) -in $(PEER01).csr -out $(PEER01)Cert.pem
+
+# RootCa signs Peer02Cert
+$(PEER02)Cert.pem: $(ROOT_CA)Cert.pem
+	$(OPENSSL) ecparam -name prime256v1 -out $(PEER02)Param
+	$(OPENSSL) req -nodes -new -newkey ec:$(PEER02)Param -config $(PEER02).cnf -keyout $(PEER02)Key.pem -out $(PEER02).csr
+	$(OPENSSL) ca -batch -create_serial -config $(ROOT_CA).cnf -days $(PEER_DAYS) -in $(PEER02).csr -out $(PEER02)Cert.pem
+


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.

:white_check_mark: I have updated the documentation accordingly.
:white_check_mark: I have read the CONTRIBUTING document.
-->

### Summary
Added `resource/cert` directory with 1 PKI: `ecdsa01`.

This PKI has 1 CA and 2 Peers. OpenSSL config files are provided for all 3 entities. A makefile is provided to generate certificates and keys for all 3 entities.


### Details and comments
No README has been generated.
