### PR TITLE
Divide the linux_static_analysis script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
       # Install the dependencies to run the Python scripts.
       - name: Install dependencies
         run: |
-          pip install Sultan scan-build
+          pip install scan-build
 
       # This script downloads the mandatory libraries of RTI Connext DDS for
       # compiling the examples
@@ -107,10 +107,14 @@ jobs:
           RTI_MIN_PACKAGE_URL: ${{ secrets.RTI_MIN_PACKAGE_URL }}
 
       # This script will compile the examples and execute the static analysis.
-      - name: Run static analysis
+      - name: Build all the examples
+        run: python resources/ci_cd/linux_build.py
+        env:
+          RTI_PACKAGE_VERSION: ${{ secrets.RTI_PACKAGE_VERSION }}
+
+      - name: Peform the static analysis
         run: python resources/ci_cd/linux_static_analysis.py
         env:
-          RTI_MIN_PACKAGE_URL: ${{ secrets.RTI_MIN_PACKAGE_URL }}
           RTI_PACKAGE_VERSION: ${{ secrets.RTI_PACKAGE_VERSION }}
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,13 +109,9 @@ jobs:
       # This script will compile the examples and execute the static analysis.
       - name: Build all the examples
         run: python resources/ci_cd/linux_build.py
-        env:
-          RTI_PACKAGE_VERSION: ${{ secrets.RTI_PACKAGE_VERSION }}
 
       - name: Peform the static analysis
         run: python resources/ci_cd/linux_static_analysis.py
-        env:
-          RTI_PACKAGE_VERSION: ${{ secrets.RTI_PACKAGE_VERSION }}
 
 
   commentpr:

--- a/resources/ci_cd/linux_build.py
+++ b/resources/ci_cd/linux_build.py
@@ -23,16 +23,32 @@ from pathlib import Path
 
 def main():
     rti_connext_dds_version = os.getenv("RTI_PACKAGE_VERSION")
+    rti_installation_path = os.getenv("RTI_INSTALLATION_PATH")
+    rti_installation_path = (
+        Path(rti_installation_path)
+        if rti_installation_path is not None
+        else Path.home()
+    )
 
     if not rti_connext_dds_version:
         sys.exit(
             "Environment variable RTI_PACKAGE_VERSION not found, skipping..."
         )
 
+    if not rti_installation_path.exists():
+        sys.exit("The RTI_INSTALLATION_PATH does not exist.")
+
     try:
         examples_dir = Path("examples/connext_dds").resolve(strict=True)
     except FileNotFoundError:
         sys.exit("Error: Examples directory not found.")
+
+    try:
+        rti_connext_dds_dir = rti_installation_path.joinpath(
+            "rti_connext_dds-{}".format(rti_connext_dds_version)
+        ).resolve(strict=True)
+    except FileNotFoundError:
+        sys.exit("Error: RTIConnextDDS not found.")
 
     build_dir = examples_dir.joinpath("build")
 
@@ -47,6 +63,7 @@ def main():
             "-DBUILD_SHARED_LIBS=ON",
             "-DCMAKE_BUILD_TYPE=Release",
             "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+            f"-DCONNEXTDDS_DIR={rti_connext_dds_dir}",
             examples_dir,
         ],
         cwd=build_dir,

--- a/resources/ci_cd/linux_build.py
+++ b/resources/ci_cd/linux_build.py
@@ -36,17 +36,6 @@ def main():
 
     build_dir = examples_dir.joinpath("build")
 
-    try:
-        rti_connext_dds_dir = (
-            Path.home()
-            .joinpath(
-                "rti_connext_dds-{}".format(rti_connext_dds_version), "include"
-            )
-            .resolve(strict=True)
-        )
-    except FileNotFoundError:
-        sys.exit("Error: RTIConnextDDS not found.")
-
     build_dir.mkdir(exist_ok=True)
 
     print("[RTICommunity] Generating build system...", flush=True)

