### PR TITLE
Remove incorrect variable assignment

### DIFF
--- a/resources/cmake/ConnextDdsCodegen.cmake
+++ b/resources/cmake/ConnextDdsCodegen.cmake
@@ -446,7 +446,6 @@ function(_connextdds_codegen_get_generated_file_list)
             # Set in the parent scope
             set(${_CODEGEN_VAR}_GENERATED_SOURCES ${sources} PARENT_SCOPE)
             set(${_CODEGEN_VAR}_SOURCES ${sources} PARENT_SCOPE)
-            set(${_CODEGEN_VAR}_HEADERS ${headers} PARENT_SCOPE)
             set(${_CODEGEN_VAR}_PUBLISHER_SOURCE PARENT_SCOPE)
             set(${_CODEGEN_VAR}_SUBSCRIBER_SOURCE PARENT_SCOPE)
         endif()


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->

### Summary

`${_CODEGEN_VAR}_HEADERS` was being assigned to the value of a undeclared variable in the else statement. I removed the assignment because the `${_CODEGEN_VAR}_HEADERS` is being initialized outside the conditional block (right [here](https://github.com/rticommunity/rticonnextdds-examples/blob/master/resources/cmake/ConnextDdsCodegen.cmake#L431)).

### Details and comments

close #514 

### Checks

<!-- Change te space between the square brackets to an `x` -->
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.

<!-- Uncomment bellow if you added a C/C++ example and updated examples/connext_dds/CMakeList.txt -->
<!--
-   [ ] I have added a new C/C++ example and updated `examples/connext_dds/CMakeList.txt` accordingly.
-->
<!-- Uncomment bellow if you added a Java example and updated examples/connext_dds/settings.gradle -->
<!--
-   [ ] I have added a new Java example and updated `examples/connext_dds/settings.gradle` accordingly.
-->
