### PR TITLE
Fix missing metp issue

### DIFF
--- a/examples/connext_dds/flat_data_latency/c++11/CMakeLists.txt
+++ b/examples/connext_dds/flat_data_latency/c++11/CMakeLists.txt
@@ -10,13 +10,6 @@ set(CMAKE_MODULE_PATH
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../resources/cmake"
 )
 
-find_package(
-    RTIConnextDDS "6.1.0"
-    REQUIRED
-    COMPONENTS
-        metp
-)
-
 # Include ConnextDdsAddExample.cmake from resources/cmake
 include(ConnextDdsAddExample)
 


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->
:white_check_mark: I have updated the documentation accordingly.
:white_check_mark: I have read the CONTRIBUTING document.


### Summary

The example issue_flat_data_latency is having a issue because the find_package cannot find the metp component, so I deleted find_package from the `CMakeList.txt`. I don't know if there is another way to find metp that really works.

### Details and comments

Ref issue #378
