### PR TITLE
Deactivate C# linter temporarily

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -32,9 +32,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.7
       - name: Install necessary tools
-        run: pip install black==22.1.0
+        run: pip install black==22.3.0
       - name: Perform format check in a pull request
         if: github.event_name == 'pull_request'
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Install necessary tools
         run: pip install black==22.1.0
       - name: Perform format check in a pull request

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Install necessary tools
-        run: pip install black==21.5b1
+        run: pip install black==22.1.0
       - name: Perform format check in a pull request
         if: github.event_name == 'pull_request'
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/lint_source.yml
+++ b/.github/workflows/lint_source.yml
@@ -12,7 +12,6 @@ on:
     paths:
       - '**/*.[ch]x?x?'
       - '**/*.java'
-      - '**/*.cs'
 
 jobs:
   lint-sourcecode:

--- a/examples/recording_service/pluggable_storage/c/FileStorageReader.c
+++ b/examples/recording_service/pluggable_storage/c/FileStorageReader.c
@@ -217,35 +217,39 @@ int FileStorageStreamInfoReader_initialize(
     }
 
     if (RTIOsapiUtility_strncpy(
-            stream_reader->file_record.fileName,
-            FILENAME_MAX,
-            fileName,
-            strlen(fileName)) == NULL) {
+                stream_reader->file_record.fileName,
+                FILENAME_MAX,
+                fileName,
+                strlen(fileName))
+        == NULL) {
         printf("%s: %s\n", "Failed to copy string", fileName);
         return FALSE;
     }
     if (RTIOsapiUtility_strncpy(
-            stream_reader->info_file_record.fileName,
-            FILENAME_MAX,
-            fileName,
-            strlen(fileName)) == NULL) {
+                stream_reader->info_file_record.fileName,
+                FILENAME_MAX,
+                fileName,
+                strlen(fileName))
+        == NULL) {
         printf("%s: %s\n", "Failed to copy string", fileName);
         return FALSE;
     }
 
     if (RTIOsapiUtility_strncat(
-            stream_reader->info_file_record.fileName,
-            FILENAME_MAX,
-            ".info",
-            strlen(".info")) == NULL) {
+                stream_reader->info_file_record.fileName,
+                FILENAME_MAX,
+                ".info",
+                strlen(".info"))
+        == NULL) {
         printf("%s: %s\n", "Failed to append string", ".info");
         return FALSE;
     }
 
     if (RTI_fopen(
-            &stream_reader->info_file_record.file,
-            stream_reader->info_file_record.fileName,
-            "r") != 0) {
+                &stream_reader->info_file_record.file,
+                stream_reader->info_file_record.fileName,
+                "r")
+        != 0) {
         perror("Failed to open info file");
         return FALSE;
     }
@@ -377,10 +381,10 @@ int FileStorageStreamReader_addSampleToData(
     current_info = DDS_SampleInfoSeq_get_reference(
             &stream_reader->taken_info,
             current_length);
-    current_info->reception_timestamp.sec = (DDS_Long)(
-            stream_reader->current_timestamp / (int64_t) NANOSECS_PER_SEC);
-    current_info->reception_timestamp.nanosec = (DDS_Long)(
-            stream_reader->current_timestamp % (int64_t) NANOSECS_PER_SEC);
+    current_info->reception_timestamp.sec =
+            (DDS_Long) (stream_reader->current_timestamp / (int64_t) NANOSECS_PER_SEC);
+    current_info->reception_timestamp.nanosec =
+            (DDS_Long) (stream_reader->current_timestamp % (int64_t) NANOSECS_PER_SEC);
     current_info->valid_data =
             (stream_reader->current_valid_data ? DDS_BOOLEAN_TRUE
                                                : DDS_BOOLEAN_FALSE);
@@ -542,18 +546,20 @@ int FileStorageStreamReader_initialize(
     }
 
     if (RTIOsapiUtility_strncpy(
-            stream_reader->file_record.fileName,
-            FILENAME_MAX,
-            file_name,
-            strlen(file_name)) == NULL) {
+                stream_reader->file_record.fileName,
+                FILENAME_MAX,
+                file_name,
+                strlen(file_name))
+        == NULL) {
         printf("%s: %s\n", "Failed to copy string", file_name);
         return FALSE;
     }
 
     if (RTI_fopen(
-            &stream_reader->file_record.file,
-            stream_reader->file_record.fileName,
-            "r") != 0) {
+                &stream_reader->file_record.file,
+                stream_reader->file_record.fileName,
+                "r")
+        != 0) {
         perror("Failed to open record file");
         return FALSE;
     }
