### PR TITLE
Fixed the custom transport example. Doing other than a non-symmetric …

### DIFF
--- a/examples/connext_dds/custom_transport/c/FileTransport.c
+++ b/examples/connext_dds/custom_transport/c/FileTransport.c
@@ -1781,10 +1781,8 @@ RTI_INT32 NDDS_Transport_FILE_get_receive_interfaces_cEA(
     /* Set the meaningful bytes of the address */
     {
         struct in_addr ipAddr;
-        unsigned int ipAddrNetworkOrder;
 
         inet_aton(me->_property.address, &ipAddr);
-        ipAddrNetworkOrder = ipAddr.s_addr;
         memcpy(
                 interface_array_inout[0].address.network_ordered_value + 12,
                 &ipAddr,

--- a/examples/connext_dds/custom_transport/c/FileTransport.c
+++ b/examples/connext_dds/custom_transport/c/FileTransport.c
@@ -1785,14 +1785,10 @@ RTI_INT32 NDDS_Transport_FILE_get_receive_interfaces_cEA(
 
         inet_aton(me->_property.address, &ipAddr);
         ipAddrNetworkOrder = ipAddr.s_addr;
-        interface_array_inout[0].address.network_ordered_value[15] =
-                (ipAddrNetworkOrder) % 256;
-        interface_array_inout[0].address.network_ordered_value[14] =
-                (ipAddrNetworkOrder >> 8) % 256;
-        interface_array_inout[0].address.network_ordered_value[13] =
-                (ipAddrNetworkOrder >> 16) % 256;
-        interface_array_inout[0].address.network_ordered_value[12] =
-                (ipAddrNetworkOrder >> 24) % 256;
+        memcpy(
+                interface_array_inout[0].address.network_ordered_value + 12,
+                &ipAddr,
+                4);
     }
 
 


### PR DESCRIPTION
…IP address did not work because the example assumed the endianness. Using memcpy instead of shifting bytes fixes it

<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->

### Summary


### Details and comments


### Checks

<!-- Change the space between the square brackets to an `x` -->
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.
