### PR TITLE
Adapt to environment variable naming to convention used in manual

### DIFF
--- a/examples/connext_dds/real_time_wan_transport/README.md
+++ b/examples/connext_dds/real_time_wan_transport/README.md
@@ -121,15 +121,15 @@ External Participant.
     configuration file. You can also use different numbers for the private UDP
     port (&lt;host&gt;) and the public UDP port (&lt;public&gt;).
 
-2)  Set the environment variable PUBLIC_ADDRESS to be the
-    public IP address in which the application will receive data. Usually this
+2)  Set the environment variables RTI_CDS_PORT and RTI_CDS_PUBLIC_ADDR to be the
+    public IP address and port where the application will receive data. Usually this
     is the public IP address of the NAT-enabled router behind which the
     application runs.
 
 `real_time_wan_transport_publisher`
 
-1)  Set the environment variable PUBLIC_ADDRESS to the public IP address in
-    which the ``real_time_wan_transport_subscriber`` application receives data.
+1)  Set the environment variables RTI_CDS_PORT and RTI_CDS_PUBLIC_ADDR to the public IP address
+    and port where the ``real_time_wan_transport_subscriber`` application receives data.
 
 ## Prerequisites before running scenario 3 or 4
 
@@ -153,8 +153,8 @@ router.
     with the new number in the XML configuration files `USER_QOS_PROFILES.xml`
     and `CLOUD_DISCOVERY_SERVICE.xml`.
 
-3)  Set the environment variable `PUBLIC_ADDRESS` to the public IP address in
-    which the Cloud Discovery services runs. This environment variable will
+3)  Set the environment variables RTI_CDS_PORT and `RTI_CDS_PUBLIC_ADDR` to the public IP address and port
+    where the Cloud Discovery services runs. This environment variable will
     have to be set for the publisher and subscriber applications and for RTI
     Cloud Discovery Service.
 

--- a/examples/connext_dds/real_time_wan_transport/c++98/CLOUD_DISCOVERY_SERVICE.xml
+++ b/examples/connext_dds/real_time_wan_transport/c++98/CLOUD_DISCOVERY_SERVICE.xml
@@ -5,11 +5,11 @@
         <transport>
             <element>
                 <alias>builtin.udpv4_wan</alias>
-                <receive_port>7400</receive_port>
+                <receive_port>$(RTI_CDS_PORT)</receive_port>
                 <property>
                     <element>
                         <name>dds.transport.UDPv4_WAN.builtin.public_address</name>
-                        <value>$(PUBLIC_ADDRESS)</value>
+                        <value>$(RTI_CDS_PUBLIC_ADDR)</value>
                     </element>
                     <element>
                         <name>dds.transport.UDPv4_WAN.builtin.parent.message_size_max</name>
@@ -37,11 +37,11 @@
         <transport>
             <element>
                 <alias>builtin.udpv4_wan</alias>
-                <receive_port>7400</receive_port>
+                <receive_port>$(RTI_CDS_PORT)</receive_port>
                 <property>
                     <element>
                         <name>dds.transport.UDPv4_WAN.builtin.public_address</name>
-                        <value>$(PUBLIC_ADDRESS)</value>
+                        <value>$(RTI_CDS_PUBLIC_ADDR)</value>
                     </element>
                     <element>
                         <name>dds.transport.UDPv4_WAN.builtin.parent.message_size_max</name>

--- a/examples/connext_dds/real_time_wan_transport/c++98/USER_QOS_PROFILES.xml
+++ b/examples/connext_dds/real_time_wan_transport/c++98/USER_QOS_PROFILES.xml
@@ -175,7 +175,7 @@
     <qos_profile name="Publisher_Scenario_1" base_name="Base_Profile">
       <participant_qos>
         <discovery>
-          <initial_peers>0@udpv4_wan://$(PUBLIC_ADDRESS):16000</initial_peers>
+          <initial_peers>0@udpv4_wan://$(RTI_CDS_PUBLIC_ADDR):$(RTI_CDS_PORT)</initial_peers>
         </discovery>
       </participant_qos>
     </qos_profile>
@@ -184,11 +184,11 @@
       <participant_qos>
         <transport_builtin>
           <udpv4_wan>
-            <public_address>$(PUBLIC_ADDRESS)</public_address>
+            <public_address>$(RTI_CDS_PUBLIC_ADDR)</public_address>
             <comm_ports>
               <default>
-                <host>16000</host>
-                <public>16000</public>
+                <host>$(RTI_CDS_PORT)</host>
+                <public>$(RTI_CDS_PORT)</public>
               </default>
             </comm_ports>
           </udpv4_wan>
@@ -223,7 +223,7 @@
     <qos_profile name="Publisher_Scenario_3" base_name="Base_Profile">
       <participant_qos>
         <discovery>
-          <initial_peers>rtps@udpv4_wan://$(PUBLIC_ADDRESS):7400</initial_peers>
+          <initial_peers>rtps@udpv4_wan://$(RTI_CDS_PUBLIC_ADDR):$(RTI_CDS_PORT)</initial_peers>
         </discovery>
       </participant_qos>
     </qos_profile>
@@ -231,7 +231,7 @@
     <qos_profile name="Subscriber_Scenario_3" base_name="Base_Profile">
       <participant_qos>
         <discovery>
-          <initial_peers>rtps@udpv4_wan://$(PUBLIC_ADDRESS):7400</initial_peers>
+          <initial_peers>rtps@udpv4_wan://$(RTI_CDS_PUBLIC_ADDR):$(RTI_CDS_PORT)</initial_peers>
         </discovery>
       </participant_qos>
     </qos_profile>


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->

### Summary
Adapt names of environment variables in cloud discovery service example to the names used in the manual.

### Details and comments
Fixes #521 

### Checks

<!-- Change te space between the square brackets to an `x` -->
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.

<!-- Uncomment bellow if you added a C/C++ example and updated examples/connext_dds/CMakeList.txt -->
<!--
-   [ ] I have added a new C/C++ example and updated `examples/connext_dds/CMakeList.txt` accordingly.
-->
<!-- Uncomment bellow if you added a Java example and updated examples/connext_dds/settings.gradle -->
<!--
-   [ ] I have added a new Java example and updated `examples/connext_dds/settings.gradle` accordingly.
-->
