### PR TITLE
Add C# instance_statistics example

### DIFF
--- a/examples/connext_dds/instance_statistics/cs/.gitignore
+++ b/examples/connext_dds/instance_statistics/cs/.gitignore
@@ -1,0 +1,2 @@
+NuGet.Config
+InstanceStatisticsExample.cs

--- a/examples/connext_dds/instance_statistics/cs/InstanceStatisticsExample.idl
+++ b/examples/connext_dds/instance_statistics/cs/InstanceStatisticsExample.idl
@@ -1,0 +1,7 @@
+module InstanceStatisticsExample {
+
+    struct HelloWorld {
+        @key string<128> message;
+    };
+
+};

--- a/examples/connext_dds/instance_statistics/cs/InstanceStatisticsExampleProgram.cs
+++ b/examples/connext_dds/instance_statistics/cs/InstanceStatisticsExampleProgram.cs
@@ -1,0 +1,161 @@
+/*
+* (c) Copyright, Real-Time Innovations, 2021.  All rights reserved.
+* RTI grants Licensee a license to use, modify, compile, and create derivative
+* works of the software solely for use with RTI Connext DDS. Licensee may
+* redistribute copies of the software provided that all such copies are subject
+* to this license. The software is provided "as is", with no warranty of any
+* type, including any warranty for fitness for any purpose. RTI is under no
+* obligation to maintain or support the software. RTI shall not be liable for
+* any incidental or consequential damages arising out of the use or inability
+* to use the software.
+*/
+
+using System;
+using Rti.Config;
+
+namespace InstanceStatisticsExample
+{
+    /// <summary>
+    /// Interface shared by HelloWorldPublisher and HelloWorldSubscriber.
+    /// </summary>
+    public interface IHelloWorldApplication : IDisposable
+    {
+        /// <summary>
+        /// Writes or reads a number of samples before returning.
+        /// </summary>
+        void Run(int sampleCount);
+
+        /// <summary>
+        /// Signals that Run() should return early.
+        /// </summary>
+        void Stop();
+    }
+
+    /// <summary>
+    /// Runs HelloWorldPublisher or HelloWorldSubscriber.
+    /// </summary>
+    public static class HelloWorldProgram
+    {
+        /// <summary>
+        /// The Main function runs the publisher or the subscriber.
+        /// </summary>
+        public static void Main(string[] args)
+        {
+            var arguments = ParseArguments(args);
+            if (arguments == null)
+            {
+                return;
+            }
+
+            if (arguments.Verbose)
+            {
+                Logger.Instance.SetVerbosity(Verbosity.Warning);
+            }
+
+            IHelloWorldApplication application;
+            if (arguments.Pub)
+            {
+                Console.WriteLine($"Running HelloWorldPublisher on domain {arguments.Domain}");
+                application = new HelloWorldPublisher(arguments.Domain);
+            }
+            else
+            {
+                Console.WriteLine($"Running HelloWorldSubscriber on domain {arguments.Domain}");
+                application = new HelloWorldSubscriber(arguments.Domain);
+            }
+
+            // Set up signal handler to Dispose the DDS entities
+            Console.CancelKeyPress += (_, eventArgs) =>
+            {
+                Console.WriteLine("Shutting down...");
+                eventArgs.Cancel = true; // let the application shutdown gracefully
+                application.Stop();
+            };
+
+            try
+            {
+                application.Run(arguments.SampleCount);
+            }
+            finally
+            {
+                application.Dispose();
+            }
+        }
+
+        private class Arguments
+        {
+            public bool Pub { get; set; }
+            public bool Sub { get; set; }
+            public int Domain { get; set; }
+            public int SampleCount { get; set; } = int.MaxValue;
+            public bool Verbose { get; set; }
+            public bool Version { get; set; }
+        }
+
+        // Uses the System.CommandLine package to parse the program arguments.
+        private static Arguments ParseArguments(string[] args)
+        {
+            // Create a root command with some options
+            var rootCommand = new System.CommandLine.RootCommand
+            {
+                new System.CommandLine.Option<bool>(
+                    new string[] { "--pub", "-p" },
+                description: "Whether to run the publisher application"),
+                new System.CommandLine.Option<bool>(
+                    new string[] { "--sub", "-s" },
+                description: "Whether to run the subscriber application"),
+                new System.CommandLine.Option<int>(
+                    new string[] { "--domain", "-d" },
+                getDefaultValue: () => 0,
+                description: "Domain ID used to create the DomainParticipant"),
+                new System.CommandLine.Option<int>(
+                    new string[] { "--sample-count", "-c" },
+                getDefaultValue: () => int.MaxValue,
+                description: "Number of samples to publish or subscribe to"),
+                new System.CommandLine.Option<bool>(
+                    "--verbose",
+                    description: "Increases the RTI Connext logging verbosity"),
+                    new System.CommandLine.Option<bool>(
+                        "--version",
+                        description: "Displays the RTI Connext version")
+                    };
+
+            rootCommand.Description = "Example RTI Connext Publisher and Subscriber."
+            + "\nSee README.txt for more information";
+
+            Arguments result = null;
+            rootCommand.Handler = System.CommandLine.Invocation.CommandHandler.Create(
+                (Arguments arguments) => result = arguments);
+
+            System.CommandLine.CommandExtensions.Invoke(rootCommand, args);
+
+            if (result == null)
+            {
+                return null;
+            }
+
+            if (result.Version)
+            {
+                Console.WriteLine(Rti.Dds.Core.ServiceEnvironment.Instance.Version);
+                return null;
+            }
+
+            if (!result.Pub && !result.Sub)
+            {
+                Console.WriteLine(rootCommand.Description);
+                Console.WriteLine("\nYou can specify --pub or --sub to choose which application to run (or -h for help).");
+                Console.WriteLine("For example:\n    dotnet run -- --pub\n");
+                Console.Write("Which one do you want to run? Enter 'pub' or 'sub' > ");
+                var choice = Console.ReadLine();
+                result.Pub = choice.StartsWith("p", StringComparison.OrdinalIgnoreCase);
+            }
+
+            if (result.SampleCount < 0)
+            {
+                result.SampleCount = int.MaxValue;
+            }
+
+            return result;
+        }
+    }
+} // namespace InstanceStatisticsExample

