### PR TITLE
Fix githook issue

### DIFF
--- a/resources/githooks/pre-commit
+++ b/resources/githooks/pre-commit
@@ -32,8 +32,9 @@ def main():
         sys.exit("Error: script not located in .git/hooks.")
 
     root = script_path.parents[2]
-    formater = root.joinpath("resources", "travis", "linux_format.py")
-    os.system(str(formater))
+    os.unsetenv("GIT_DIR")
+    formater = root.joinpath("resources", "ci_cd", "linux_format.py")
+    os.system(str(formater) + " -a")
 
 
 if __name__ == "__main__":

--- a/resources/githooks/pre-commit
+++ b/resources/githooks/pre-commit
@@ -34,7 +34,7 @@ def main():
     root = script_path.parents[2]
     os.unsetenv("GIT_DIR")
     formater = root.joinpath("resources", "ci_cd", "linux_format.py")
-    os.system(str(formater) + " -a")
+    os.system(f"{str(formater)} -a")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->
:white_check_mark: I have updated the documentation accordingly.
:white_check_mark: I have read the CONTRIBUTING document.

### Summary

The commit added in this PR solves the issue with `resources/githooks/pre-commit`. Basically, there was an environment variable creating this issue (take a look [here](https://stackoverflow.com/questions/56023577/why-does-git-commands-fail-when-run-as-part-of-a-git-hook-in-a-subfolder)), so I used `os.unsetenv` to solve it.

### Details and comments

Ref issue #380