--- a/resources/ci_cd/linux_build.py
+++ b/resources/ci_cd/linux_build.py
@@ -22,18 +22,12 @@ from pathlib import Path
 
 
 def main():
-    rti_connext_dds_version = os.getenv("RTI_PACKAGE_VERSION")
     rti_installation_path = os.getenv("RTI_INSTALLATION_PATH")
     rti_installation_path = (
         Path(rti_installation_path)
         if rti_installation_path is not None
         else Path.home()
     )
-
-    if not rti_connext_dds_version:
-        sys.exit(
-            "Environment variable RTI_PACKAGE_VERSION not found, skipping..."
-        )
 
     if not rti_installation_path.exists():
         sys.exit("The RTI_INSTALLATION_PATH does not exist.")
@@ -43,13 +37,14 @@ def main():
     except FileNotFoundError:
         sys.exit("Error: Examples directory not found.")
 
-    try:
-        rti_connext_dds_dir = rti_installation_path.joinpath(
-            "rti_connext_dds-{}".format(rti_connext_dds_version)
-        ).resolve(strict=True)
-    except FileNotFoundError:
+    found_rti_connext_dds = list(
+        rti_installation_path.glob("rti_connext_dds-?.?.?")
+    )
+
+    if len(found_rti_connext_dds) == 0:
         sys.exit("Error: RTIConnextDDS not found.")
 
+    rti_connext_dds_dir = found_rti_connext_dds[0]
     build_dir = examples_dir.joinpath("build")
 
     build_dir.mkdir(exist_ok=True)

--- a/resources/ci_cd/linux_build.py
+++ b/resources/ci_cd/linux_build.py
@@ -74,7 +74,7 @@ def main():
         cwd=build_dir,
     )
 
-    if building_result.returncode != 0:
+    if building_result.returncode:
         sys.exit("There was some errors during build.")
 
 

--- a/resources/ci_cd/linux_build.py
+++ b/resources/ci_cd/linux_build.py
@@ -64,7 +64,7 @@ def main():
         cwd=build_dir,
     )
 
-    if build_gen_result.returncode != 0:
+    if build_gen_result.returncode:
         sys.exit("There was some errors during generating the build system.")
 
     print("\n[RTICommunity] Compiling the examples...", flush=True)

--- a/resources/ci_cd/linux_build.py
+++ b/resources/ci_cd/linux_build.py
@@ -22,14 +22,11 @@ from pathlib import Path
 
 
 def main():
-    rti_installation_path = os.getenv("RTI_INSTALLATION_PATH")
-    rti_installation_path = (
-        Path(rti_installation_path)
-        if rti_installation_path is not None
-        else Path.home()
-    )
-
-    if not rti_installation_path.exists():
+    try:
+        rti_installation_path = Path(
+            os.getenv("RTI_INSTALLATION_PATH") or Path.home()
+        ).resolve(strict=True)
+    except FileNotFoundError:
         sys.exit("The RTI_INSTALLATION_PATH does not exist.")
 
     try:

--- a/resources/ci_cd/linux_build.py
+++ b/resources/ci_cd/linux_build.py
@@ -41,7 +41,7 @@ def main():
         rti_installation_path.glob("rti_connext_dds-?.?.?")
     )
 
-    if len(found_rti_connext_dds) == 0:
+    if not found_rti_connext_dds:
         sys.exit("Error: RTIConnextDDS not found.")
 
     rti_connext_dds_dir = found_rti_connext_dds[0]

--- a/resources/ci_cd/linux_install.py
+++ b/resources/ci_cd/linux_install.py
@@ -46,19 +46,17 @@ class ZipFileWithPermissions(ZipFile):
 
 def main():
     rti_minimal_package_url = os.getenv("RTI_MIN_PACKAGE_URL")
-    rti_installation_path = os.getenv("RTI_INSTALLATION_PATH")
-    rti_installation_path = (
-        Path(rti_installation_path)
-        if rti_installation_path is not None
-        else Path.home()
-    )
 
     if not rti_minimal_package_url:
         sys.exit(
             "Environment variable RTI_MIN_PACKAGE_URL not found, skipping..."
         )
 
