### PR TITLE
Add c++11 property.

### DIFF
--- a/examples/routing_service/routing_service_struct_array_transf/cpp/CMakeLists.txt
+++ b/examples/routing_service/routing_service_struct_array_transf/cpp/CMakeLists.txt
@@ -114,3 +114,8 @@ target_link_libraries(SensorDataSubscriber
     RTIConnextDDS::cpp2_api
     RTIConnextDDS::c_api
     ${CONNEXTDDS_EXTERNAL_LIBS})
+    
+set_target_properties(SensorDataSubscriber
+    PROPERTIES
+    CXX_STANDARD 11
+)

--- a/examples/routing_service/routing_service_struct_array_transf/cpp/CMakeLists.txt
+++ b/examples/routing_service/routing_service_struct_array_transf/cpp/CMakeLists.txt
@@ -118,4 +118,5 @@ target_link_libraries(SensorDataSubscriber
 set_target_properties(SensorDataSubscriber
     PROPERTIES
     CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED
 )

--- a/examples/routing_service/routing_service_struct_array_transf/cpp/CMakeLists.txt
+++ b/examples/routing_service/routing_service_struct_array_transf/cpp/CMakeLists.txt
@@ -118,5 +118,5 @@ target_link_libraries(SensorDataSubscriber
 set_target_properties(SensorDataSubscriber
     PROPERTIES
     CXX_STANDARD 11
-    CXX_STANDARD_REQUIRED
+    CXX_STANDARD_REQUIRED ON
 )


### PR DESCRIPTION
# Summary
Add c++11 property for compile in older compilers where c++11 is allowed but not the default.


### Details and comments

Tested on x64Linux3gcc5.4.0, x64Linux3gcc7.3.0 and x64Win10vs2017