--- a/examples/connext_dds/instance_statistics/cs/InstanceStatisticsExampleProgram.cs
+++ b/examples/connext_dds/instance_statistics/cs/InstanceStatisticsExampleProgram.cs
@@ -1,14 +1,14 @@
 /*
-* (c) Copyright, Real-Time Innovations, 2021.  All rights reserved.
-* RTI grants Licensee a license to use, modify, compile, and create derivative
-* works of the software solely for use with RTI Connext DDS. Licensee may
-* redistribute copies of the software provided that all such copies are subject
-* to this license. The software is provided "as is", with no warranty of any
-* type, including any warranty for fitness for any purpose. RTI is under no
-* obligation to maintain or support the software. RTI shall not be liable for
-* any incidental or consequential damages arising out of the use or inability
-* to use the software.
-*/
+ * (c) Copyright, Real-Time Innovations, 2021.  All rights reserved.
+ * RTI grants Licensee a license to use, modify, compile, and create derivative
+ * works of the software solely for use with RTI Connext DDS. Licensee may
+ * redistribute copies of the software provided that all such copies are subject
+ * to this license. The software is provided "as is", with no warranty of any
+ * type, including any warranty for fitness for any purpose. RTI is under no
+ * obligation to maintain or support the software. RTI shall not be liable for
+ * any incidental or consequential damages arising out of the use or inability
+ * to use the software.
+ */
 
 using System;
 using Rti.Config;

