### PR TITLE
Feature/hmaint 231

### DIFF
--- a/examples/routing_service/routing_service_file_adapter/cpp/README.md
+++ b/examples/routing_service/routing_service_file_adapter/cpp/README.md
@@ -46,7 +46,6 @@ cmake --build .
 **Note**: when compiling on a Windows 64-bit machine you will need to add the
 `-A x64` parameter to the call to CMake.
 
-
 **Note:** If you are using a multi-configuration generator, such as Visual Studio
 Solutions, you can specify the configuration mode to build as follows:
 

--- a/examples/routing_service/routing_service_file_adapter/cpp/README.md
+++ b/examples/routing_service/routing_service_file_adapter/cpp/README.md
@@ -43,6 +43,10 @@ $cmake -DCONNEXTDDS_DIR=<Connext DDS Directory>
 cmake --build .
 ```
 
+**Note**: when compiling on a Windows 64-bit machine you will need to add the
+`-A x64` parameter to the call to CMake.
+
+
 **Note:** If you are using a multi-configuration generator, such as Visual Studio
 Solutions, you can specify the configuration mode to build as follows:
 

--- a/examples/routing_service/routing_service_shapes_processor/cpp/README.md
+++ b/examples/routing_service/routing_service_shapes_processor/cpp/README.md
@@ -17,7 +17,7 @@ cmake -DBUILD_SHARED_LIBS=ON ..
 ```
 
 **Note**: when compiling on a Windows 64-bit machine you will need to add the
-`-A x64` parameter to the call to CMake. See 
+`-A x64` parameter to the call to CMake. See
 [Customizing the Build](#customizing-the-build) for more details.
 
 Once you have run CMake, you will find a number of new files in your build

--- a/examples/routing_service/routing_service_shapes_processor/cpp/README.md
+++ b/examples/routing_service/routing_service_shapes_processor/cpp/README.md
@@ -16,6 +16,10 @@ cd build
 cmake -DBUILD_SHARED_LIBS=ON ..
 ```
 
+**Note**: when compiling on a Windows 64-bit machine you will need to add the
+`-A x64` parameter to the call to CMake. See 
+[Customizing the Build](#customizing-the-build) for more details.
+
 Once you have run CMake, you will find a number of new files in your build
 directory (the list of generated files will depend on the specific CMake
 Generator). To build the example, run CMake as follows:


### PR DESCRIPTION
### Summary

Clarifying the use of -A x64 for Win 64 builds.

### Details and comments

Very simple changes, just modifying `.md` files.

### Checks
-   [X] I have updated the documentation accordingly.
-   [X] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.
