### PR TITLE
Unified the minimum required CMake version

### DIFF
--- a/examples/connext_dds/compression/c++/CMakeLists.txt
+++ b/examples/connext_dds/compression/c++/CMakeLists.txt
@@ -3,7 +3,7 @@
 # without express written permission.  Any such copies, or revisions thereof,
 # must display this notice unaltered.
 # This code contains trade secrets of Real-Time Innovations, Inc.
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.11)
 project(rtiexamples-compression)
 set(CMAKE_MODULE_PATH
     ${CMAKE_MODULE_PATH}


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->
:white_check_mark: I have updated the documentation accordingly.
:white_check_mark: I have read the CONTRIBUTING document.

### Summary

I changed the minimum required CMake version of the compression example to 3.11, so that the minimum required CMake version is unified across all the examples.

### Details and comments

Ref issue #342 