### PR TITLE
Adds .markdownlintignore file to ignore .github and node_modules dirs

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,3 @@
+node_modules
+.github
+

--- a/resources/ci_cd/linux_format.py
+++ b/resources/ci_cd/linux_format.py
@@ -241,8 +241,6 @@ if __name__ == "__main__":
         markdownlint_cmd: List[str] = [
             "npx",
             "markdownlint",
-            "--ignore",
-            "node_modules",
             ".",
         ]
         markdownlint_filtered_file_list: List[str] = filter_files(


### PR DESCRIPTION
Closes #350 

:white_check_mark: I have updated the documentation accordingly.
:white_check_mark: I have read the CONTRIBUTING document.

### Summary

The GitHub Action that lints markdown files were failing because we were linting the issues and pr templates from the .github directory.