-    if not rti_installation_path.exists():
+    try:
+        rti_installation_path = Path(
+            os.getenv("RTI_INSTALLATION_PATH") or Path.home()
+        ).resolve(strict=True)
+    except FileNotFoundError:
         sys.exit("The RTI_INSTALLATION_PATH does not exist.")
 
     try:

--- a/resources/ci_cd/linux_install.py
+++ b/resources/ci_cd/linux_install.py
@@ -46,8 +46,11 @@ class ZipFileWithPermissions(ZipFile):
 
 def main():
     rti_minimal_package_url = os.getenv("RTI_MIN_PACKAGE_URL")
+    rti_installation_path = os.getenv("RTI_INSTALLATION_PATH")
     rti_installation_path = (
-        Path(os.getenv("RTI_INSTALLATION_PATH")) or Path.home()
+        Path(rti_installation_path)
+        if rti_installation_path is not None
+        else Path.home()
     )
 
     if not rti_minimal_package_url:
@@ -56,7 +59,7 @@ def main():
         )
 
     if not rti_installation_path.exists():
-        sys.exit("The RTI_INSTALALTION_PATH does not exist.")
+        sys.exit("The RTI_INSTALLATION_PATH does not exist.")
 
     try:
         resp = request.urlopen(rti_minimal_package_url)

--- a/resources/ci_cd/linux_install.py
+++ b/resources/ci_cd/linux_install.py
@@ -46,7 +46,9 @@ class ZipFileWithPermissions(ZipFile):
 
 def main():
     rti_minimal_package_url = os.getenv("RTI_MIN_PACKAGE_URL")
