### PR TITLE
Fixed CMakeLists.txt to only use standard CMake variables

### DIFF
--- a/examples/routing_service/routing_service_remote_admin/c++11/CMakeLists.txt
+++ b/examples/routing_service/routing_service_remote_admin/c++11/CMakeLists.txt
@@ -29,13 +29,13 @@ find_package(
 
 # Flags for code generation
 set(CODEGEN_FLAGS UNBOUNDED)
-set(IDL_GEN_CODE_OUTPUT_DIR "${CMAKE_SOURCE_DIR}/build/${RTI_ARCH}/generated/")
+set(IDL_GEN_CODE_OUTPUT_DIR "${CMAKE_SOURCE_DIR}/build/generated/")
 # Include the CodegenRTIConnextDDS cmake module
 include(ConnextDdsCodegen)
 
 connextdds_rtiddsgen_run(
     IDL_FILE
-      "$ENV{NDDSHOME}/resource/idl/ServiceCommon.idl"
+      "${CONNEXTDDS_DIR}/resource/idl/ServiceCommon.idl"
     LANG
       "C++11"
     OUTPUT_DIRECTORY
@@ -47,7 +47,7 @@ connextdds_rtiddsgen_run(
 
 connextdds_rtiddsgen_run(
     IDL_FILE
-      "$ENV{NDDSHOME}/resource/idl/ServiceAdmin.idl"
+      "${CONNEXTDDS_DIR}/resource/idl/ServiceAdmin.idl"
     LANG
       "C++11"
     OUTPUT_DIRECTORY


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->

### Summary


### Details and comments


### Checks

<!-- Change te space between the square brackets to an `x` -->
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.

<!-- Uncomment bellow if you added a C/C++ example and updated examples/connext_dds/CMakeList.txt -->
<!--
-   [ ] I have added a new C/C++ example and updated `examples/connext_dds/CMakeList.txt` accordingly.
-->
<!-- Uncomment bellow if you added a Java example and updated examples/connext_dds/settings.gradle -->
<!--
-   [ ] I have added a new Java example and updated `examples/connext_dds/settings.gradle` accordingly.
-->