--- a/examples/connext_dds/instance_statistics/cs/InstanceStatisticsExamplePublisher.cs
+++ b/examples/connext_dds/instance_statistics/cs/InstanceStatisticsExamplePublisher.cs
@@ -1,0 +1,100 @@
+/*
+* (c) Copyright, Real-Time Innovations, 2021.  All rights reserved.
+* RTI grants Licensee a license to use, modify, compile, and create derivative
+* works of the software solely for use with RTI Connext DDS. Licensee may
+* redistribute copies of the software provided that all such copies are subject
+* to this license. The software is provided "as is", with no warranty of any
+* type, including any warranty for fitness for any purpose. RTI is under no
+* obligation to maintain or support the software. RTI shall not be liable for
+* any incidental or consequential damages arising out of the use or inability
+* to use the software.
+*/
+
+using System;
+using System.Threading;
+using Rti.Dds.Core;
+using Rti.Dds.Core.Status;
+using Rti.Dds.Domain;
+using Rti.Dds.Publication;
+using Rti.Dds.Topics;
+
+namespace InstanceStatisticsExample
+{
+    /// <summary>
+    /// Example application that publishes HelloWorld
+    /// </summary>
+    public sealed class HelloWorldPublisher : IHelloWorldApplication
+    {
+        private readonly DomainParticipant participant;
+        private readonly DataWriter<HelloWorld> writer;
+
+        private bool continueRunning = true;
+
+        /// <summary>
+        /// Creates a DomainParticipant, Topic, Publisher and DataWriter<HelloWorld>.
+        /// </summary>
+        public HelloWorldPublisher(int domainId)
+        {
+            // Start communicating in a domain, usually one participant per application
+            // Load QoS profile from USER_QOS_PROFILES.xml file
+            participant = DomainParticipantFactory.Instance.CreateParticipant(domainId);
+
+            // A Topic has a name and a datatype.
+            Topic<HelloWorld> topic = participant.CreateTopic<HelloWorld>(
+                "Example InstanceStatisticsExample_HelloWorld");
+
+            // Create a Publisher
+            Publisher publisher = participant.CreatePublisher();
+
+            // Create a DataWriter, loading QoS profile from USER_QOS_PROFILES.xml
+            writer = publisher.CreateDataWriter(topic);
+        }
+
+        /// <summary>
+        /// Publishes the data
+        /// </summary>
+        public void Run(int sampleCount)
+        {
+            var sample = new HelloWorld();
+            for (int count = 0; count < sampleCount && continueRunning; count++)
+            {
+                // Modify the data to be sent here
+                sample.message =  $"Hello {count}";
+
+                Console.WriteLine($"Writing HelloWorld, count {count}");
+
+                InstanceHandle instanceHandle = writer.RegisterInstance(sample);
+                writer.Write(sample, instanceHandle);
+
+                Thread.Sleep(1000);
+
+                if (count % 2 == 0)
+                {
+                    Console.WriteLine("Unregistering the instance");
+                    writer.UnregisterInstance(instanceHandle);
+                }
+                else if (count % 3 == 0)
+                {
+                    Console.WriteLine("Disposing the instance");
+                    writer.DisposeInstance(instanceHandle);
+                }
+
+                var status = writer.DataWriterCacheStatus;
+                Console.WriteLine("Instance statistics: ");
+                Console.WriteLine($"  * Alive instance count:        {status.AliveInstanceCount}");
+                Console.WriteLine($"  * Unregistered instance count: {status.UnregisteredInstanceCount}");
+                Console.WriteLine($"  * Disposed instance count:     {status.DisposedInstanceCount}");
+            }
+        }
+
+        /// <summary>
+        /// Signals that Run() should return early.
+        /// </summary>
+        public void Stop() => continueRunning = false;
+
+        /// <summary>
+        /// Disposes all DDS entities created by this application.
+        /// </summary>
+        public void Dispose() => participant.Dispose();
+    }
+} // namespace InstanceStatisticsExample

--- a/examples/connext_dds/instance_statistics/cs/InstanceStatisticsExamplePublisher.cs
+++ b/examples/connext_dds/instance_statistics/cs/InstanceStatisticsExamplePublisher.cs
@@ -1,14 +1,14 @@
 /*
-* (c) Copyright, Real-Time Innovations, 2021.  All rights reserved.
-* RTI grants Licensee a license to use, modify, compile, and create derivative
-* works of the software solely for use with RTI Connext DDS. Licensee may
-* redistribute copies of the software provided that all such copies are subject
-* to this license. The software is provided "as is", with no warranty of any
-* type, including any warranty for fitness for any purpose. RTI is under no
-* obligation to maintain or support the software. RTI shall not be liable for
-* any incidental or consequential damages arising out of the use or inability
-* to use the software.
-*/
+ * (c) Copyright, Real-Time Innovations, 2021.  All rights reserved.
+ * RTI grants Licensee a license to use, modify, compile, and create derivative
+ * works of the software solely for use with RTI Connext DDS. Licensee may
+ * redistribute copies of the software provided that all such copies are subject
+ * to this license. The software is provided "as is", with no warranty of any
+ * type, including any warranty for fitness for any purpose. RTI is under no
+ * obligation to maintain or support the software. RTI shall not be liable for
+ * any incidental or consequential damages arising out of the use or inability
+ * to use the software.
+ */
 
 using System;
 using System.Threading;

