### PR TITLE
Even out with rticonnextdds-cmake-utils repository

### DIFF
--- a/resources/cmake/FindRTIConnextDDS.cmake
+++ b/resources/cmake/FindRTIConnextDDS.cmake
@@ -1117,11 +1117,7 @@ if(CONNEXTDDS_ARCH MATCHES "Linux")
         "-lrt"
         "-rdynamic"
     )
-    if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "6.0.0")
-        list(APPEND CONNEXTDDS_EXTERNAL_LIBS
-            "-no-pie"
-        )
-    endif()
+
     set(CONNEXTDDS_COMPILE_DEFINITIONS
         "RTI_UNIX"
         "RTI_LINUX"
@@ -1313,8 +1309,8 @@ if(distributed_logger IN_LIST RTIConnextDDS_FIND_COMPONENTS
             CMAKE_COMPILER_VERSION VERSION_GREATER "4.6.0" AND
             RTICONNEXTDDS_VERSION VERSION_LESS "6.1.0"
         )
-            list(APPEND CONNEXTDDS_EXTERNAL_LIBS
-                -Wl,--no-as-needed
+            list(PREPEND CONNEXTDDS_EXTERNAL_LIBS
+                "-Wl,--no-as-needed"
             )
         endif()
     else()
@@ -1502,7 +1498,7 @@ if(security_plugins IN_LIST RTIConnextDDS_FIND_COMPONENTS)
         )
 
         # Add OpenSSL libraries to the list of CONNEXTDDS_EXTERNAL_LIBS
-        list(APPEND CONNEXTDDS_EXTERNAL_LIBS
+        list(PREPEND CONNEXTDDS_EXTERNAL_LIBS
             ${OPENSSL_SSL_LIBRARY}
             ${OPENSSL_CRYPTO_LIBRARY}
         )
@@ -1523,7 +1519,7 @@ if(monitoring_libraries IN_LIST RTIConnextDDS_FIND_COMPONENTS)
 
     if(MONITORING_FOUND)
         if(CONNEXTDDS_ARCH MATCHES "Win")
-            list(APPEND CONNEXTDDS_EXTERNAL_LIBS
+            list(PREPEND CONNEXTDDS_EXTERNAL_LIBS
                 psapi
             )
         endif()

--- a/resources/cmake/FindRTIConnextDDS.cmake
+++ b/resources/cmake/FindRTIConnextDDS.cmake
@@ -1,9 +1,14 @@
 #.rst:
 # (c) 2017 Copyright, Real-Time Innovations, Inc. All rights reserved.
+#
 # RTI grants Licensee a license to use, modify, compile, and create derivative
-# works of this file solely for use with RTI Connext DDS.  Licensee may
-# redistribute copies of this file provided that all such copies are subject
-# to this license.
+# works of the software solely for use with RTI Connext DDS.  Licensee may
+# redistribute copies of the software provided that all such copies are
+# subject to this license. The software is provided "as is", with no warranty
+# of any type, including any warranty for fitness for any purpose. RTI is
+# under no obligation to maintain or support the software.  RTI shall not be
+# liable for any incidental or consequential damages arising out of the use or
+# inability to use the software.
 #
 # FindRTIConnextDDS
 # -----------------
@@ -1110,7 +1115,13 @@ if(CONNEXTDDS_ARCH MATCHES "Linux")
         "-lm"
         "-lpthread"
         "-lrt"
+        "-rdynamic"
     )
+    if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "6.0.0")
+        list(APPEND CONNEXTDDS_EXTERNAL_LIBS
+            "-no-pie"
+        )
+    endif()
     set(CONNEXTDDS_COMPILE_DEFINITIONS
         "RTI_UNIX"
         "RTI_LINUX"
@@ -1302,8 +1313,9 @@ if(distributed_logger IN_LIST RTIConnextDDS_FIND_COMPONENTS
             CMAKE_COMPILER_VERSION VERSION_GREATER "4.6.0" AND
             RTICONNEXTDDS_VERSION VERSION_LESS "6.1.0"
         )
-           set(CONNEXTDDS_EXTERNAL_LIBS
-               -Wl,--no-as-needed  ${CONNEXTDDS_EXTERNAL_LIBS})
+            list(APPEND CONNEXTDDS_EXTERNAL_LIBS
+                -Wl,--no-as-needed
+            )
         endif()
     else()
         set(RTIConnextDDS_distributed_logger_FOUND FALSE)
@@ -1490,10 +1502,9 @@ if(security_plugins IN_LIST RTIConnextDDS_FIND_COMPONENTS)
         )
 
         # Add OpenSSL libraries to the list of CONNEXTDDS_EXTERNAL_LIBS
-        set(CONNEXTDDS_EXTERNAL_LIBS
+        list(APPEND CONNEXTDDS_EXTERNAL_LIBS
             ${OPENSSL_SSL_LIBRARY}
             ${OPENSSL_CRYPTO_LIBRARY}
-            ${CONNEXTDDS_EXTERNAL_LIBS}
         )
 
         set(RTIConnextDDS_security_plugins_FOUND TRUE)
@@ -1512,7 +1523,9 @@ if(monitoring_libraries IN_LIST RTIConnextDDS_FIND_COMPONENTS)
 
     if(MONITORING_FOUND)
         if(CONNEXTDDS_ARCH MATCHES "Win")
-            set(CONNEXTDDS_EXTERNAL_LIBS psapi ${CONNEXTDDS_EXTERNAL_LIBS})
+            list(APPEND CONNEXTDDS_EXTERNAL_LIBS
+                psapi
+            )
         endif()
         set(RTIConnextDDS_monitoring_libraries_FOUND TRUE)
     else()


### PR DESCRIPTION
:white_check_mark: I have updated the documentation accordingly.
:white_check_mark: I have read the CONTRIBUTING document.

### Summary

Even out with the cmake-utils repository

### Details and comments
Closes #412 
Check rticommunity/rticonnextdds-cmake-utils#21
