### PR TITLE
Rename dynamic_data_access_union_discriminator executable

### DIFF
--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c++11/CMakeLists.txt
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c++11/CMakeLists.txt
@@ -20,21 +20,21 @@ if(NOT RTIConnextDDS_FOUND)
     )
 endif()
 
-add_executable(dynamic_data_union_example_cxx2
+add_executable(dynamic_data_union_example_cxx2_1
     "${CMAKE_CURRENT_SOURCE_DIR}/dynamic_data_union_example.cxx"
 )
 
-target_link_libraries(dynamic_data_union_example_cxx2
+target_link_libraries(dynamic_data_union_example_cxx2_1
     PRIVATE
         RTIConnextDDS::cpp2_api
 )
 
-set_target_properties(dynamic_data_union_example_cxx2
+set_target_properties(dynamic_data_union_example_cxx2_1
     PROPERTIES
         OUTPUT_NAME "dynamic_data_union_example")
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    set_target_properties(dynamic_data_union_example_cxx2
+    set_target_properties(dynamic_data_union_example_cxx2_1
         PROPERTIES
             LINK_FLAGS -Wl,--no-as-needed)
 endif()


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->
:white_check_mark: I have updated the documentation accordingly.
:white_check_mark: I have read the CONTRIBUTING document.


### Summary

There is a compilation error because there are two executables with the same name and I just renamed one of them.

### Details and comments

Ref issue #388 