--- a/examples/connext_dds/instance_statistics/cs/InstanceStatisticsExampleSubscriber.cs
+++ b/examples/connext_dds/instance_statistics/cs/InstanceStatisticsExampleSubscriber.cs
@@ -1,14 +1,14 @@
 /*
-* (c) Copyright, Real-Time Innovations, 2012.  All rights reserved.
-* RTI grants Licensee a license to use, modify, compile, and create derivative
-* works of the software solely for use with RTI Connext DDS. Licensee may
-* redistribute copies of the software provided that all such copies are subject
-* to this license. The software is provided "as is", with no warranty of any
-* type, including any warranty for fitness for any purpose. RTI is under no
-* obligation to maintain or support the software. RTI shall not be liable for
-* any incidental or consequential damages arising out of the use or inability
-* to use the software.
-*/
+ * (c) Copyright, Real-Time Innovations, 2021.  All rights reserved.
+ * RTI grants Licensee a license to use, modify, compile, and create derivative
+ * works of the software solely for use with RTI Connext DDS. Licensee may
+ * redistribute copies of the software provided that all such copies are subject
+ * to this license. The software is provided "as is", with no warranty of any
+ * type, including any warranty for fitness for any purpose. RTI is under no
+ * obligation to maintain or support the software. RTI shall not be liable for
+ * any incidental or consequential damages arising out of the use or inability
+ * to use the software.
+ */
 
 using System;
 using Omg.Dds.Core;

--- a/examples/connext_dds/instance_statistics/cs/InstanceStatisticsExampleSubscriber.cs
+++ b/examples/connext_dds/instance_statistics/cs/InstanceStatisticsExampleSubscriber.cs
@@ -1,0 +1,122 @@
+/*
+* (c) Copyright, Real-Time Innovations, 2012.  All rights reserved.
+* RTI grants Licensee a license to use, modify, compile, and create derivative
+* works of the software solely for use with RTI Connext DDS. Licensee may
+* redistribute copies of the software provided that all such copies are subject
+* to this license. The software is provided "as is", with no warranty of any
+* type, including any warranty for fitness for any purpose. RTI is under no
+* obligation to maintain or support the software. RTI shall not be liable for
+* any incidental or consequential damages arising out of the use or inability
+* to use the software.
+*/
+
+using System;
+using Omg.Dds.Core;
+using Rti.Dds.Core;
+using Rti.Dds.Core.Status;
+using Rti.Dds.Domain;
+using Rti.Dds.Subscription;
+using Rti.Dds.Topics;
+
+namespace InstanceStatisticsExample
+{
+    /// <summary>
+    /// Example application that subscribes to HelloWorld.
+    /// </summary>
+    public sealed class HelloWorldSubscriber : IHelloWorldApplication
+    {
+        private readonly DomainParticipant participant;
+        private readonly DataReader<HelloWorld> reader;
+
+        private readonly WaitSet waitset = new WaitSet();
+
+        private bool continueRunning = true;
+
+        private int samplesRead;
+
+        /// <summary>
+        /// Creates a DomainParticipant, Topic, Subscriber and DataReader<HelloWorld>.
+        /// </summary>
+        public HelloWorldSubscriber(int domainId)
+        {
+            // Start communicating in a domain, usually one participant per application
+            // Load QoS profile from USER_QOS_PROFILES.xml file
+            participant = DomainParticipantFactory.Instance.CreateParticipant(domainId);
+
+            // A Topic has a name and a datatype.
+            Topic<HelloWorld> topic = participant.CreateTopic<HelloWorld>("Example InstanceStatisticsExample_HelloWorld");
+
+            // Create a subscriber
+            Subscriber subscriber = participant.CreateSubscriber();
+
+            // Create a DataReader, loading QoS profile from USER_QOS_PROFILES.xml.
+            reader = subscriber.CreateDataReader(topic);
+
+            // Obtain the DataReader's Status Condition
+            StatusCondition statusCondition = reader.StatusCondition;
+
+            // Enable the 'data available' status.
+            statusCondition.EnabledStatuses = StatusMask.DataAvailable;
+
+            // Associate an event handler with the status condition.
+            // This will run when the condition is triggered, in the context of
+            // the dispatch call (see below)
+            statusCondition.Triggered += ProcessData;
+
+            // Create a WaitSet and attach the StatusCondition
+            waitset.AttachCondition(statusCondition);
+        }
+
+        /// <summary>
+        /// Processes the data received by the DataReader.
+        /// </summary>
+        public void Run(int sampleCount)
+        {
+            while (samplesRead < sampleCount && continueRunning)
+            {
+                // Dispatch will call the handlers associated to the WaitSet
+                // conditions when they activate
+                Console.WriteLine("HelloWorld subscriber sleeping up to 1 sec...");
+                waitset.Dispatch(Duration.FromSeconds(1));
+
+                var status = reader.DataReaderCacheStatus;
+                Console.WriteLine("Instance statistics: ");
+                Console.WriteLine($"  * Alive instance count:      {status.AliveInstanceCount}");
+                Console.WriteLine($"  * No-writers instance count: {status.NoWritersInstanceCount}");
+                Console.WriteLine($"  * Disposed instance count:   {status.DisposedInstanceCount}");
+                Console.WriteLine($"  * Detached instance count:   {status.DetachedInstanceCount}");
+            }
+        }
+
+        /// <summary>
+        /// Signals that Run() should return early.
+        /// </summary>
+        public void Stop() => continueRunning = false;
+
+        /// <summary>
+        /// Disposes all DDS entities created by this application.
+        /// </summary>
+        public void Dispose() => participant.Dispose();
+
+        private void ProcessData(Condition _)
+        {
+            // Take all samples. Samples are loaned to application; loan is
+            // returned when the samples collection is Disposed.
+            using (var samples = reader.Take())
+            {
+                foreach (var sample in samples)
+                {
+                    if (sample.Info.ValidData)
+                    {
+                        samplesRead++;
+                        Console.WriteLine(sample.Data);
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Instance state changed to: {sample.Info.State.Instance}");
+                    }
+                }
+            }
+        }
+    }
+} // namespace InstanceStatisticsExample