@@ -625,10 +631,10 @@ void FileStorageReader_delete_stream_reader(
  * the given end time.
  */
 struct RTI_RecordingServiceStorageStreamReader *
-        FileStorageReader_create_stream_reader(
-                void *storage_reader_data,
-                const struct RTI_RoutingServiceStreamInfo *stream_info,
-                const struct RTI_RoutingServiceProperties *properties)
+FileStorageReader_create_stream_reader(
+        void *storage_reader_data,
+        const struct RTI_RoutingServiceStreamInfo *stream_info,
+        const struct RTI_RoutingServiceProperties *properties)
 {
     struct FileStorageReader *storage_reader =
             (struct FileStorageReader *) storage_reader_data;
@@ -724,9 +730,9 @@ void FileStorageReader_delete_stream_info_reader(
  * time should be ignored - this is, not discovered).
  */
 struct RTI_RecordingServiceStorageStreamInfoReader *
-        FileStorageReader_create_stream_info_reader(
-                void *storage_reader_data,
-                const struct RTI_RoutingServiceProperties *properties)
+FileStorageReader_create_stream_info_reader(
+        void *storage_reader_data,
+        const struct RTI_RoutingServiceProperties *properties)
 {
     struct FileStorageReader *storage_reader =
             (struct FileStorageReader *) storage_reader_data;
@@ -807,10 +813,11 @@ struct RTI_RecordingServiceStorageReader *FileStorageReader_create(
     }
 
     if (RTIOsapiUtility_strncpy(
-            storage_reader->file_name,
-            FileStorageReader_FILE_NAME_MAX,
-            file_name,
-            strlen(file_name)) == NULL) {
+                storage_reader->file_name,
+                FileStorageReader_FILE_NAME_MAX,
+                file_name,
+                strlen(file_name))
+        == NULL) {
         printf("%s: %s\n", "Failed to copy string", file_name);
         return FALSE;
     }

--- a/examples/recording_service/pluggable_storage/c/FileStorageWriter.c
+++ b/examples/recording_service/pluggable_storage/c/FileStorageWriter.c
@@ -204,24 +204,29 @@ int FileStorageWriter_connect(void *storage_writer_data)
     }
 
     if (RTIOsapiUtility_strncpy(
-            writer->info_file.file_name,
-            FileStorageWriter_FILE_NAME_MAX,
-            writer->file.file_name,
-            strlen(writer->file.file_name)) == NULL) {
+                writer->info_file.file_name,
+                FileStorageWriter_FILE_NAME_MAX,
+                writer->file.file_name,
+                strlen(writer->file.file_name))
+        == NULL) {
         printf("%s: %s\n", "Failed to copy string", writer->file.file_name);
         return FALSE;
     }
 
     if (RTIOsapiUtility_strncat(
-            writer->info_file.file_name,
-            FileStorageWriter_FILE_NAME_MAX,
-            FileStorageWriter_INFO_EXT,
-            strlen(FileStorageWriter_INFO_EXT)) == NULL) {
-        printf("%s: %s\n", "Failed to append string", FileStorageWriter_INFO_EXT);
+                writer->info_file.file_name,
+                FileStorageWriter_FILE_NAME_MAX,
+                FileStorageWriter_INFO_EXT,
+                strlen(FileStorageWriter_INFO_EXT))
+        == NULL) {
+        printf("%s: %s\n",
+               "Failed to append string",
+               FileStorageWriter_INFO_EXT);
         return FALSE;
     }
 
