### PR TITLE
Fix C and C++ standard versions

### DIFF
--- a/examples/connext_dds/asynchronous_publication/c++03/async_subscriber.cxx
+++ b/examples/connext_dds/asynchronous_publication/c++03/async_subscriber.cxx
@@ -69,7 +69,7 @@ void subscriber_main(int domain_id, int sample_count)
 
     // Create a data reader listener using ListenerBinder, a RAII utility that
     // will take care of reseting it from the reader and deleting it.
-    rti::core::ListenerBinder<DataReader<async>> scoped_listener =
+    rti::core::ListenerBinder<DataReader<async> > scoped_listener =
             rti::core::bind_and_manage_listener(
                     reader,
                     new AsyncListener,

--- a/examples/connext_dds/batching/c++03/batch_data_subscriber.cxx
+++ b/examples/connext_dds/batching/c++03/batch_data_subscriber.cxx
@@ -69,7 +69,7 @@ void subscriber_main(int domain_id, int sample_count, bool turbo_mode_on)
             QosProvider::Default().datareader_qos(profile_name));
 
     // Set the listener using a RAII so it's exception-safe
-    rti::core::ListenerBinder<DataReader<batch_data>> scoped_listener =
+    rti::core::ListenerBinder<DataReader<batch_data> > scoped_listener =
             rti::core::bind_and_manage_listener(
                     reader,
                     new BatchDataReaderListener,

--- a/examples/connext_dds/builtin_topics/c++03/msg_publisher.cxx
+++ b/examples/connext_dds/builtin_topics/c++03/msg_publisher.cxx
@@ -158,29 +158,29 @@ void publisher_main(int domain_id, int sample_count)
     Subscriber builtin_subscriber = dds::sub::builtin_subscriber(participant);
 
     // Then get builtin subscriber's datareader for participants.
-    std::vector<DataReader<ParticipantBuiltinTopicData>> participant_reader;
-    find<DataReader<ParticipantBuiltinTopicData>>(
+    std::vector<DataReader<ParticipantBuiltinTopicData> > participant_reader;
+    find<DataReader<ParticipantBuiltinTopicData> >(
             builtin_subscriber,
             dds::topic::participant_topic_name(),
             std::back_inserter(participant_reader));
 
     // Install our listener using ListenerBinder, a RAII that will take care
     // of setting it to NULL and deleting it.
-    rti::core::ListenerBinder<DataReader<ParticipantBuiltinTopicData>>
+    rti::core::ListenerBinder<DataReader<ParticipantBuiltinTopicData> >
             participant_listener = rti::core::bind_and_manage_listener(
                     participant_reader[0],
                     new BuiltinParticipantListener,
                     dds::core::status::StatusMask::data_available());
 
     // Get builtin subscriber's datareader for subscribers.
-    std::vector<DataReader<SubscriptionBuiltinTopicData>> subscription_reader;
-    find<DataReader<SubscriptionBuiltinTopicData>>(
+    std::vector<DataReader<SubscriptionBuiltinTopicData> > subscription_reader;
+    find<DataReader<SubscriptionBuiltinTopicData> >(
             builtin_subscriber,
             dds::topic::subscription_topic_name(),
             std::back_inserter(subscription_reader));
 
     // Install our listener using ListenerBinder.
-    rti::core::ListenerBinder<DataReader<SubscriptionBuiltinTopicData>>
+    rti::core::ListenerBinder<DataReader<SubscriptionBuiltinTopicData> >
             subscriber_listener = rti::core::bind_and_manage_listener(
                     subscription_reader[0],
                     new BuiltinSubscriberListener,

--- a/examples/connext_dds/builtin_topics/c++03/msg_subscriber.cxx
+++ b/examples/connext_dds/builtin_topics/c++03/msg_subscriber.cxx
@@ -82,7 +82,7 @@ void subscriber_main(
 
     // Create a data reader listener using ListenerBinder, a RAII utility that
     // will take care of reseting it from the reader and deleting it.
-    ListenerBinder<DataReader<msg>> scoped_listener = bind_and_manage_listener(
+    ListenerBinder<DataReader<msg> > scoped_listener = bind_and_manage_listener(
             reader,
             new MsgListener,
             dds::core::status::StatusMask::data_available());

--- a/examples/connext_dds/coherent_presentation/c++03/coherent_subscriber.cxx
+++ b/examples/connext_dds/coherent_presentation/c++03/coherent_subscriber.cxx
@@ -92,7 +92,7 @@ void subscriber_main(int domain_id, int sample_count)
 
     // Create a DataReader listener using ListenerBinder, a RAII utility that
     // will take care of reseting it from the reader and deleting it.
-    ListenerBinder<DataReader<coherent>> scoped_listener =
+    ListenerBinder<DataReader<coherent> > scoped_listener =
             bind_and_manage_listener(
                     reader,
                     new CoherentListener,

--- a/examples/connext_dds/content_filtered_topic/c++03/cft_subscriber.cxx
+++ b/examples/connext_dds/content_filtered_topic/c++03/cft_subscriber.cxx
@@ -94,7 +94,7 @@ void subscriber_main(int domain_id, int sample_count, bool is_cft)
 
     // Create a data reader listener using ListenerBinder, a RAII that
     // will take care of setting it to NULL on destruction.
-    rti::core::ListenerBinder<DataReader<cft>> scoped_listener =
+    rti::core::ListenerBinder<DataReader<cft> > scoped_listener =
             rti::core::bind_and_manage_listener(
                     reader,
                     new CftListener,

--- a/examples/connext_dds/content_filtered_topic_string_filter/c++03/cft_subscriber.cxx
+++ b/examples/connext_dds/content_filtered_topic_string_filter/c++03/cft_subscriber.cxx
@@ -90,7 +90,7 @@ void subscriber_main(int domain_id, int sample_count, bool is_cft)
 
     // Create a DataReader listener using ListenerBinder, a RAII utility that
     // will take care of reseting it from the reader and deleting it.
-    ListenerBinder<DataReader<cft>> scoped_listener = bind_and_manage_listener(
+    ListenerBinder<DataReader<cft> > scoped_listener = bind_and_manage_listener(
             reader,
             new cftReaderListener,
             StatusMask::data_available());

--- a/examples/connext_dds/custom_content_filter/c++03/ccf_subscriber.cxx
+++ b/examples/connext_dds/custom_content_filter/c++03/ccf_subscriber.cxx
@@ -72,7 +72,7 @@ void subscriber_main(int domain_id, int sample_count)
 
     // Create a data reader listener using ListenerBinder, a RAII that
     // will take care of setting it to NULL on destruction.
-    rti::core::ListenerBinder<DataReader<Foo>> scoped_listener =
+    rti::core::ListenerBinder<DataReader<Foo> > scoped_listener =
             rti::core::bind_and_manage_listener(
                     reader,
                     new CcfListener,

--- a/examples/connext_dds/custom_flow_controller/c++03/cfc_subscriber.cxx
+++ b/examples/connext_dds/custom_flow_controller/c++03/cfc_subscriber.cxx
@@ -80,7 +80,7 @@ void subscriber_main(int domain_id, int sample_count)
 
     // Associate a listener to the DataReader using ListenerBinder, a RAII that
     // will take care of setting it to NULL on destruction.
-    ListenerBinder<DataReader<cfc>> reader_listener =
+    ListenerBinder<DataReader<cfc> > reader_listener =
             rti::core::bind_and_manage_listener(
                     reader,
                     new cfcReaderListener,

--- a/examples/connext_dds/deadline_contentfilter/c++03/deadline_contentfilter_publisher.cxx
+++ b/examples/connext_dds/deadline_contentfilter/c++03/deadline_contentfilter_publisher.cxx
@@ -65,7 +65,7 @@ void publisher_main(int domain_id, int sample_count)
 
     // Associate a listener to the DataWriter using ListenerBinder, a RAII that
     // will take care of setting it to NULL on destruction.
-    rti::core::ListenerBinder<DataWriter<deadline_contentfilter>> listener =
+    rti::core::ListenerBinder<DataWriter<deadline_contentfilter> > listener =
             rti::core::bind_and_manage_listener(
                     writer,
                     new DeadlineWriterListener,

--- a/examples/connext_dds/deadline_contentfilter/c++03/deadline_contentfilter_subscriber.cxx
+++ b/examples/connext_dds/deadline_contentfilter/c++03/deadline_contentfilter_subscriber.cxx
@@ -116,7 +116,7 @@ void subscriber_main(int domain_id, int sample_count)
 
     // Create a data reader listener using ListenerBinder, a RAII that
     // will take care of setting it to NULL on destruction.
-    rti::core::ListenerBinder<DataReader<deadline_contentfilter>> listener =
+    rti::core::ListenerBinder<DataReader<deadline_contentfilter> > listener =
             rti::core::bind_and_manage_listener(
                     reader,
                     new deadline_contentfilterReaderListener,

--- a/examples/connext_dds/keyed_data/c++03/keys_subscriber.cxx
+++ b/examples/connext_dds/keyed_data/c++03/keys_subscriber.cxx
@@ -77,7 +77,7 @@ void subscriber_main(int domain_id, int sample_count)
 
     // Associate a listener to the datareader using ListenerBinder, a RAII that
     // will take care of setting it to NULL on destruction.
-    ListenerBinder<DataReader<keys>> reader_listener = bind_and_manage_listener(
+    ListenerBinder<DataReader<keys> > reader_listener = bind_and_manage_listener(
             reader,
             new KeysReaderListener,
             dds::core::status::StatusMask::all());

--- a/examples/connext_dds/keyed_data_advanced/c++03/keys_subscriber.cxx
+++ b/examples/connext_dds/keyed_data_advanced/c++03/keys_subscriber.cxx
@@ -152,7 +152,7 @@ void subscriber_main(int domain_id, int sample_count)
 
     // Associate a listener using ListenerBinder, a RAII that will take care of
     // setting it to NULL on destruction.
-    rti::core::ListenerBinder<DataReader<keys>> reader_listener =
+    rti::core::ListenerBinder<DataReader<keys> > reader_listener =
             rti::core::bind_and_manage_listener(
                     reader,
                     new KeysReaderListener,

--- a/examples/connext_dds/listeners/c++03/listeners_publisher.cxx
+++ b/examples/connext_dds/listeners/c++03/listeners_publisher.cxx
@@ -121,7 +121,7 @@ void publisher_main(int domain_id, int sample_count)
     // By using ListenerBinder (a RAII) it will take care of setting the
     // listener to NULL on destruction.
     DataWriter<listeners> writer(publisher, topic);
-    rti::core::ListenerBinder<DataWriter<listeners>> writer_listener =
+    rti::core::ListenerBinder<DataWriter<listeners> > writer_listener =
             rti::core::bind_and_manage_listener(
                     writer,
                     new MyDataWriterListener,

--- a/examples/connext_dds/listeners/c++03/listeners_subscriber.cxx
+++ b/examples/connext_dds/listeners/c++03/listeners_subscriber.cxx
@@ -249,7 +249,7 @@ void subscriber_main(int domain_id, int sample_count)
 
     // Create the DataReader and associate a listener
     DataReader<listeners> reader(subscriber, topic);
-    ListenerBinder<DataReader<listeners>> datareader_listener =
+    ListenerBinder<DataReader<listeners> > datareader_listener =
             rti::core::bind_and_manage_listener(
                     reader,
                     new MyDataReaderListener,

--- a/examples/connext_dds/multichannel/c++03/market_data_subscriber.cxx
+++ b/examples/connext_dds/multichannel/c++03/market_data_subscriber.cxx
@@ -66,7 +66,7 @@ void subscriber_main(int domain_id, int sample_count)
 
     // Create a data reader listener using ListenerBinder, a RAII that
     // will take care of setting it to NULL on destruction.
-    rti::core::ListenerBinder<DataReader<market_data>> scoped_listener =
+    rti::core::ListenerBinder<DataReader<market_data> > scoped_listener =
             rti::core::bind_and_manage_listener(
                     reader,
                     new MarketDataReaderListener,

--- a/examples/connext_dds/partitions/c++03/partitions_subscriber.cxx
+++ b/examples/connext_dds/partitions/c++03/partitions_subscriber.cxx
@@ -94,7 +94,7 @@ void subscriber_main(int domain_id, int sample_count)
 
     // Create a DataReader listener using ListenerBinder, a RAII utility that
     // will take care of reseting it from the reader and deleting it.
-    ListenerBinder<DataReader<partitions>> scoped_listener =
+    ListenerBinder<DataReader<partitions> > scoped_listener =
             bind_and_manage_listener(
                     reader,
                     new PartitionsListener,

--- a/examples/connext_dds/time_based_filter/c++03/tbf_subscriber.cxx
+++ b/examples/connext_dds/time_based_filter/c++03/tbf_subscriber.cxx
@@ -69,7 +69,7 @@ void subscriber_main(int domain_id, int sample_count)
 
     // Associate a listener to the DataReader using ListenerBinder, a RAII that
     // will take care of setting it to NULL on destruction.
-    ListenerBinder<DataReader<tbf>> reader_listener =
+    ListenerBinder<DataReader<tbf> > reader_listener =
             rti::core::bind_and_manage_listener(
                     reader,
                     new tbfReaderListener,

--- a/examples/connext_dds/using_qos_profiles/c++03/profiles_subscriber.cxx
+++ b/examples/connext_dds/using_qos_profiles/c++03/profiles_subscriber.cxx
@@ -85,7 +85,7 @@ void subscriber_main(int domain_id, int sample_count)
                     "profiles_Library::transient_local_profile"));
 
     // Use a ListeberBinder to take care of resetting and deleting the listener.
-    rti::core::ListenerBinder<DataReader<profiles>> scoped_transient_listener =
+    rti::core::ListenerBinder<DataReader<profiles> > scoped_transient_listener =
             rti::core::bind_and_manage_listener(
                     reader_transient_local,
                     new ProfilesListener("transient_local_profile"),
@@ -99,7 +99,7 @@ void subscriber_main(int domain_id, int sample_count)
             qos_provider.datareader_qos("profiles_Library::volatile_profile"));
 
     // Use a ListeberBinder to take care of resetting and deleting the listener.
-    rti::core::ListenerBinder<DataReader<profiles>> scoped_volatile_listener =
+    rti::core::ListenerBinder<DataReader<profiles> > scoped_volatile_listener =
             rti::core::bind_and_manage_listener(
                     reader_volatile,
                     new ProfilesListener("volatile_profile"),

--- a/examples/connext_dds/using_typecodes/c++03/msg_subscriber.cxx
+++ b/examples/connext_dds/using_typecodes/c++03/msg_subscriber.cxx
@@ -87,13 +87,13 @@ void subscriber_main(int domain_id, int sample_count)
     // Then get builtin subscriber's DataReader for DataWriters.
     DataReader<PublicationBuiltinTopicData> publication_reader =
             rti::sub::find_datareader_by_topic_name<
-                    DataReader<PublicationBuiltinTopicData>>(
+                    DataReader<PublicationBuiltinTopicData> >(
                     builtin_subscriber,
                     dds::topic::publication_topic_name());
 
     // Install our listener using ListenerBinder, a RAII that will take care
     // of setting it to NULL and deleting it.
-    rti::core::ListenerBinder<DataReader<PublicationBuiltinTopicData>>
+    rti::core::ListenerBinder<DataReader<PublicationBuiltinTopicData> >
             publication_listener = rti::core::bind_and_manage_listener(
                     publication_reader,
                     new BuiltinPublicationListener,

--- a/resources/cmake/ConnextDdsAddExample.cmake
+++ b/resources/cmake/ConnextDdsAddExample.cmake
@@ -345,11 +345,15 @@ function(connextdds_call_codegen)
     )
 
     set(api "c")
+    set(c_standard C_STANDARD 90)
+    set(cxx_standard CXX_STANDARD 98)
     if("${_CONNEXT_LANG}" STREQUAL "C++")
         set(api "cpp")
-    elseif("${_CONNEXT_LANG}" STREQUAL "C++03" OR
-        "${_CONNEXT_LANG}" STREQUAL "C++11")
+    elseif("${_CONNEXT_LANG}" STREQUAL "C++03")
         set(api "cpp2")
+    elseif("${_CONNEXT_LANG}" STREQUAL "C++11")
+        set(api "cpp2")
+        set(cxx_standard CXX_STANDARD 11)
     endif()
 
     target_compile_definitions(
@@ -361,6 +365,13 @@ function(connextdds_call_codegen)
         ${obj_library}
         PRIVATE
         $<TARGET_PROPERTY:RTIConnextDDS::${api}_api,INTERFACE_INCLUDE_DIRECTORIES>)
+
+    set_target_properties(
+        ${obj_library}
+        PROPERTIES
+            ${c_standard}
+            ${cxx_standard}
+    )
 
     add_dependencies(${obj_library}
         ${_CONNEXT_PREFIX}_${lang_var}_sources
@@ -381,7 +392,7 @@ function(connextdds_copy_qos_profile)
         ${ARGN}
     )
 
-    if(_EXAMPLE_QOS_FILENAME) 
+    if(_EXAMPLE_QOS_FILENAME)
         set(user_qos_profile_name ${_EXAMPLE_QOS_FILENAME})
     else()
         set(user_qos_profile_name "USER_QOS_PROFILES.xml")
@@ -444,11 +455,13 @@ function(connextdds_add_application)
      )
 
     set(api "c")
-
+    set(c_standard C_STANDARD 90)
+    set(cxx_standard CXX_STANDARD 98)
     if("${_CONNEXT_LANG}" STREQUAL "C++")
         set(api "cpp")
-    elseif("${_CONNEXT_LANG}" STREQUAL "C++03" OR
-        "${_CONNEXT_LANG}" STREQUAL "C++11")
+    elseif("${_CONNEXT_LANG}" STREQUAL "C++03")
+        set(api "cpp2")
+    elseif("${_CONNEXT_LANG}" STREQUAL "C++11")
         set(api "cpp2")
         set(cxx_standard CXX_STANDARD 11)
     endif()
@@ -483,6 +496,7 @@ function(connextdds_add_application)
     set_target_properties(${target_name}
         PROPERTIES
             OUTPUT_NAME "${_CONNEXT_OUTPUT_NAME}"
+            ${c_standard}
             ${cxx_standard}
     )
 


### PR DESCRIPTION
### Summary

This PR adds the C and C++ standard version to all targets created by `connextdds_add_example()` and `connextdds_add_application().

### Details and comments

Besides adding the corresponding C and C++ standard version, this PR fixes all issues uncovered by the new compiler options. These affect mainly to the use of nested template arguments in C++03. 