--- a/examples/connext_dds/instance_statistics/cs/README.md
+++ b/examples/connext_dds/instance_statistics/cs/README.md
@@ -8,7 +8,7 @@ If you haven't used the RTI Connext C# API before, first check the
 First use **rtiddsgen** to generate the C# type and project files from
 `InstanceStatisticsExample.idl`:
 
-```
+```sh
 <install dir>/bin/rtiddsgen -language c# -platform net5 -create typefiles -create makefiles InstanceStatisticsExample.idl
 ```
 
@@ -16,7 +16,7 @@ Where `<install dir>` refers to your RTI Connext installation.
 
 Then build it using the dotnet CLI:
 
-```
+```sh
 dotnet build
 ```
 
@@ -27,12 +27,12 @@ following commands from the example directory (this is necessary to ensure the
 application loads the QoS defined in *USER_QOS_PROFILES.xml*):
 
 
-```
+```sh
 dotnet run -- --pub -domain-id <domain_id> --sample-count <samples_to_send>
 dotnet run -- --sub -domain-id <domain_id> --sample-count <samples_to_receive>
 ```
 
 For the full list of arguments:
-```
+```sh
 dotnet run -- -h
 ```

--- a/examples/connext_dds/instance_statistics/cs/README.md
+++ b/examples/connext_dds/instance_statistics/cs/README.md
@@ -26,13 +26,13 @@ In two separate command prompt windows for the publisher and subscriber. Run the
 following commands from the example directory (this is necessary to ensure the
 application loads the QoS defined in *USER_QOS_PROFILES.xml*):
 
-
 ```sh
 dotnet run -- --pub -domain-id <domain_id> --sample-count <samples_to_send>
 dotnet run -- --sub -domain-id <domain_id> --sample-count <samples_to_receive>
 ```
 
 For the full list of arguments:
+
 ```sh
 dotnet run -- -h
 ```

