### PR TITLE
Update CLOUD_DISCOVERY_SERVICE.xml to lower refresh_period

### DIFF
--- a/examples/connext_dds/real_time_wan_transport/c++98/CLOUD_DISCOVERY_SERVICE.xml
+++ b/examples/connext_dds/real_time_wan_transport/c++98/CLOUD_DISCOVERY_SERVICE.xml
@@ -2,6 +2,14 @@
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xsi:noNamespaceSchemaLocation="https://community.rti.com/schema/6.1.0/rti_cloud_discovery_service.xsd">
     <cloud_discovery_service name="AllDomains">
+        <forwarder>
+            <event>
+                <refresh_period>
+                    <sec>5</sec>
+                    <nanosec>0</nanosec>
+                </refresh_period>
+            </event>
+        </forwarder>
         <transport>
             <element>
                 <alias>builtin.udpv4_wan</alias>
@@ -17,6 +25,14 @@
     </cloud_discovery_service>
 
     <cloud_discovery_service name="AllDomainsSecure">
+        <forwarder>
+            <event>
+                <refresh_period>
+                    <sec>5</sec>
+                    <nanosec>0</nanosec>
+                </refresh_period>
+            </event>
+        </forwarder>
         <transport>
             <element>
                 <alias>builtin.udpv4_wan</alias>


### PR DESCRIPTION

### Summary
The default refresh_period is 60 seconds which can cause two participants to take a significant amount of time before data samples are exchanged.

### Details and comments
This change lowers the refresh period from the default 60 seconds down to 5 seconds to speed up initial startup

### Checks

<!-- Change the space between the square brackets to an `x` -->
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.
