### PR TITLE
Adds missing cmake_utils configure function to all the examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ gradle-app.setting
 .gradletasknamecache
 
 .settings
+
+.venv

--- a/examples/connext_dds/builtin_topics/c++98/CMakeLists.txt
+++ b/examples/connext_dds/builtin_topics/c++98/CMakeLists.txt
@@ -5,9 +5,11 @@
 # This code contains trade secrets of Real-Time Innovations, Inc.
 cmake_minimum_required(VERSION 3.11)
 project(rtiexamples-builtin-topics)
-set(CMAKE_MODULE_PATH
-    ${CMAKE_MODULE_PATH}
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../resources/cmake")
+list(APPEND CMAKE_MODULE_PATH
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../resources/cmake/Modules"
+)
+include(ConnextDdsConfigureCmakeUtils)
+connextdds_configure_cmake_utils()
 
 # Include ConnextDdsAddExample.cmake from resources/cmake
 include(ConnextDdsAddExample)

--- a/examples/connext_dds/dynamic_data_request_reply/c++11/CMakeLists.txt
+++ b/examples/connext_dds/dynamic_data_request_reply/c++11/CMakeLists.txt
@@ -5,10 +5,11 @@
 # This code contains trade secrets of Real-Time Innovations, Inc.
 cmake_minimum_required(VERSION 3.11)
 project(rtiexamples-dynamic-data-request_reply)
-set(CMAKE_MODULE_PATH
-    ${CMAKE_MODULE_PATH}
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../resources/cmake"
+list(APPEND CMAKE_MODULE_PATH
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../resources/cmake/Modules"
 )
+include(ConnextDdsConfigureCmakeUtils)
+connextdds_configure_cmake_utils()
 
 # Find the RTI Connext DDS libraries
 find_package(RTIConnextDDS

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++11/CMakeLists.txt
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++11/CMakeLists.txt
@@ -5,10 +5,11 @@
 # This code contains trade secrets of Real-Time Innovations, Inc.
 cmake_minimum_required(VERSION 3.11)
 project(rtiexamples-network-capture)
-set(CMAKE_MODULE_PATH
-    ${CMAKE_MODULE_PATH}
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../resources/cmake"
+list(APPEND CMAKE_MODULE_PATH
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../resources/cmake/Modules"
 )
+include(ConnextDdsConfigureCmakeUtils)
+connextdds_configure_cmake_utils()
 
 # Include ConnextDdsAddExample.cmake from resources/cmake
 include(ConnextDdsAddExample)

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++98/CMakeLists.txt
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++98/CMakeLists.txt
@@ -5,10 +5,11 @@
 # This code contains trade secrets of Real-Time Innovations, Inc.
 cmake_minimum_required(VERSION 3.11)
 project(rtiexamples-network-capture)
-set(CMAKE_MODULE_PATH
-    ${CMAKE_MODULE_PATH}
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../resources/cmake"
+list(APPEND CMAKE_MODULE_PATH
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../resources/cmake/Modules"
 )
+include(ConnextDdsConfigureCmakeUtils)
+connextdds_configure_cmake_utils()
 
 # Include ConnextDdsAddExample.cmake from resources/cmake
 include(ConnextDdsAddExample)

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c/CMakeLists.txt
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c/CMakeLists.txt
@@ -5,10 +5,11 @@
 # This code contains trade secrets of Real-Time Innovations, Inc.
 cmake_minimum_required(VERSION 3.11)
 project(rtiexamples-network-capture)
-set(CMAKE_MODULE_PATH
-    ${CMAKE_MODULE_PATH}
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../resources/cmake"
+list(APPEND CMAKE_MODULE_PATH
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../resources/cmake/Modules"
 )
+include(ConnextDdsConfigureCmakeUtils)
+connextdds_configure_cmake_utils()
 
 # Include ConnextDdsAddExample.cmake from resources/cmake
 include(ConnextDdsAddExample)

--- a/examples/connext_dds/network_capture/02_tcp/c/CMakeLists.txt
+++ b/examples/connext_dds/network_capture/02_tcp/c/CMakeLists.txt
@@ -5,10 +5,11 @@
 # This code contains trade secrets of Real-Time Innovations, Inc.
 cmake_minimum_required(VERSION 3.11)
 project(rtiexamples-network-capture)
-set(CMAKE_MODULE_PATH
-    ${CMAKE_MODULE_PATH}
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../resources/cmake"
+list(APPEND CMAKE_MODULE_PATH
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../resources/cmake/Modules"
 )
+include(ConnextDdsConfigureCmakeUtils)
+connextdds_configure_cmake_utils()
 
 # Include ConnextDdsAddExample.cmake from resources/cmake
 include(ConnextDdsAddExample)

--- a/examples/connext_dds/network_capture/03_security/c/CMakeLists.txt
+++ b/examples/connext_dds/network_capture/03_security/c/CMakeLists.txt
@@ -5,10 +5,11 @@
 # This code contains trade secrets of Real-Time Innovations, Inc.
 cmake_minimum_required(VERSION 3.11)
 project(rtiexamples-network-capture)
-set(CMAKE_MODULE_PATH
-    ${CMAKE_MODULE_PATH}
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../resources/cmake"
+list(APPEND CMAKE_MODULE_PATH
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../resources/cmake/Modules"
 )
+include(ConnextDdsConfigureCmakeUtils)
+connextdds_configure_cmake_utils()
 
 # Include ConnextDdsAddExample.cmake from resources/cmake
 include(ConnextDdsAddExample)

--- a/examples/connext_dds/network_capture/04_advanced_api/c/CMakeLists.txt
+++ b/examples/connext_dds/network_capture/04_advanced_api/c/CMakeLists.txt
@@ -5,10 +5,11 @@
 # This code contains trade secrets of Real-Time Innovations, Inc.
 cmake_minimum_required(VERSION 3.11)
 project(rtiexamples-builtin-topics)
-set(CMAKE_MODULE_PATH
-    ${CMAKE_MODULE_PATH}
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../resources/cmake"
+list(APPEND CMAKE_MODULE_PATH
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../resources/cmake/Modules"
 )
+include(ConnextDdsConfigureCmakeUtils)
+connextdds_configure_cmake_utils()
 
 # Include ConnextDdsAddExample.cmake from resources/cmake
 include(ConnextDdsAddExample)


### PR DESCRIPTION
Fixes #529

<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->

### Summary

Added missing `connextdds_configure_cmake_utils` CMake function call to the rest of the examples.

### Details and comments


### Checks

<!-- Change te space between the square brackets to an `x` -->
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.

<!-- Uncomment bellow if you added a C/C++ example and updated examples/connext_dds/CMakeList.txt -->
<!--
-   [ ] I have added a new C/C++ example and updated `examples/connext_dds/CMakeList.txt` accordingly.
-->
<!-- Uncomment bellow if you added a Java example and updated examples/connext_dds/settings.gradle -->
<!--
-   [ ] I have added a new Java example and updated `examples/connext_dds/settings.gradle` accordingly.
-->