--- a/examples/connext_dds/instance_statistics/cs/README.md
+++ b/examples/connext_dds/instance_statistics/cs/README.md
@@ -1,0 +1,38 @@
+# Example Code: Instance Statistics
+
+If you haven't used the RTI Connext C# API before, first check the
+[Getting Started Guide](https://community.rti.com/static/documentation/connext-dds/6.0.1/doc/manuals/connext_dds/getting_started/index.html).
+
+## Building the Example :wrench:
+
+First use **rtiddsgen** to generate the C# type and project files from
+`InstanceStatisticsExample.idl`:
+
+```
+<install dir>/bin/rtiddsgen -language c# -platform net5 -create typefiles -create makefiles InstanceStatisticsExample.idl
+```
+
+Where `<install dir>` refers to your RTI Connext installation.
+
+Then build it using the dotnet CLI:
+
+```
+dotnet build
+```
+
+## Running the Example
+
+In two separate command prompt windows for the publisher and subscriber. Run the
+following commands from the example directory (this is necessary to ensure the
+application loads the QoS defined in *USER_QOS_PROFILES.xml*):
+
+
+```
+dotnet run -- --pub -domain-id <domain_id> --sample-count <samples_to_send>
+dotnet run -- --sub -domain-id <domain_id> --sample-count <samples_to_receive>
+```
+
+For the full list of arguments:
+```
+dotnet run -- -h
+```

--- a/examples/connext_dds/instance_statistics/cs/USER_QOS_PROFILES.xml
+++ b/examples/connext_dds/instance_statistics/cs/USER_QOS_PROFILES.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<!--
+Description
+XML QoS Profile for instance statistics example
+
+(c) Copyright, Real-Time Innovations, 2021.  All rights reserved.
+RTI grants Licensee a license to use, modify, compile, and create derivative
+works of the software solely for use with RTI Connext DDS. Licensee may
+redistribute copies of the software provided that all such copies are
+subject to this license. The software is provided "as is", with no warranty
+of any type, including any warranty for fitness for any purpose. RTI is
+under no obligation to maintain or support the software. RTI shall not be
+liable for any incidental or consequential damages arising out of the use
+or inability to use the software.
+
+The QoS configuration of the DDS entities in the generated example is loaded
+from this file.
+
+This file is used only when it is in the current working directory or when the
+environment variable NDDS_QOS_PROFILES is defined and points to this file.
+
+The profile in this file inherits from the builtin QoS profile
+BuiltinQosLib::Generic.StrictReliable. That profile, along with all of the
+other built-in QoS profiles can be found in the
+BuiltinProfiles.documentationONLY.xml file located in the
+$NDDSHOME/resource/xml/ directory.
+
+You may use any of these QoS configurations in your application simply by
+referring to them by the name shown in the
+BuiltinProfiles.documentationONLY.xml file.
+
+Also, following the QoS Profile composition pattern you can use QoS Snippets
+to easily create your final QoS Profile. For further information visit:
+https://community.rti.com/best-practices/qos-profile-inheritance-and-composition-guidance
+
+There is a QoS Snippet library that contains a collection of
+QoS Snippets that set some specific features or configurations. You can find
+them in the BuiltinProfiles.documentationONLY.xml file as well.
+
+You should not edit the file BuiltinProfiles.documentationONLY.xml directly.
+However, if you wish to modify any of the values in a built-in profile, the
+recommendation is to create a profile of your own and inherit from the built-in
+profile you wish to modify. The NDDS_QOS_PROFILES.example.xml file (contained in
+the same directory as the BuiltinProfiles.documentationONLY.xml file) shows how
+to inherit from the built-in profiles.
+
+For more information about XML QoS Profiles see the "Configuring QoS with
+XML" chapter in the RTI Connext DDS Core Libraries User's Manual.
+-->
+
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/6.1.0/rti_dds_qos_profiles.xsd">
+    <!-- QoS Library containing the QoS profile used in the generated example.
+
+        A QoS library is a named set of QoS profiles.
+    -->
+    <qos_library name="InstanceStatisticsExample_Library">
+
+        <!-- QoS profile used to configure reliable communication between the DataWriter
+             and DataReader created in the example code.
+
+             A QoS profile groups a set of related QoS.
+        -->
+        <qos_profile name="InstanceStatisticsExample_Profile" base_name="BuiltinQosLib::Generic.StrictReliable" is_default_qos="true">
+            <!-- QoS used to configure the data writer created in the example code -->
+            <datawriter_qos>
+                    <durability>
+                        <!--
+                            When volatile durability is used, unregistered
+                            instances are automatically purged from the
+                            DataWriter's queue.
+                        -->
+                        <kind>VOLATILE_DURABILITY_QOS</kind>
+                    </durability>
+            </datawriter_qos>
+        </qos_profile>
+
+    </qos_library>
+</dds>


### PR DESCRIPTION
### Summary
Add C# directory for the instance_statistics example

### Details and comments
* This example uses the new C# API.
* I used better names for the IDL file, namespace, and type. I think the other examples should be updated.