### PR TITLE
Fix typos in error handling for examples/connext_dds/dynamic_data_nes…

### DIFF
--- a/examples/connext_dds/dynamic_data_nested_structs/c/dynamic_data_nested_struct_example.c
+++ b/examples/connext_dds/dynamic_data_nested_structs/c/dynamic_data_nested_struct_example.c
@@ -188,7 +188,7 @@ int main()
     /* Creating the typeCode of the outer_struct that contains an inner_struct
      */
     outer_tc = outer_struct_get_typecode(factory);
-    if (inner_tc == NULL) {
+    if (outer_tc == NULL) {
         fprintf(stderr, "! Unable to create typeCode\n");
         goto fail;
     }
@@ -211,7 +211,7 @@ int main()
 
     inner_data =
             DDS_DynamicData_new(inner_tc, &DDS_DYNAMIC_DATA_PROPERTY_DEFAULT);
-    if (outer_data == NULL) {
+    if (inner_data == NULL) {
         fprintf(stderr, "! Unable to create inner dynamicData\n");
         goto fail;
     }


### PR DESCRIPTION


<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->

### Summary
Typos in error handling for examples/connext_dds/dynamic_data_nested_struct/c/dynamic_data_nested_struct_example.c

### Details and comments
The wrong variable is checked for error handling in lines 214 and 191.

fixes #510 

### Checks

<!-- Change te space between the square brackets to an `x` -->
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.

<!-- Uncomment bellow if you added a C/C++ example and updated examples/connext_dds/CMakeList.txt -->
<!--
-   [ ] I have added a new C/C++ example and updated `examples/connext_dds/CMakeList.txt` accordingly.
-->
<!-- Uncomment bellow if you added a Java example and updated examples/connext_dds/settings.gradle -->
<!--
-   [ ] I have added a new Java example and updated `examples/connext_dds/settings.gradle` accordingly.
-->