-    if (RTI_fopen(&writer->info_file.file, writer->info_file.file_name, "w") != 0) {
+    if (RTI_fopen(&writer->info_file.file, writer->info_file.file_name, "w")
+        != 0) {
         printf("%s: %s\n",
                "Failed to open file for writing",
                writer->info_file.file_name);
@@ -295,7 +300,7 @@ int FileStorageWriter_disconnect(void *storage_writer_data)
  * the case of the user-data creation function.
  */
 struct RTI_RecordingServiceStoragePublicationWriter *
-        FileStorageWriter_create_publication_writer(void *storage_writer_data)
+FileStorageWriter_create_publication_writer(void *storage_writer_data)
 {
     struct RTI_RecordingServiceStoragePublicationWriter *stream_writer = NULL;
 
@@ -335,10 +340,10 @@ struct RTI_RecordingServiceStoragePublicationWriter *
  * HelloMsg topic/type defined in the example.
  */
 struct RTI_RecordingServiceStorageStreamWriter *
-        FileStorageWriter_create_stream_writer(
-                void *storage_writer_data,
-                const struct RTI_RoutingServiceStreamInfo *stream_info,
-                const struct RTI_RoutingServiceProperties *properties)
+FileStorageWriter_create_stream_writer(
+        void *storage_writer_data,
+        const struct RTI_RoutingServiceStreamInfo *stream_info,
+        const struct RTI_RoutingServiceProperties *properties)
 {
     struct FileStorageWriter *writer =
             (struct FileStorageWriter *) storage_writer_data;
@@ -446,10 +451,11 @@ int FileStorageWriter_initialize(
     }
 
     if (RTIOsapiUtility_strncpy(
-            writer->file.file_name,
-            FileStorageWriter_FILE_NAME_MAX,
-            file_name,
-            strlen(file_name)) == NULL) {
+                writer->file.file_name,
+                FileStorageWriter_FILE_NAME_MAX,
+                file_name,
+                strlen(file_name))
+        == NULL) {
         printf("%s: %s\n", "Failed to copy string", file_name);
         return FALSE;
     }

--- a/examples/recording_service/pluggable_storage/cpp/FileStorageReader.cxx
+++ b/examples/recording_service/pluggable_storage/cpp/FileStorageReader.cxx
@@ -61,9 +61,8 @@ FileStorageReader::~FileStorageReader()
 {
 }
 
-rti::recording::storage::StorageStreamInfoReader *
-        FileStorageReader::create_stream_info_reader(
-                const rti::routing::PropertySet &)
+rti::recording::storage::StorageStreamInfoReader *FileStorageReader::
+        create_stream_info_reader(const rti::routing::PropertySet &)
 {
     return new FileStorageStreamInfoReader(&info_file_);
 }
@@ -74,8 +73,8 @@ void FileStorageReader::delete_stream_info_reader(
     delete stream_info_reader;
 }
 
-rti::recording::storage::StorageStreamReader *
-        FileStorageReader::create_stream_reader(
+rti::recording::storage::StorageStreamReader *FileStorageReader::
+        create_stream_reader(
                 const rti::routing::StreamInfo &,
                 const rti::routing::PropertySet &)
 {
@@ -280,7 +279,7 @@ void FileStorageStreamReader::read(
         read_sampleInfo.valid_data =
                 current_valid_data_ ? DDS_BOOLEAN_TRUE : DDS_BOOLEAN_FALSE;
         read_sampleInfo.reception_timestamp.sec =
-                (DDS_Long)(current_timestamp_ / (int64_t) NANOSECS_PER_SEC);
+                (DDS_Long) (current_timestamp_ / (int64_t) NANOSECS_PER_SEC);
         read_sampleInfo.reception_timestamp.nanosec =
                 current_timestamp_ % (int64_t) NANOSECS_PER_SEC;
         dds::sub::SampleInfo *cpp_sample_info = new dds::sub::SampleInfo;

--- a/examples/recording_service/pluggable_storage/cpp/FileStorageWriter.cxx
+++ b/examples/recording_service/pluggable_storage/cpp/FileStorageWriter.cxx
@@ -83,16 +83,16 @@ FileStorageWriter::~FileStorageWriter()
     }
 }
 
-rti::recording::storage::StorageStreamWriter *
-        FileStorageWriter::create_stream_writer(
+rti::recording::storage::StorageStreamWriter *FileStorageWriter::
+        create_stream_writer(
                 const rti::routing::StreamInfo &stream_info,
                 const rti::routing::PropertySet &)
 {
     return new FileStreamWriter(data_file_, stream_info.stream_name());
 }
 
-rti::recording::storage::PublicationStorageWriter *
-        FileStorageWriter::create_publication_writer()
+rti::recording::storage::PublicationStorageWriter *FileStorageWriter::
+        create_publication_writer()
 {
     return new PubDiscoveryFileStreamWriter(pub_file_);
 }

--- a/resources/ci_cd/linux_format.py
+++ b/resources/ci_cd/linux_format.py
@@ -259,7 +259,6 @@ if __name__ == "__main__":
             ".hxx",
             ".c",
             ".cxx",
-            ".cs",
             ".java",
         }
         clang_format_cmd: List[str]


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->

### Summary

As the title states, the linting for C# was disabled temporarily until we find a new linter.

### Details and comments

close #495 

### Checks

<!-- Change te space between the square brackets to an `x` -->
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.