-    rti_installation_path = os.getenv("RTI_INSTALLATION_PATH") or Path.home()
+    rti_installation_path = (
+        Path(os.getenv("RTI_INSTALLATION_PATH")) or Path.home()
+    )
 
     if not rti_minimal_package_url:
         sys.exit(

--- a/resources/ci_cd/linux_install.py
+++ b/resources/ci_cd/linux_install.py
@@ -24,8 +24,6 @@ from pathlib import Path
 from zipfile import ZipFile, ZipInfo
 from urllib.error import URLError
 
-HOME_PATH = Path.home()
-
 
 class ZipFileWithPermissions(ZipFile):
     """Custom ZipFile class handling file permissions.
@@ -48,11 +46,15 @@ class ZipFileWithPermissions(ZipFile):
 
 def main():
     rti_minimal_package_url = os.getenv("RTI_MIN_PACKAGE_URL")
+    rti_installation_path = os.getenv("RTI_INSTALLATION_PATH") or Path.home()
 
     if not rti_minimal_package_url:
         sys.exit(
             "Environment variable RTI_MIN_PACKAGE_URL not found, skipping..."
         )
+
+    if not rti_installation_path.exists():
+        sys.exit("The RTI_INSTALALTION_PATH does not exist.")
 
     try:
         resp = request.urlopen(rti_minimal_package_url)
@@ -68,7 +70,7 @@ def main():
             if bad_file_name:
                 sys.exit("Bad file found in the archive.")
 
-            rti_zipfile.extractall(HOME_PATH)
+            rti_zipfile.extractall(rti_installation_path)
     except zipfile.BadZipFile as e:
         sys.exit("Error opening zip file: {}".format(e))
 

--- a/resources/ci_cd/linux_static_analysis.py
+++ b/resources/ci_cd/linux_static_analysis.py
@@ -42,7 +42,7 @@ def main():
         rti_installation_path.glob("rti_connext_dds-?.?.?")
     )
 
-    if found_rti_connext_dds:
+    if not found_rti_connext_dds:
         sys.exit("Error: RTIConnextDDS not found.")
 
     rti_connext_dds_dir = found_rti_connext_dds[0]

--- a/resources/ci_cd/linux_static_analysis.py
+++ b/resources/ci_cd/linux_static_analysis.py
@@ -24,7 +24,9 @@ from pathlib import Path
 
 def main():
     rti_connext_dds_version = os.getenv("RTI_PACKAGE_VERSION")
-    rti_installation_path = os.getenv("RTI_INSTALLATION_PATH") or Path.home()
+    rti_installation_path = (
+        Path(os.getenv("RTI_INSTALLATION_PATH")) or Path.home()
+    )
 
     if not rti_connext_dds_version:
         sys.exit(
@@ -43,13 +45,9 @@ def main():
         )
 
     try:
-        rti_connext_dds_dir = (
-            rti_installation_path
-            .joinpath(
-                "rti_connext_dds-{}".format(rti_connext_dds_version), "include"
-            )
-            .resolve(strict=True)
-        )
+        rti_connext_dds_dir = rti_installation_path.joinpath(
+            "rti_connext_dds-{}".format(rti_connext_dds_version), "include"
+        ).resolve(strict=True)
     except FileNotFoundError:
         sys.exit("Error: RTIConnextDDS not found.")
 

--- a/resources/ci_cd/linux_static_analysis.py
+++ b/resources/ci_cd/linux_static_analysis.py
@@ -24,8 +24,11 @@ from pathlib import Path
 
 def main():
     rti_connext_dds_version = os.getenv("RTI_PACKAGE_VERSION")
+    rti_installation_path = os.getenv("RTI_INSTALLATION_PATH")
     rti_installation_path = (
-        Path(os.getenv("RTI_INSTALLATION_PATH")) or Path.home()
+        Path(rti_installation_path)
+        if rti_installation_path is not None
+        else Path.home()
     )
 
     if not rti_connext_dds_version:

--- a/resources/ci_cd/linux_static_analysis.py
+++ b/resources/ci_cd/linux_static_analysis.py
@@ -23,7 +23,6 @@ from pathlib import Path
 
 
 def main():
-    rti_connext_dds_version = os.getenv("RTI_PACKAGE_VERSION")
     rti_installation_path = os.getenv("RTI_INSTALLATION_PATH")
     rti_installation_path = (
         Path(rti_installation_path)
@@ -31,13 +30,8 @@ def main():
         else Path.home()
     )
 
-    if not rti_connext_dds_version:
-        sys.exit(
-            "Environment variable RTI_PACKAGE_VERSION not found, skipping..."
-        )
-
     if not rti_installation_path.exists():
-        sys.exit("The RTI_INSTALALTION_PATH does not exist.")
+        sys.exit("The RTI_INSTALLATION_PATH does not exist.")
 
     try:
         build_dir = Path("examples/connext_dds/build").resolve(strict=True)
@@ -47,9 +41,18 @@ def main():
             "running this script."
         )
 
+    found_rti_connext_dds = list(
+        rti_installation_path.glob("rti_connext_dds-?.?.?")
+    )
+
+    if len(found_rti_connext_dds) == 0:
+        sys.exit("Error: RTIConnextDDS not found.")
+
+    rti_connext_dds_dir = found_rti_connext_dds[0]
+
     try:
-        rti_connext_dds_dir = rti_installation_path.joinpath(
-            "rti_connext_dds-{}".format(rti_connext_dds_version), "include"
+        rti_connext_dds_include_dir = rti_connext_dds_dir.joinpath(
+            "include"
         ).resolve(strict=True)
     except FileNotFoundError:
         sys.exit("Error: RTIConnextDDS not found.")
@@ -60,7 +63,7 @@ def main():
             "--verbose",
             "--status-bugs",
             "--exclude",
-            rti_connext_dds_dir,
+            rti_connext_dds_include_dir,
             "--exclude",
             ".",
             "-o",

--- a/resources/ci_cd/linux_static_analysis.py
+++ b/resources/ci_cd/linux_static_analysis.py
@@ -26,10 +26,9 @@ def main():
     try:
         rti_installation_path = Path(
             os.getenv("RTI_INSTALLATION_PATH") or Path.home()
-         ).resolve(strict=True)
+        ).resolve(strict=True)
     except FileNotFoundError:
         sys.exit("The RTI_INSTALLATION_PATH does not exist.")
-
 
     try:
         build_dir = Path("examples/connext_dds/build").resolve(strict=True)

--- a/resources/ci_cd/linux_static_analysis.py
+++ b/resources/ci_cd/linux_static_analysis.py
@@ -8,7 +8,7 @@
 # is under no obligation to maintain or support the Software.  RTI shall not be
 # liable for any incidental or consequential damages arising out of the use or
 # inability to use the software.
-"""Build all the examples.
+"""Run static analysis over all the built examples.
 
 The environment variable RTI_PACKAGE_VERSION must be assigned to find the
 correct RTIConnextDDS package version. Also, the examples must be compiled

--- a/resources/ci_cd/linux_static_analysis.py
+++ b/resources/ci_cd/linux_static_analysis.py
@@ -24,11 +24,15 @@ from pathlib import Path
 
 def main():
     rti_connext_dds_version = os.getenv("RTI_PACKAGE_VERSION")
+    rti_installation_path = os.getenv("RTI_INSTALLATION_PATH") or Path.home()
 
     if not rti_connext_dds_version:
         sys.exit(
             "Environment variable RTI_PACKAGE_VERSION not found, skipping..."
         )
+
+    if not rti_installation_path.exists():
+        sys.exit("The RTI_INSTALALTION_PATH does not exist.")
 
     try:
         build_dir = Path("examples/connext_dds/build").resolve(strict=True)
@@ -40,7 +44,7 @@ def main():
 
     try:
         rti_connext_dds_dir = (
-            Path.home()
+            rti_installation_path
             .joinpath(
                 "rti_connext_dds-{}".format(rti_connext_dds_version), "include"
             )

--- a/resources/ci_cd/linux_static_analysis.py
+++ b/resources/ci_cd/linux_static_analysis.py
@@ -23,12 +23,12 @@ from pathlib import Path
 
 
 def main():
-    rti_installation_path = os.getenv("RTI_INSTALLATION_PATH")
-    rti_installation_path = (
-        Path(rti_installation_path)
-        if rti_installation_path is not None
-        else Path.home()
-    )
+    try:
+        rti_installation_path = Path(
+            os.getenv("RTI_INSTALLATION_PATH") or Path.home()
+         ).resolve(strict=True)
+    except FileNotFoundError:
+        sys.exit("The RTI_INSTALLATION_PATH does not exist.")
 
     if not rti_installation_path.exists():
         sys.exit("The RTI_INSTALLATION_PATH does not exist.")

--- a/resources/ci_cd/linux_static_analysis.py
+++ b/resources/ci_cd/linux_static_analysis.py
@@ -30,8 +30,6 @@ def main():
     except FileNotFoundError:
         sys.exit("The RTI_INSTALLATION_PATH does not exist.")
 
-    if not rti_installation_path.exists():
-        sys.exit("The RTI_INSTALLATION_PATH does not exist.")
 
     try:
         build_dir = Path("examples/connext_dds/build").resolve(strict=True)

--- a/resources/ci_cd/linux_static_analysis.py
+++ b/resources/ci_cd/linux_static_analysis.py
@@ -43,7 +43,7 @@ def main():
         rti_installation_path.glob("rti_connext_dds-?.?.?")
     )
 
-    if len(found_rti_connext_dds) == 0:
+    if found_rti_connext_dds:
         sys.exit("Error: RTIConnextDDS not found.")
 
     rti_connext_dds_dir = found_rti_connext_dds[0]


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->

### Summary

The functionality of the linux_static_analysis script was divided into two scripts. This was done because, in the future Jenkins pipeline, Valgrind will be executed in parallel with the static analysis.

### Details and comments

close #442 

### Checks

<!-- Change the space between the square brackets to an `x` -->
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.
