### PR TITLE
Adding a new community example for RS: constrained wan

### DIFF
--- a/examples/routing_service/routing_service_constrained_wan/README.md
+++ b/examples/routing_service/routing_service_constrained_wan/README.md
@@ -4,5 +4,5 @@
 
 These files are used to configure routing service for use in a constrained WAN
 environment. For a full description of how to use these files see the example
-located on the [RTI community website]
-(https://community.rti.com/examples/Routing-Service-Constrained-WAN-Example)
+located on the [RTI community website](
+https://community.rti.com/examples/Routing-Service-Constrained-WAN-Example)

--- a/examples/routing_service/routing_service_constrained_wan/README.md
+++ b/examples/routing_service/routing_service_constrained_wan/README.md
@@ -1,0 +1,3 @@
+These files are used to configure a constrained WAN demo that is available on RTI's community 'examples' website
+
+https://community.rti.com/examples

--- a/examples/routing_service/routing_service_constrained_wan/README.md
+++ b/examples/routing_service/routing_service_constrained_wan/README.md
@@ -24,7 +24,7 @@ their routes using the 300ms.xml and 1000ms.xml files.
 
 ## Instructions
 
-1. Start two copies of shapesdemo, a publisher on domain 0 and a
+1. Start two copies of the shapesdemo, a publisher on domain 0 and a
 subscriber on domain 1.
 
 2. Start routing service using this configuration, from the command

--- a/examples/routing_service/routing_service_constrained_wan/README.md
+++ b/examples/routing_service/routing_service_constrained_wan/README.md
@@ -49,8 +49,8 @@ Notice how the triangle is now updating in batches of 6 samples,
 compared to the other shapes that are updating one sample at a time.
 
 6.  Combine batching and time filters together  
-From the rtirssh shell run: `update example
-Route::Session::TriangleBatch <path to xml>\300ms.xml`  
+From the rtirssh shell run:
+`update example Route::Session::TriangleBatch <path to xml>\300ms.xml`  
 Notice how the triangle is still batching 6 samples up at a time, but
 it is also time filtering one sample every 300ms.
 

--- a/examples/routing_service/routing_service_constrained_wan/README.md
+++ b/examples/routing_service/routing_service_constrained_wan/README.md
@@ -9,26 +9,55 @@ https://community.rti.com/examples/Routing-Service-Constrained-WAN-Example)
 
 ## Concept
 
-This example shows how to utilize routing service's features such as time 
-based filters, batching, propagation of content filters, and transformations 
-to limit the amount of bandwidth DDS samples require. This can be useful to 
-use cases such as autonomous vehicles that require a high sample rate of data 
-on the vehicle, while also utilizing a WAN link to a backend server that 
-has a much more limited network link. These filters can be applied without 
-andy changes to the original publishing applications.
+This example shows how to utilize routing service's features such as time
+based filters, batching, propagation of content filters, and transformations
+to limit the amount of bandwidth DDS samples require. This can be useful to
+use cases such as autonomous vehicles that require a high sample rate of data
+on the vehicle, while also utilizing a WAN link to a backend server that
+has a much more limited network link. These filters can be applied without
+any changes to the original publishing applications.
 
-This example also will walk you through out to use admin console and rtirssh 
-to control the running routing service process via the remote administration 
-interface. Existing routes can have new filters applied to them by updating 
-their routes using the 300ms.xml and 1000ms.xml files. 
+This example also will walk you through using admin console and rtirssh
+to control the running routing service process via the remote administration
+interface. Existing routes can have new filters applied to them by updating
+their routes using the 300ms.xml and 1000ms.xml files.
 
-To run routing service using this configuration, from the command line 
-execute:  
-`rtiroutingservice -cfgFile <path to xml>/localhost.xml -cfgName example`
+## Instructions
 
-Routes can be enabled and disabled via the admin console GUI or via rtirssh:  
-`disable example Route::Session::Triangle`  
-`enable example Route::Session::TriangleBatch`
+Markup : 1. Start two copies of shapesdemo, a publisher on domain 0 and a
+subscriber on domain 1.
 
-Routes can be updated via rtirssh:  
-`update example Route::Session::TriangleBatch <path to xml>\300ms.xml`
+         2. Start routing service using this configuration, from the command
+line execute:  
+`rtiroutingservice -cfgFile <path to xml>/localhost.xml -cfgName example`  
+You should now see shapes routed to your subscriber on domain 1
+
+         3. From the command line run: `rtirssh -domainId 0 -timeout 3`
+
+         4. Update the square route to include a time based filter  
+         From the rtirssh shell run:
+         `update example Route::Session::Square <path to xml>/300ms.xml`  
+         Notice how the square is now only received on domain 1 every 300ms
+
+         5. Enable batching by first disabling the triangle's route, and then
+         enabling the TriangleBatch route. This can be done by launching admin
+         console, selecting the routing service instance in the "physical view"
+         , and then right clicking on the Triangle route to disable it. Repeat
+         this process on the TriangleBatch route to enable it.
+
+        Notice how the triangle is now updating in batches of 6 samples,
+        compared to the other shapes that are updating one sample at a time.
+
+         6. Combine batching and time filters together
+
+         From the rtirssh shell run: `update example
+         Route::Session::TriangleBatch <path to xml>\300ms.xml`
+
+         Notice how the triangle is still batching 6 samples up at a time, but
+         it is also time filtering one sample every 300ms.
+
+         7. Combine multiple topics into a single topic
+
+         Within admin console, disable the TriangleBatch route, and enable the
+         TriangleToCircle route (similar to step 5).  
+         Notice how the triangle is now remapped to circles.

--- a/examples/routing_service/routing_service_constrained_wan/README.md
+++ b/examples/routing_service/routing_service_constrained_wan/README.md
@@ -6,3 +6,29 @@ These files are used to configure routing service for use in a constrained WAN
 environment. For a full description of how to use these files see the example
 located on the [RTI community website](
 https://community.rti.com/examples/Routing-Service-Constrained-WAN-Example)
+
+## Concept
+
+This example shows how to utilize routing service's features such as time 
+based filters, batching, propagation of content filters, and transformations 
+to limit the amount of bandwidth DDS samples require. This can be useful to 
+use cases such as autonomous vehicles that require a high sample rate of data 
+on the vehicle, while also utilizing a WAN link to a backend server that 
+has a much more limited network link. These filters can be applied without 
+andy changes to the original publishing applications.
+
+This example also will walk you through out to use admin console and rtirssh 
+to control the running routing service process via the remote administration 
+interface. Existing routes can have new filters applied to them by updating 
+their routes using the 300ms.xml and 1000ms.xml files. 
+
+To run routing service using this configuration, from the command line 
+execute:  
+`rtiroutingservice -cfgFile <path to xml>/localhost.xml -cfgName example`
+
+Routes can be enabled and disabled via the admin console GUI or via:  
+`disable example Route::Session::Triangle`  
+`enable example Route::Session::TriangleBatch`
+
+Routes can be updated via:  
+`update example Route::Session::TriangleBatch <path to xml>\300ms.xml`

--- a/examples/routing_service/routing_service_constrained_wan/README.md
+++ b/examples/routing_service/routing_service_constrained_wan/README.md
@@ -4,5 +4,5 @@
 
 These files are used to configure routing service for use in a constrained WAN
 environment. For a full description of how to use these files see the example
-located on the [RTI community website](https://community.rti.com/examples/
-Routing-Service-Constrained-WAN-Example)
+located on the [RTI community website]
+(https://community.rti.com/examples/Routing-Service-Constrained-WAN-Example)

--- a/examples/routing_service/routing_service_constrained_wan/README.md
+++ b/examples/routing_service/routing_service_constrained_wan/README.md
@@ -26,9 +26,9 @@ To run routing service using this configuration, from the command line
 execute:  
 `rtiroutingservice -cfgFile <path to xml>/localhost.xml -cfgName example`
 
-Routes can be enabled and disabled via the admin console GUI or via:  
+Routes can be enabled and disabled via the admin console GUI or via rtirssh:  
 `disable example Route::Session::Triangle`  
 `enable example Route::Session::TriangleBatch`
 
-Routes can be updated via:  
+Routes can be updated via rtirssh:  
 `update example Route::Session::TriangleBatch <path to xml>\300ms.xml`

--- a/examples/routing_service/routing_service_constrained_wan/README.md
+++ b/examples/routing_service/routing_service_constrained_wan/README.md
@@ -24,22 +24,22 @@ their routes using the 300ms.xml and 1000ms.xml files.
 
 ## Instructions
 
-1. Start two copies of the shapesdemo, a publisher on domain 0 and a
+1.  Start two copies of the shapesdemo, a publisher on domain 0 and a
 subscriber on domain 1.
 
-2. Start routing service using this configuration, from the command
+2.  Start routing service using this configuration, from the command
 line execute:  
 `rtiroutingservice -cfgFile <path to xml>/localhost.xml -cfgName example`  
 You should now see shapes routed to your subscriber on domain 1
 
-3. From the command line run: `rtirssh -domainId 0 -timeout 3`
+3.  From the command line run: `rtirssh -domainId 0 -timeout 3`
 
-4. Update the square route to include a time based filter  
+4.  Update the square route to include a time based filter  
 From the rtirssh shell run:
 `update example Route::Session::Square <path to xml>/300ms.xml`  
 Notice how the square is now only received on domain 1 every 300ms
 
-5. Enable batching by first disabling the triangle's route, and then
+5.  Enable batching by first disabling the triangle's route, and then
 enabling the TriangleBatch route.  
 This can be done by launching admin console, selecting the routing service
 instance in the "physical view", and then right clicking on the Triangle
@@ -48,13 +48,13 @@ Repeat this process on the TriangleBatch route to enable it.
 Notice how the triangle is now updating in batches of 6 samples,
 compared to the other shapes that are updating one sample at a time.
 
-6. Combine batching and time filters together  
+6.  Combine batching and time filters together  
 From the rtirssh shell run: `update example
 Route::Session::TriangleBatch <path to xml>\300ms.xml`  
 Notice how the triangle is still batching 6 samples up at a time, but
 it is also time filtering one sample every 300ms.
 
-7. Combine multiple topics into a single topic  
+7.  Combine multiple topics into a single topic  
 Within admin console, disable the TriangleBatch route, and enable the
 TriangleToCircle route (similar to step 5).  
 Notice how the triangle is now remapped to circles.

--- a/examples/routing_service/routing_service_constrained_wan/README.md
+++ b/examples/routing_service/routing_service_constrained_wan/README.md
@@ -24,40 +24,36 @@ their routes using the 300ms.xml and 1000ms.xml files.
 
 ## Instructions
 
-Markup : 1. Start two copies of shapesdemo, a publisher on domain 0 and a
+1. Start two copies of shapesdemo, a publisher on domain 0 and a
 subscriber on domain 1.
 
-    2. Start routing service using this configuration, from the command
+2. Start routing service using this configuration, from the command
 line execute:  
 `rtiroutingservice -cfgFile <path to xml>/localhost.xml -cfgName example`  
 You should now see shapes routed to your subscriber on domain 1
 
-    3. From the command line run: `rtirssh -domainId 0 -timeout 3`
+3. From the command line run: `rtirssh -domainId 0 -timeout 3`
 
-    4. Update the square route to include a time based filter  
-         From the rtirssh shell run:
-         `update example Route::Session::Square <path to xml>/300ms.xml`  
-         Notice how the square is now only received on domain 1 every 300ms
+4. Update the square route to include a time based filter  
+From the rtirssh shell run:
+`update example Route::Session::Square <path to xml>/300ms.xml`  
+Notice how the square is now only received on domain 1 every 300ms
 
-    5. Enable batching by first disabling the triangle's route, and then
-         enabling the TriangleBatch route. This can be done by launching admin
-         console, selecting the routing service instance in the "physical view"
-         , and then right clicking on the Triangle route to disable it. Repeat
-         this process on the TriangleBatch route to enable it.
+5. Enable batching by first disabling the triangle's route, and then
+enabling the TriangleBatch route. This can be done by launching admin
+console, selecting the routing service instance in the "physical view"
+, and then right clicking on the Triangle route to disable it. Repeat
+this process on the TriangleBatch route to enable it.  
+Notice how the triangle is now updating in batches of 6 samples,
+compared to the other shapes that are updating one sample at a time.
 
-        Notice how the triangle is now updating in batches of 6 samples,
-        compared to the other shapes that are updating one sample at a time.
+6. Combine batching and time filters together  
+From the rtirssh shell run: `update example
+Route::Session::TriangleBatch <path to xml>\300ms.xml`  
+Notice how the triangle is still batching 6 samples up at a time, but
+it is also time filtering one sample every 300ms.
 
-    6. Combine batching and time filters together
-
-         From the rtirssh shell run: `update example
-         Route::Session::TriangleBatch <path to xml>\300ms.xml`
-
-         Notice how the triangle is still batching 6 samples up at a time, but
-         it is also time filtering one sample every 300ms.
-
-    7. Combine multiple topics into a single topic
-
-         Within admin console, disable the TriangleBatch route, and enable the
-         TriangleToCircle route (similar to step 5).  
-         Notice how the triangle is now remapped to circles.
+7. Combine multiple topics into a single topic  
+Within admin console, disable the TriangleBatch route, and enable the
+TriangleToCircle route (similar to step 5).  
+Notice how the triangle is now remapped to circles.

--- a/examples/routing_service/routing_service_constrained_wan/README.md
+++ b/examples/routing_service/routing_service_constrained_wan/README.md
@@ -1,3 +1,8 @@
-These files are used to configure a constrained WAN demo that is available on RTI's community 'examples' website
+# Example: Routing Service Constrained WAN
 
-https://community.rti.com/examples
+## Description
+
+These files are used to configure routing service for use in a constrained WAN
+environment. For a full description of how to use these files see the example
+located on the [RTI community website](https://community.rti.com/examples/
+Routing-Service-Constrained-WAN-Example)

--- a/examples/routing_service/routing_service_constrained_wan/README.md
+++ b/examples/routing_service/routing_service_constrained_wan/README.md
@@ -27,19 +27,19 @@ their routes using the 300ms.xml and 1000ms.xml files.
 Markup : 1. Start two copies of shapesdemo, a publisher on domain 0 and a
 subscriber on domain 1.
 
-         2. Start routing service using this configuration, from the command
+    2. Start routing service using this configuration, from the command
 line execute:  
 `rtiroutingservice -cfgFile <path to xml>/localhost.xml -cfgName example`  
 You should now see shapes routed to your subscriber on domain 1
 
-         3. From the command line run: `rtirssh -domainId 0 -timeout 3`
+    3. From the command line run: `rtirssh -domainId 0 -timeout 3`
 
-         4. Update the square route to include a time based filter  
+    4. Update the square route to include a time based filter  
          From the rtirssh shell run:
          `update example Route::Session::Square <path to xml>/300ms.xml`  
          Notice how the square is now only received on domain 1 every 300ms
 
-         5. Enable batching by first disabling the triangle's route, and then
+    5. Enable batching by first disabling the triangle's route, and then
          enabling the TriangleBatch route. This can be done by launching admin
          console, selecting the routing service instance in the "physical view"
          , and then right clicking on the Triangle route to disable it. Repeat
@@ -48,7 +48,7 @@ You should now see shapes routed to your subscriber on domain 1
         Notice how the triangle is now updating in batches of 6 samples,
         compared to the other shapes that are updating one sample at a time.
 
-         6. Combine batching and time filters together
+    6. Combine batching and time filters together
 
          From the rtirssh shell run: `update example
          Route::Session::TriangleBatch <path to xml>\300ms.xml`
@@ -56,7 +56,7 @@ You should now see shapes routed to your subscriber on domain 1
          Notice how the triangle is still batching 6 samples up at a time, but
          it is also time filtering one sample every 300ms.
 
-         7. Combine multiple topics into a single topic
+    7. Combine multiple topics into a single topic
 
          Within admin console, disable the TriangleBatch route, and enable the
          TriangleToCircle route (similar to step 5).  

--- a/examples/routing_service/routing_service_constrained_wan/README.md
+++ b/examples/routing_service/routing_service_constrained_wan/README.md
@@ -40,10 +40,11 @@ From the rtirssh shell run:
 Notice how the square is now only received on domain 1 every 300ms
 
 5. Enable batching by first disabling the triangle's route, and then
-enabling the TriangleBatch route. This can be done by launching admin
-console, selecting the routing service instance in the "physical view"
-, and then right clicking on the Triangle route to disable it. Repeat
-this process on the TriangleBatch route to enable it.  
+enabling the TriangleBatch route.  
+This can be done by launching admin console, selecting the routing service
+instance in the "physical view", and then right clicking on the Triangle
+route to disable it.  
+Repeat this process on the TriangleBatch route to enable it.  
 Notice how the triangle is now updating in batches of 6 samples,
 compared to the other shapes that are updating one sample at a time.
 

--- a/examples/routing_service/routing_service_constrained_wan/localhostdemo/0ms.xml
+++ b/examples/routing_service/routing_service_constrained_wan/localhostdemo/0ms.xml
@@ -1,3 +1,13 @@
+<!--
+ (c) 2005-2020 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+ RTI grants Licensee a license to use, modify, compile, and create derivative
+ works of the Software.  Licensee has the right to distribute object form only
+ for use with RTI products.  The Software is provided "as is", with no warranty
+ of any type, including any warranty for fitness for any purpose. RTI is under
+ no obligation to maintain or support the Software.  RTI shall not be liable for
+ any incidental or consequential damages arising out of the use or inability to
+ use the software.
+ -->
 <auto_topic_route>
     <input>
         <datareader_qos>

--- a/examples/routing_service/routing_service_constrained_wan/localhostdemo/0ms.xml
+++ b/examples/routing_service/routing_service_constrained_wan/localhostdemo/0ms.xml
@@ -1,0 +1,12 @@
+<auto_topic_route>
+    <input>
+        <datareader_qos>
+            <time_based_filter>
+                <minimum_separation>
+                    <sec>0</sec>
+                    <nanosec>0</nanosec>
+                </minimum_separation>
+            </time_based_filter>
+        </datareader_qos>
+    </input>
+</auto_topic_route>

--- a/examples/routing_service/routing_service_constrained_wan/localhostdemo/1000ms.xml
+++ b/examples/routing_service/routing_service_constrained_wan/localhostdemo/1000ms.xml
@@ -1,0 +1,12 @@
+<auto_topic_route>
+    <input>
+        <datareader_qos>
+            <time_based_filter>
+                <minimum_separation>
+                    <sec>0</sec>
+                    <nanosec>1000000000</nanosec>
+                </minimum_separation>
+            </time_based_filter>
+        </datareader_qos>
+    </input>
+</auto_topic_route>

--- a/examples/routing_service/routing_service_constrained_wan/localhostdemo/1000ms.xml
+++ b/examples/routing_service/routing_service_constrained_wan/localhostdemo/1000ms.xml
@@ -1,3 +1,13 @@
+<!--
+ (c) 2005-2020 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+ RTI grants Licensee a license to use, modify, compile, and create derivative
+ works of the Software.  Licensee has the right to distribute object form only
+ for use with RTI products.  The Software is provided "as is", with no warranty
+ of any type, including any warranty for fitness for any purpose. RTI is under
+ no obligation to maintain or support the Software.  RTI shall not be liable for
+ any incidental or consequential damages arising out of the use or inability to
+ use the software.
+ -->
 <auto_topic_route>
     <input>
         <datareader_qos>

--- a/examples/routing_service/routing_service_constrained_wan/localhostdemo/300ms.xml
+++ b/examples/routing_service/routing_service_constrained_wan/localhostdemo/300ms.xml
@@ -1,3 +1,13 @@
+<!--
+ (c) 2005-2020 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+ RTI grants Licensee a license to use, modify, compile, and create derivative
+ works of the Software.  Licensee has the right to distribute object form only
+ for use with RTI products.  The Software is provided "as is", with no warranty
+ of any type, including any warranty for fitness for any purpose. RTI is under
+ no obligation to maintain or support the Software.  RTI shall not be liable for
+ any incidental or consequential damages arising out of the use or inability to
+ use the software.
+ -->
 <auto_topic_route>
     <input>
         <datareader_qos>

--- a/examples/routing_service/routing_service_constrained_wan/localhostdemo/300ms.xml
+++ b/examples/routing_service/routing_service_constrained_wan/localhostdemo/300ms.xml
@@ -1,0 +1,12 @@
+<auto_topic_route>
+    <input>
+        <datareader_qos>
+            <time_based_filter>
+                <minimum_separation>
+                    <sec>0</sec>
+                    <nanosec>300000000</nanosec>
+                </minimum_separation>
+            </time_based_filter>
+        </datareader_qos>
+    </input>
+</auto_topic_route>

--- a/examples/routing_service/routing_service_constrained_wan/localhostdemo/localhost.xml
+++ b/examples/routing_service/routing_service_constrained_wan/localhostdemo/localhost.xml
@@ -10,7 +10,7 @@
  use the software.
  -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-     xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/6.0.1/6.0.0/rti_routing_service.xsd">
+     xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/6.0.1/rti_routing_service.xsd">
     <routing_service name="example">
         <annotation><documentation>Routing Service Example</documentation></annotation>
         <administration><domain_id>0</domain_id></administration>

--- a/examples/routing_service/routing_service_constrained_wan/localhostdemo/localhost.xml
+++ b/examples/routing_service/routing_service_constrained_wan/localhostdemo/localhost.xml
@@ -1,0 +1,207 @@
+<?xml version="1.0"?>
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+     xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/6.0.1/6.0.0/rti_routing_service.xsd">
+    <routing_service name="example">
+        <annotation><documentation>Routing Service Example</documentation></annotation>
+        <administration><domain_id>0</domain_id></administration>
+
+        <domain_route name="Route" enabled="true">
+            <participant name="participant0"><domain_id>0</domain_id></participant>
+            <participant name="participant1"><domain_id>1</domain_id></participant>
+
+            <session name="Session" enabled="true">
+    <!-- Three topic routes are auto-enabled, to pass squares, circles, and triangles from domain 0 to domain 1 -->
+                <auto_topic_route name="Square" enabled="true">
+                    <input participant="participant0">
+                        <allow_topic_name_filter>Square</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                    </input>
+                    <output participant="participant1">
+                        <allow_topic_name_filter>Square</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                    </output>
+                </auto_topic_route>
+
+                <auto_topic_route name="Circle" enabled="true">
+                    <filter_propagation>
+                        <enabled>true</enabled>
+                        <max_event_delay><sec>1</sec><nanosec>0</nanosec></max_event_delay>
+                    </filter_propagation>
+                    <input participant="participant0">
+                        <allow_topic_name_filter>Circle</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                    </input>
+                    <output participant="participant1">
+                        <allow_topic_name_filter>Circle</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                    </output>
+                </auto_topic_route>
+
+                <auto_topic_route name="Triangle" enabled="true">
+                    <filter_propagation>
+                        <enabled>true</enabled>
+                        <max_event_delay><sec>1</sec><nanosec>0</nanosec></max_event_delay>
+                    </filter_propagation>
+                    <input participant="participant0">
+                        <allow_topic_name_filter>Triangle</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                    </input>
+                    <output participant="participant1">
+                        <allow_topic_name_filter>Triangle</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                    </output>
+                </auto_topic_route>
+
+<!--Batching routes for squares, triangles, and circles, disabled by default 
+    Batching cannot be loaded dynamically via "update" calls, instead this route must be enabled-->
+                <auto_topic_route name="SquareBatch" enabled="false">
+                    <input participant="participant0">
+                        <allow_topic_name_filter>Square</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                    </input>
+                    <output participant="participant1">
+                        <allow_topic_name_filter>Square</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                        <datawriter_qos>
+                            <batch>
+                                <enable>true</enable>
+                                <max_samples>6</max_samples>
+                                <max_flush_delay>
+                                    <sec>2</sec>
+                                    <nanosec>0</nanosec>
+                                </max_flush_delay>
+                            </batch>
+                            <history>
+                                <kind>KEEP_LAST_HISTORY_QOS</kind>
+                                <depth>12</depth>
+                            </history>
+                        </datawriter_qos>
+                    </output>
+                </auto_topic_route>
+
+                <auto_topic_route name="TriangleBatch" enabled="false">
+                    <input participant="participant0">
+                        <allow_topic_name_filter>Triangle</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                    </input>
+                    <output participant="participant1">
+                        <allow_topic_name_filter>Triangle</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                        <datawriter_qos>
+                            <batch>
+                                <enable>true</enable>
+                                <max_samples>6</max_samples>
+                                <max_flush_delay>
+                                    <sec>2</sec>
+                                    <nanosec>0</nanosec>
+                                </max_flush_delay>
+                            </batch>
+                            <history>
+                                <kind>KEEP_LAST_HISTORY_QOS</kind>
+                                <depth>12</depth>
+                            </history>
+                        </datawriter_qos>
+                    </output>
+                </auto_topic_route>
+
+                <auto_topic_route name="CircleBatch" enabled="false">
+                    <input participant="participant0">
+                        <allow_topic_name_filter>Circle</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                    </input>
+                    <output participant="participant1">
+                        <allow_topic_name_filter>Circle</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                        <datawriter_qos>
+                            <batch>
+                                <enable>true</enable>
+                                <max_samples>6</max_samples>
+                                <max_flush_delay>
+                                    <sec>2</sec>
+                                    <nanosec>0</nanosec>
+                                </max_flush_delay>
+                            </batch>
+                            <history>
+                                <kind>KEEP_LAST_HISTORY_QOS</kind>
+                                <depth>12</depth>
+                            </history>
+                        </datawriter_qos>
+                    </output>
+                </auto_topic_route>
+
+<!--Adapt Square and Triangle topics to Circle topics, 
+    they could be split back apart on a remote RS if color could be used to designate original shape for example -->
+                <topic_route name="SquareToCircle" enabled="false">
+                    <input participant="participant0">
+                        <registered_type_name>ShapeType</registered_type_name>
+                        <topic_name>Square</topic_name>
+                    </input>
+                    <output participant="participant1">
+                        <registered_type_name>ShapeType</registered_type_name>
+                        <topic_name>Circle</topic_name>
+                    </output>
+                </topic_route>
+                <topic_route name="TriangleToCircle" enabled="false">
+                    <input participant="participant0">
+                        <registered_type_name>ShapeType</registered_type_name>
+                        <topic_name>Triangle</topic_name>
+                    </input>
+                    <output participant="participant1">
+                        <registered_type_name>ShapeType</registered_type_name>
+                        <topic_name>Circle</topic_name>
+                    </output>
+                </topic_route>
+
+                <!-- Routes for each shape that include a filter on the x value. Values < 150 are not filtered -->
+                <auto_topic_route name="SquareFilter" enabled="false">
+                    <publish_with_original_info>true</publish_with_original_info> 
+                    <input participant="participant0">
+                        <allow_topic_name_filter>Square</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                        <content_filter>
+                            <expression>x &lt; %0</expression>
+                            <parameter>150</parameter>
+                        </content_filter>
+                    </input>
+                    <output participant="participant1">
+                        <allow_topic_name_filter>Square</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                    </output>
+                </auto_topic_route>
+
+                <auto_topic_route name="CircleFilter" enabled="false">
+                    <publish_with_original_info>true</publish_with_original_info> 
+                    <input participant="participant0">
+                        <allow_topic_name_filter>Circle</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                        <content_filter>
+                            <expression>x &lt; %0</expression>
+                            <parameter>150</parameter>
+                        </content_filter>
+                    </input>
+                    <output participant="participant1">
+                        <allow_topic_name_filter>Circle</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                    </output>
+                </auto_topic_route>
+                
+                <auto_topic_route name="TriangleFilter" enabled="false">
+                    <publish_with_original_info>true</publish_with_original_info> 
+                    <input participant="participant0">
+                        <allow_topic_name_filter>Triangle</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                        <content_filter>
+                            <expression>x &lt; %0</expression>
+                            <parameter>150</parameter>
+                        </content_filter>
+                    </input>
+                    <output participant="participant1">
+                        <allow_topic_name_filter>Triangle</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                    </output>
+                </auto_topic_route>
+
+            </session>
+        </domain_route>
+    </routing_service>
+</dds>

--- a/examples/routing_service/routing_service_constrained_wan/localhostdemo/localhost.xml
+++ b/examples/routing_service/routing_service_constrained_wan/localhostdemo/localhost.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0"?>
+<!--
+ (c) 2005-2020 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+ RTI grants Licensee a license to use, modify, compile, and create derivative
+ works of the Software.  Licensee has the right to distribute object form only
+ for use with RTI products.  The Software is provided "as is", with no warranty
+ of any type, including any warranty for fitness for any purpose. RTI is under
+ no obligation to maintain or support the Software.  RTI shall not be liable for
+ any incidental or consequential damages arising out of the use or inability to
+ use the software.
+ -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
      xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/6.0.1/6.0.0/rti_routing_service.xsd">
     <routing_service name="example">

--- a/examples/routing_service/routing_service_constrained_wan/wandemo/0ms.xml
+++ b/examples/routing_service/routing_service_constrained_wan/wandemo/0ms.xml
@@ -1,4 +1,14 @@
-<auto_topic_route>
+<!--
+ (c) 2005-2020 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+ RTI grants Licensee a license to use, modify, compile, and create derivative
+ works of the Software.  Licensee has the right to distribute object form only
+ for use with RTI products.  The Software is provided "as is", with no warranty
+ of any type, including any warranty for fitness for any purpose. RTI is under
+ no obligation to maintain or support the Software.  RTI shall not be liable for
+ any incidental or consequential damages arising out of the use or inability to
+ use the software.
+ -->
+ <auto_topic_route>
     <input>
         <datareader_qos>
             <time_based_filter>

--- a/examples/routing_service/routing_service_constrained_wan/wandemo/0ms.xml
+++ b/examples/routing_service/routing_service_constrained_wan/wandemo/0ms.xml
@@ -1,0 +1,12 @@
+<auto_topic_route>
+    <input>
+        <datareader_qos>
+            <time_based_filter>
+                <minimum_separation>
+                    <sec>0</sec>
+                    <nanosec>0</nanosec>
+                </minimum_separation>
+            </time_based_filter>
+        </datareader_qos>
+    </input>
+</auto_topic_route>

--- a/examples/routing_service/routing_service_constrained_wan/wandemo/1000ms.xml
+++ b/examples/routing_service/routing_service_constrained_wan/wandemo/1000ms.xml
@@ -1,0 +1,12 @@
+<auto_topic_route>
+    <input>
+        <datareader_qos>
+            <time_based_filter>
+                <minimum_separation>
+                    <sec>0</sec>
+                    <nanosec>1000000000</nanosec>
+                </minimum_separation>
+            </time_based_filter>
+        </datareader_qos>
+    </input>
+</auto_topic_route>

--- a/examples/routing_service/routing_service_constrained_wan/wandemo/1000ms.xml
+++ b/examples/routing_service/routing_service_constrained_wan/wandemo/1000ms.xml
@@ -1,3 +1,13 @@
+<!--
+ (c) 2005-2020 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+ RTI grants Licensee a license to use, modify, compile, and create derivative
+ works of the Software.  Licensee has the right to distribute object form only
+ for use with RTI products.  The Software is provided "as is", with no warranty
+ of any type, including any warranty for fitness for any purpose. RTI is under
+ no obligation to maintain or support the Software.  RTI shall not be liable for
+ any incidental or consequential damages arising out of the use or inability to
+ use the software.
+ -->
 <auto_topic_route>
     <input>
         <datareader_qos>

--- a/examples/routing_service/routing_service_constrained_wan/wandemo/300ms.xml
+++ b/examples/routing_service/routing_service_constrained_wan/wandemo/300ms.xml
@@ -1,4 +1,14 @@
-<auto_topic_route>
+<!--
+ (c) 2005-2020 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+ RTI grants Licensee a license to use, modify, compile, and create derivative
+ works of the Software.  Licensee has the right to distribute object form only
+ for use with RTI products.  The Software is provided "as is", with no warranty
+ of any type, including any warranty for fitness for any purpose. RTI is under
+ no obligation to maintain or support the Software.  RTI shall not be liable for
+ any incidental or consequential damages arising out of the use or inability to
+ use the software.
+ -->
+ <auto_topic_route>
     <input>
         <datareader_qos>
             <time_based_filter>

--- a/examples/routing_service/routing_service_constrained_wan/wandemo/300ms.xml
+++ b/examples/routing_service/routing_service_constrained_wan/wandemo/300ms.xml
@@ -1,0 +1,12 @@
+<auto_topic_route>
+    <input>
+        <datareader_qos>
+            <time_based_filter>
+                <minimum_separation>
+                    <sec>0</sec>
+                    <nanosec>300000000</nanosec>
+                </minimum_separation>
+            </time_based_filter>
+        </datareader_qos>
+    </input>
+</auto_topic_route>

--- a/examples/routing_service/routing_service_constrained_wan/wandemo/local.tcp.transport.xml
+++ b/examples/routing_service/routing_service_constrained_wan/wandemo/local.tcp.transport.xml
@@ -1,0 +1,248 @@
+<?xml version="1.0"?>
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+     xsi:noNamespaceSchemaLocation="https://community.rti.com/schema/6.0.0/rti_routing_service.xsd">
+    <!-- ********************************************************************** -->
+    <!-- RTI Routing service examples for TCP over WAN                          -->
+    <!-- Note: Change the IPs and ports below to fit yours                      -->
+    <!-- ********************************************************************** -->
+    <!-- UDP/Shared memory (domain 0) => TCP (domain 1)                         -->
+    <!-- ********************************************************************** -->
+    <routing_service name="example">
+
+        <annotation><documentation>In a WAN, routes from UDP or shared memory to TCP. Remember to edit the file and change the public IP address.</documentation></annotation>
+        <administration><domain_id>0</domain_id></administration>
+
+        <domain_route name="Route">
+            <participant name="participant0">
+                <domain_id>0</domain_id>
+            </participant>
+
+            <participant name="participant1">
+                <domain_id>1</domain_id>
+                <participant_qos>
+                    <discovery>
+                        <initial_peers>
+                            <element>tcpv4_wan://50.18.214.8:7400</element>
+                        </initial_peers>
+                    </discovery>
+                    <discovery_config>
+                        <participant_liveliness_assert_period>
+                            <sec>10</sec>
+                            <nanosec>0</nanosec>
+                        </participant_liveliness_assert_period>
+                    </discovery_config>
+                    <transport_builtin>
+                        <mask>MASK_NONE</mask>
+                    </transport_builtin>
+                    <property>
+                        <value>
+                            <element>
+                                <name>dds.transport.load_plugins</name>
+                                <value>dds.transport.TCPv4.tcp1</value>
+                            </element>
+                            <element>
+                                <name>dds.transport.TCPv4.tcp1.library</name>
+                                <value>nddstransporttcp</value>
+                            </element>
+                            <element>
+                                <name>dds.transport.TCPv4.tcp1.create_function</name>
+                                <value>NDDS_Transport_TCPv4_create</value>
+                            </element>
+                            <element>
+                                <name>dds.transport.TCPv4.tcp1.parent.classid</name>
+                                <value>NDDS_TRANSPORT_CLASSID_TCPV4_WAN</value>
+                            </element>
+                            <element>
+                                <name>dds.transport.TCPv4.tcp1.connection_liveliness.enable</name>
+                                <value>1</value>
+                            </element>
+                            <element>
+                                <name>dds.transport.TCPv4.tcp1.connection_liveliness.lease_duration</name>
+                                <value>10</value>
+                            </element>
+                            <element>
+                                <name>dds.transport.TCPv4.tcp1.connection_liveliness.assertions_per_lease_duration</name>
+                                <value>4</value>
+                            </element>
+                            <!--
+                            <element>
+                                <name>dds.transport.TCPv4.tcp1.public_address</name>
+                                <value>x.x.x.x:7400</value>
+                            </element>
+                            -->
+                            <element>
+                                <name>dds.transport.TCPv4.tcp1.server_bind_port</name>
+                                <value>0</value> <!-- changed to zero since we're not supporting inbound connections -->
+                            </element>
+                            <element>
+                                <name>dds.transport.TCPv4.tcp1.disable_nagle</name>
+                                <value>1</value>
+                            </element>
+                        </value>
+                    </property>
+                </participant_qos>
+            </participant>
+
+            <session name="Session" enabled="true">
+                <auto_topic_route name="Square" enabled="true">
+                    <publish_with_original_info>true</publish_with_original_info> 
+                    <input participant="participant0">
+                        <allow_topic_name_filter>Square</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                        <datareader_qos>
+                            <time_based_filter>
+                                <minimum_separation>
+                                    <sec>0</sec>
+                                    <nanosec>300000000</nanosec>
+                                </minimum_separation>
+                            </time_based_filter>
+                        </datareader_qos>
+                    </input>
+                    <output participant="participant1">
+                        <allow_topic_name_filter>Square</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                    </output>
+                </auto_topic_route>
+
+                <auto_topic_route name="Circle" enabled="true">
+                    <publish_with_original_info>true</publish_with_original_info> 
+                    <input participant="participant0">
+                        <allow_topic_name_filter>Circle</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                    </input>
+                    <output participant="participant1">
+                        <allow_topic_name_filter>Circle</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                        <!--<datawriter_qos>
+                            <writer_data_lifecycle>
+                                <autodispose_unregistered_instances>
+                                    false
+                                </autodispose_unregistered_instances>
+                            </writer_data_lifecycle>
+                        </datawriter_qos>
+                    -->
+                    </output>
+                </auto_topic_route>
+
+                <auto_topic_route name="Triangle" enabled="true">
+                    <publish_with_original_info>true</publish_with_original_info> 
+                    <input participant="participant0">
+                        <allow_topic_name_filter>Triangle</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                        <datareader_qos>
+                            <time_based_filter>
+                                <minimum_separation>
+                                    <sec>0</sec>
+                                    <nanosec>1000000000</nanosec>
+                                </minimum_separation>
+                            </time_based_filter>
+                        </datareader_qos>
+                    </input>
+                    <output participant="participant1">
+                        <allow_topic_name_filter>Triangle</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                    </output>
+                </auto_topic_route>
+                <!-- Not needed since we break out each topic into their own auto routes
+                     and batching doesn't show history using the WIS js display, so batching isn't useful to demo
+                <auto_topic_route name="AllForward" enabled="false">                    
+                    <publish_with_original_info>true</publish_with_original_info>                   
+                    <input participant="1">
+                        <deny_topic_name_filter>rti/*</deny_topic_name_filter>
+                        <creation_mode>ON_DOMAIN_MATCH</creation_mode>
+                    </input>
+                    <output>
+                        <deny_topic_name_filter>rti/*</deny_topic_name_filter>
+                        <creation_mode>ON_DOMAIN_OR_ROUTE_MATCH</creation_mode>
+                    </output>
+                </auto_topic_route> -->
+
+                <!-- Content filtered topics, samples are filtered if x > 150 -->
+                <auto_topic_route name="SquareFilter" enabled="false">
+                    <publish_with_original_info>true</publish_with_original_info> 
+                    <input participant="participant0">
+                        <allow_topic_name_filter>Square</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                        <content_filter>
+                            <expression>x &lt; %0</expression>
+                            <parameter>150</parameter>
+                        </content_filter>
+                    </input>
+                    <output participant="participant1">
+                        <allow_topic_name_filter>Square</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                    </output>
+                </auto_topic_route>
+
+                <auto_topic_route name="CircleFilter" enabled="false">
+                    <publish_with_original_info>true</publish_with_original_info> 
+                    <input participant="participant0">
+                        <allow_topic_name_filter>Circle</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                        <content_filter>
+                            <expression>x &lt; %0</expression>
+                            <parameter>150</parameter>
+                        </content_filter>
+                    </input>
+                    <output participant="participant1">
+                        <allow_topic_name_filter>Circle</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                    </output>
+                </auto_topic_route>
+
+                <auto_topic_route name="TriangleFilter" enabled="false">
+                    <publish_with_original_info>true</publish_with_original_info> 
+                    <input participant="participant0">
+                        <allow_topic_name_filter>Triangle</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                        <content_filter>
+                            <expression>x &lt; %0</expression>
+                            <parameter>150</parameter>
+                        </content_filter>
+                    </input>
+                    <output participant="participant1">
+                        <allow_topic_name_filter>Triangle</allow_topic_name_filter>
+                        <allow_registered_type_name_filter>ShapeType</allow_registered_type_name_filter>
+                    </output>
+                </auto_topic_route>
+
+            <!--Adapt Square and Triangle topics to Circle topics, 
+                they could be split back apart on a remote RS if color could be used to designate original shape for example -->
+                <topic_route name="SquareToCircle" enabled="false">
+                    <input participant="participant0">
+                        <registered_type_name>ShapeType</registered_type_name>
+                        <topic_name>Square</topic_name>
+                    </input>
+                    <output participant="participant1">
+                        <registered_type_name>ShapeType</registered_type_name>
+                        <topic_name>Circle</topic_name>
+                    </output>
+                </topic_route>
+
+                <topic_route name="TriangleToCircle" enabled="false">
+                    <input participant="participant0">
+                        <registered_type_name>ShapeType</registered_type_name>
+                        <topic_name>Triangle</topic_name>
+                    </input>
+                    <output participant="participant1">
+                        <registered_type_name>ShapeType</registered_type_name>
+                        <topic_name>Circle</topic_name>
+                    </output>
+                </topic_route>
+
+                <auto_topic_route name="AllBackward" enabled="true">
+                    <publish_with_original_info>true</publish_with_original_info>                    
+                    <input participant="participant1">
+                        <deny_topic_name_filter>rti/*</deny_topic_name_filter>
+                        <creation_mode>ON_DOMAIN_OR_ROUTE_MATCH</creation_mode>
+                    </input>
+                    <output participant="participant0">
+                        <deny_topic_name_filter>rti/*</deny_topic_name_filter>
+                        <creation_mode>ON_DOMAIN_MATCH</creation_mode>
+                    </output>
+                </auto_topic_route>
+                
+            </session>
+        </domain_route>
+    </routing_service>
+</dds>

--- a/examples/routing_service/routing_service_constrained_wan/wandemo/local.tcp.transport.xml
+++ b/examples/routing_service/routing_service_constrained_wan/wandemo/local.tcp.transport.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0"?>
+<!--
+ (c) 2005-2020 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+ RTI grants Licensee a license to use, modify, compile, and create derivative
+ works of the Software.  Licensee has the right to distribute object form only
+ for use with RTI products.  The Software is provided "as is", with no warranty
+ of any type, including any warranty for fitness for any purpose. RTI is under
+ no obligation to maintain or support the Software.  RTI shall not be liable for
+ any incidental or consequential damages arising out of the use or inability to
+ use the software.
+ -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
      xsi:noNamespaceSchemaLocation="https://community.rti.com/schema/6.0.0/rti_routing_service.xsd">
     <!-- ********************************************************************** -->

--- a/examples/routing_service/routing_service_constrained_wan/wandemo/local.tcp.transport.xml
+++ b/examples/routing_service/routing_service_constrained_wan/wandemo/local.tcp.transport.xml
@@ -10,7 +10,7 @@
  use the software.
  -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-     xsi:noNamespaceSchemaLocation="https://community.rti.com/schema/6.0.0/rti_routing_service.xsd">
+     xsi:noNamespaceSchemaLocation="https://community.rti.com/schema/6.0.1/rti_routing_service.xsd">
     <!-- ********************************************************************** -->
     <!-- RTI Routing service examples for TCP over WAN                          -->
     <!-- Note: Change the IPs and ports below to fit yours                      -->

--- a/examples/routing_service/routing_service_constrained_wan/wandemo/server.tcp.transport.xml
+++ b/examples/routing_service/routing_service_constrained_wan/wandemo/server.tcp.transport.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0"?>
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+     xsi:noNamespaceSchemaLocation="https://community.rti.com/schema/6.0.0/rti_routing_service.xsd">
+    <!-- RTI Routing service examples for TCP over WAN                          -->
+    <!-- Note: Change the IPs and ports below to fit yours                      -->
+    <!-- ********************************************************************** -->
+    <!-- TCP (domain 1) => UDP/Shared memory (domain 2)                         -->
+    <!-- ********************************************************************** -->
+    <routing_service name="TCP_2">
+        <annotation><documentation>In a WAN, routes from TCP to UDP or shared memory. Remember to edit the file and change the public IP address.</documentation></annotation>
+        <domain_route name="DR_TCPWAN_UPDLAN">
+            <participant name="1">
+                <domain_id>1</domain_id>
+                <participant_qos>
+                    <transport_builtin>
+                        <mask>MASK_NONE</mask>
+                    </transport_builtin>
+                    <property>
+                        <value>
+                            <element>
+                                <name>dds.transport.load_plugins</name>
+                                <value>dds.transport.TCPv4.tcp1</value>
+                            </element>
+                            <element>
+                                <name>dds.transport.TCPv4.tcp1.library</name>
+                                <value>nddstransporttcp</value>
+                            </element>
+                            <element>
+                                <name>dds.transport.TCPv4.tcp1.create_function</name>
+                                <value>NDDS_Transport_TCPv4_create</value>
+                            </element>
+                            <element>
+                                <name>dds.transport.TCPv4.tcp1.parent.classid</name>
+                                <value>NDDS_TRANSPORT_CLASSID_TCPV4_WAN</value>
+                            </element>
+                            <!--
+                                OPTIONAL ASYMMETRIC CONFIGURATION:
+                                You can use asymmetric communication across NAT and in that case you don't need a public IP address or
+                                forwarding a port for one of the routing services (for example this one, TCP_2). In that case you can remove
+                                this property, set server_bind_port to 0 and configure the initial peers only on this host, using the
+                                public IP and port of TCP_1.                                                                
+                                See the chapter about the TCP Transport in the RTI DDS User's Manual for more information.
+                            -->
+                            <element>
+                                <name>dds.transport.TCPv4.tcp1.public_address</name>
+                                <value>50.18.214.8:7400</value>
+                            </element>
+                            <element>
+                                <name>dds.transport.TCPv4.tcp1.server_bind_port</name>
+                                <value>7400</value>
+                            </element>
+                            <element>
+                                <name>dds.transport.TCPv4.tcp1.disable_nagle</name>
+                                <value>1</value>
+                            </element>
+                        </value>
+                    </property>
+                </participant_qos>
+            </participant>
+
+            <participant name="2">
+                <domain_id>2</domain_id>
+            </participant>
+
+            <session name="Session" enabled="true">
+                <auto_topic_route name="AllForward" enabled="true">
+                    <publish_with_original_info>true</publish_with_original_info>                    
+                    <input participant="1">
+                        <creation_mode>ON_DOMAIN_AND_ROUTE_MATCH</creation_mode>
+                        <deny_topic_name_filter>rti/*</deny_topic_name_filter>
+                    </input>
+                    <output>
+                        <creation_mode>ON_DOMAIN_MATCH</creation_mode>
+                        <deny_topic_name_filter>rti/*</deny_topic_name_filter>
+                    </output>
+                </auto_topic_route>
+
+                <auto_topic_route name="AllBackward" enabled="true">
+                    <publish_with_original_info>true</publish_with_original_info>
+                    <input participant="2">
+                        <creation_mode>ON_DOMAIN_MATCH</creation_mode>
+                        <deny_topic_name_filter>rti/*</deny_topic_name_filter>
+                    </input>
+                    <output>
+                        <creation_mode>ON_DOMAIN_AND_ROUTE_MATCH</creation_mode>
+                        <deny_topic_name_filter>rti/*</deny_topic_name_filter>
+                    </output>
+                </auto_topic_route>
+            </session>
+        </domain_route>
+    </routing_service>
+</dds>

--- a/examples/routing_service/routing_service_constrained_wan/wandemo/server.tcp.transport.xml
+++ b/examples/routing_service/routing_service_constrained_wan/wandemo/server.tcp.transport.xml
@@ -10,14 +10,16 @@
  use the software.
  -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-     xsi:noNamespaceSchemaLocation="https://community.rti.com/schema/6.0.0/rti_routing_service.xsd">
+     xsi:noNamespaceSchemaLocation="https://community.rti.com/schema/6.0.1/rti_routing_service.xsd">
     <!-- RTI Routing service examples for TCP over WAN                          -->
     <!-- Note: Change the IPs and ports below to fit yours                      -->
     <!-- ********************************************************************** -->
     <!-- TCP (domain 1) => UDP/Shared memory (domain 2)                         -->
     <!-- ********************************************************************** -->
     <routing_service name="TCP_2">
-        <annotation><documentation>In a WAN, routes from TCP to UDP or shared memory. Remember to edit the file and change the public IP address.</documentation></annotation>
+        <annotation>
+            <documentation>On WAN server, routes TCP to UDP or shared memory. Remember to change the public IP address.</documentation>
+        </annotation>
         <domain_route name="DR_TCPWAN_UPDLAN">
             <participant name="1">
                 <domain_id>1</domain_id>

--- a/examples/routing_service/routing_service_constrained_wan/wandemo/server.tcp.transport.xml
+++ b/examples/routing_service/routing_service_constrained_wan/wandemo/server.tcp.transport.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0"?>
+<!--
+ (c) 2005-2020 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+ RTI grants Licensee a license to use, modify, compile, and create derivative
+ works of the Software.  Licensee has the right to distribute object form only
+ for use with RTI products.  The Software is provided "as is", with no warranty
+ of any type, including any warranty for fitness for any purpose. RTI is under
+ no obligation to maintain or support the Software.  RTI shall not be liable for
+ any incidental or consequential damages arising out of the use or inability to
+ use the software.
+ -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
      xsi:noNamespaceSchemaLocation="https://community.rti.com/schema/6.0.0/rti_routing_service.xsd">
     <!-- RTI Routing service examples for TCP over WAN                          -->

--- a/examples/routing_service/routing_service_constrained_wan/wandemo/simple_shapes_demo.xml
+++ b/examples/routing_service/routing_service_constrained_wan/wandemo/simple_shapes_demo.xml
@@ -10,7 +10,7 @@
  use the software.
  -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/6.0.0/latest/rti_web_integration_service.xsd">
+    xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/6.0.1/latest/rti_web_integration_service.xsd">
 
     <qos_library name="SimpleShapesDemoQoSLib">
         <qos_profile name="SimpleShapesDemoQosProfile" is_default_qos="true">

--- a/examples/routing_service/routing_service_constrained_wan/wandemo/simple_shapes_demo.xml
+++ b/examples/routing_service/routing_service_constrained_wan/wandemo/simple_shapes_demo.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<!--
+    (c) 2016 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+    RTI grants Licensee a license to use, modify, compile, and create derivative
+    works of the Software.  Licensee has the right to distribute object form only
+    for use with RTI products.  The Software is provided "as is", with no warranty
+    of any type, including any warranty for fitness for any purpose. RTI is under
+    no obligation to maintain or support the Software.  RTI shall not be liable for
+    any incidental or consequential damages arising out of the use or inability to
+    use the software.
+-->
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/6.0.0/latest/rti_web_integration_service.xsd">
+
+    <qos_library name="SimpleShapesDemoQoSLib">
+        <qos_profile name="SimpleShapesDemoQosProfile" is_default_qos="true">
+            <datareader_qos>
+                <reliability>
+                    <kind>RELIABLE_RELIABILITY_QOS</kind>
+                </reliability>
+                <history>
+                    <depth>6</depth>
+                    <kind>KEEP_LAST_HISTORY_QOS</kind>
+                </history>
+            </datareader_qos>
+        </qos_profile>
+    </qos_library>
+
+    <!--
+        This configuration contains a complete scenario for interacting with RTI
+        Shapes Demo. That is, it creates all the necessary Topics, DataWriters,
+        and DataReaders to publish and subscribe to Squares, Circles, and
+        Triangles. The data types and domains in "MyParticipant" refer to the
+        ones defined in resource/xml/RTI_WEB_INTEGRATION_SERVICE.xml.
+        Note that this file is automatically loaded by Web Integration Service
+        at startup.
+    -->
+    <web_integration_service name="simpleShapesDemo">
+        <application name="ShapesDemoApp">
+            <domain_participant name="MyParticipant" domain_ref="ShapesDomainLibrary::ShapesDomain" domain_id="2">
+                <register_type name="ShapeType" type_ref="ShapeType" />
+                <topic name="Square" register_type_ref="ShapeType" />
+                <topic name="Circle" register_type_ref="ShapeType" />
+                <topic name="Triangle" register_type_ref="ShapeType" />
+                <publisher name="MyPublisher">
+                    <data_writer name="MySquareWriter" topic_ref="Square" />
+                    <data_writer name="MyCircleWriter" topic_ref="Circle" />
+                    <data_writer name="MyTriangleWriter" topic_ref="Triangle" />
+                </publisher>
+                <subscriber name="MySubscriber">
+                    <data_reader name="MySquareReader" topic_ref="Square" />
+                    <data_reader name="MyCircleReader" topic_ref="Circle" />
+                    <data_reader name="MyTriangleReader" topic_ref="Triangle" />
+                </subscriber>
+            </domain_participant>
+        </application>
+    </web_integration_service>
+</dds>

--- a/examples/routing_service/routing_service_constrained_wan/wandemo/simple_shapes_demo.xml
+++ b/examples/routing_service/routing_service_constrained_wan/wandemo/simple_shapes_demo.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0"?>
 <!--
-    (c) 2016 Copyright, Real-Time Innovations, Inc.  All rights reserved.
-    RTI grants Licensee a license to use, modify, compile, and create derivative
-    works of the Software.  Licensee has the right to distribute object form only
-    for use with RTI products.  The Software is provided "as is", with no warranty
-    of any type, including any warranty for fitness for any purpose. RTI is under
-    no obligation to maintain or support the Software.  RTI shall not be liable for
-    any incidental or consequential damages arising out of the use or inability to
-    use the software.
--->
+ (c) 2005-2020 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+ RTI grants Licensee a license to use, modify, compile, and create derivative
+ works of the Software.  Licensee has the right to distribute object form only
+ for use with RTI products.  The Software is provided "as is", with no warranty
+ of any type, including any warranty for fitness for any purpose. RTI is under
+ no obligation to maintain or support the Software.  RTI shall not be liable for
+ any incidental or consequential damages arising out of the use or inability to
+ use the software.
+ -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/6.0.0/latest/rti_web_integration_service.xsd">
 


### PR DESCRIPTION
### Summary
I plan on adding a new constrained wan example on our community site, and I need these .xml files hosted on github to reference them (there doesn't seem to be any other way to reference files on our community site)

### Details and comments
These are xml files that configure routing service (both one locally and a hosted instance on AWS) for use by customers and FAEs to demonstrate routing service concepts that can benefit use cases that include a constrained network link. It also includes one WIS xml configuration file for shapes demo. 

This will be a public facing demo of the current internal demo described on our internal confluence: /display/FAE/Routing+Service+Constrained+Wan+Demo

If there is a better or different way to host these files and make them available on our community site when I write an example let me know