### PR TITLE
Python async pub example

### DIFF
--- a/examples/connext_dds/asynchronous_publication/py/README.md
+++ b/examples/connext_dds/asynchronous_publication/py/README.md
@@ -1,0 +1,23 @@
+# Example Code: Asynchronous Publishing
+
+If you haven't used the RTI Connext Python API before, first check the
+[Getting Started Guide](https://community.rti.com/static/documentation/connext-dds/7.0.0/doc/manuals/connext_dds_professional/getting_started_guide/index.html).
+
+## Running the Example
+
+In two separate command prompt windows for the publisher and subscriber run the
+following commands from the example directory (this is necessary to ensure the
+application loads the QoS defined in *USER_QOS_PROFILES.xml*):
+
+```sh
+python async_publisher.py
+python async_subscriber.py
+```
+
+For the full list of arguments:
+
+```sh
+python async_publisher.py -h
+or
+python async_subscriber.py -h
+```

--- a/examples/connext_dds/asynchronous_publication/py/USER_QOS_PROFILES.xml
+++ b/examples/connext_dds/asynchronous_publication/py/USER_QOS_PROFILES.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0"?>
+<!--
+ (c) 2005-2015 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+ RTI grants Licensee a license to use, modify, compile, and create derivative
+ works of the Software.  Licensee has the right to distribute object form only
+ for use with RTI products.  The Software is provided "as is", with no warranty
+ of any type, including any warranty for fitness for any purpose. RTI is under
+ no obligation to maintain or support the Software.  RTI shall not be liable for
+ any incidental or consequential damages arising out of the use or inability to
+ use the software.
+ -->
+
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/6.1.1/rti_dds_qos_profiles.xsd">
+
+     <!-- QoS Library containing the QoS profile used in the generated example.
+
+        A QoS library is a named set of QoS profiles.
+    -->
+    <qos_library name="async_Library">
+
+        <!-- QoS profile used to configure reliable communication between the DataWriter
+             and DataReader created in the example code.
+
+             A QoS profile groups a set of related QoS.
+        -->
+        <qos_profile name="async_Profile" is_default_qos="true">
+            <!-- QoS used to configure the data writer created in the example code -->
+            <datawriter_qos>
+
+                <!-- QoS for asynchronous publishing -->
+                <publish_mode>
+                    <kind>ASYNCHRONOUS_PUBLISH_MODE_QOS</kind>
+                    <flow_controller_name>DDS_FIXED_RATE_FLOW_CONTROLLER_NAME</flow_controller_name>
+                </publish_mode>
+
+                <reliability>
+                    <kind>RELIABLE_RELIABILITY_QOS</kind>
+                    <max_blocking_time>
+                        <sec>60</sec>
+                    </max_blocking_time>
+                </reliability>
+
+                <history>
+                    <kind>KEEP_LAST_HISTORY_QOS</kind>
+                    <depth>12</depth>
+                </history>
+
+                <protocol>
+                    <rtps_reliable_writer>
+                        <min_send_window_size>50</min_send_window_size>
+                        <max_send_window_size>50</max_send_window_size>
+                    </rtps_reliable_writer>
+                </protocol>
+
+            </datawriter_qos>
+
+            <!-- QoS used to configure the data reader created in the example code -->
+            <datareader_qos>
+
+                <reliability>
+                    <kind>RELIABLE_RELIABILITY_QOS</kind>
+                </reliability>
+
+                <history>
+                    <kind>KEEP_ALL_HISTORY_QOS</kind>
+                </history>
+
+            </datareader_qos>
+
+            <domain_participant_qos>
+                <!--
+                The participant name, if it is set, will be displayed in the
+                RTI Analyzer tool, making it easier for you to tell one
+                application from another when you're debugging.
+                -->
+                <participant_name>
+                    <name>Asynchronous Publisher Python Example</name>
+                </participant_name>
+
+            </domain_participant_qos>
+        </qos_profile>
+
+    </qos_library>
+</dds>

--- a/examples/connext_dds/asynchronous_publication/py/async.idl
+++ b/examples/connext_dds/asynchronous_publication/py/async.idl
@@ -1,0 +1,15 @@
+/*
+ * (c) 2013-2019 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+ *
+ * RTI grants Licensee a license to use, modify, compile, and create derivative
+ * works of the Software.  Licensee has the right to distribute object form
+ * only for use with RTI products.  The Software is provided "as is", with no
+ * warranty of any type, including any warranty for fitness for any purpose.
+ * RTI is under no obligation to maintain or support the Software.  RTI shall
+ * not be liable for any incidental or consequential damages arising out of the
+ * use or inability to use the software.
+ */
+
+ struct async {
+    int32 x;
+};

--- a/examples/connext_dds/asynchronous_publication/py/async_publisher.py
+++ b/examples/connext_dds/asynchronous_publication/py/async_publisher.py
@@ -13,8 +13,6 @@ import time
 
 import rti.connextdds as dds
 
-# Note: cannot do 'from async' because async is a keyword since Python 3.5
-# therefore I have to update the name of async.idl to async_type.idl
 from async_type import async_type
 
 
@@ -70,9 +68,8 @@ def run_publisher_application(
     # You can wait until all written samples have been actually published
     # (note that this doesn't ensure that they have actually been received
     # if the sample required retransmission)
-    writer.wait_for_asynchronous_publishing
+    writer.wait_for_asynchronous_publishing()
     print("preparing to shut down...")
-    participant.close()
 
 
 def main():

--- a/examples/connext_dds/asynchronous_publication/py/async_publisher.py
+++ b/examples/connext_dds/asynchronous_publication/py/async_publisher.py
@@ -1,0 +1,127 @@
+#
+# (c) 2022 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+#
+# RTI grants Licensee a license to use, modify, compile, and create derivative
+# works of the Software solely for use with RTI products.  The Software is
+# provided "as is", with no warranty of any type, including any warranty for
+# fitness for any purpose. RTI is under no obligation to maintain or support
+# the Software.  RTI shall not be liable for any incidental or consequential
+# damages arising out of the use or inability to use the software.
+#
+import argparse
+import time
+
+# Note, I have not run this program yet. Need to pull on my local laptop so that I can download the wheel
+import rti.connextdds as dds
+# Note: cannot do 'from async' because async is a keyword since Python 3.5 
+# therefore I have to update the name of async.idl to async_type.idl
+from async_type import async_type
+
+
+def run_publisher_application(domain_id: int, sample_count: int):
+    # Start communicating in a domain, usually one participant per application
+    participant = dds.DomainParticipant(domain_id)
+
+    # Create a Topic
+    topic = dds.Topic(participant, "Example async", async_type)
+
+    # Retrieve the default DataWriter QoS, from USER_QOS_PROFILES.xml
+    writer_qos = dds.QosProvider.default.datawriter_qos
+
+    # Note: Update this to Python
+    """ # If you want to change the DataWriter's QoS programmatically rather than
+    # using the XML file, uncomment the following lines.
+
+    # In this case, we set the publish mode QoS to asynchronous publish mode,
+    # which enables asynchronous publishing. We also set the flow controller
+    # to be the fixed rate flow controller, and we increase the history depth.
+    writer_qos << Reliability::Reliable(Duration(60));
+
+    DataWriterProtocol writer_protocol_qos;
+    RtpsReliableWriterProtocol rtps_writer_protocol;
+    rtps_writer_protocol.min_send_window_size(50);
+    rtps_writer_protocol.max_send_window_size(50);
+    writer_protocol_qos.rtps_reliable_writer(rtps_writer_protocol);
+    writer_qos << writer_protocol_qos;
+
+    # Since samples are only being sent once per second, DataWriter will need
+    # to keep them on queue.  History defaults to only keeping the last
+    # sample enqueued, so we increase that here.
+    writer_qos << History::KeepLast(12);
+
+    # Set flowcontroller for DataWriter
+    writer_qos << PublishMode::Asynchronous(FlowController::FIXED_RATE_NAME); """
+
+    # Create a DataWriter with the QoS in our profile
+    writer = dds.DataWriter(participant.implicit_publisher, topic, writer_qos)
+
+    # Create data sample for writing
+    sample = async_type(x=42)
+
+    for count in range(sample_count):
+        try:
+            # Modify the data to be sent here
+            sample.x = count
+            print("Writing async_type, count {}".format(count))
+            writer.write(sample)
+            time.sleep(1)
+        except KeyboardInterrupt:
+            break
+    print("preparing to shut down...")
+    writer.close()
+    topic.close()
+    participant.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="RTI Connext DDS Example: Using Asynchronous Publishing"
+    )
+    parser.add_argument(
+        "-d",
+        "--domain",
+        type=int,
+        default=0,
+        help="DDS Domain ID | Range: 0-232 | Default: 0",
+    )
+    parser.add_argument(
+        "-c",
+        "--count",
+        type=int,
+        default=50,
+        help="Number of samples to send | Default 50",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbosity",
+        type=int,
+        default=1,
+        help="How much debugging output to show | Range: 0-3 | Default: 1",
+    )
+
+    args = parser.parse_args()
+    assert 0 <= args.domain < 233
+    assert args.count >= 0
+    assert 0 <= args.verbosity < 4
+
+    verbosity_levels = {
+        0: dds.Verbosity.SILENT,
+        1: dds.Verbosity.EXCEPTION,
+        2: dds.Verbosity.WARNING,
+        3: dds.Verbosity.STATUS_ALL,
+    }
+
+    # Sets Connext verbosity to help debugging
+    verbosity = verbosity_levels.get(args.verbosity, dds.Verbosity.EXCEPTION)
+
+    dds.Logger.instance.verbosity = verbosity
+
+    try:
+        run_publisher_application(args.domain, args.count)
+    except Exception as e:
+        print(f"Exception in run_publisher_application(): {e}")
+    return
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/connext_dds/asynchronous_publication/py/async_publisher.py
+++ b/examples/connext_dds/asynchronous_publication/py/async_publisher.py
@@ -11,7 +11,6 @@
 import argparse
 import time
 
-# Note, I have not run this program yet. Need to pull on my local laptop so that I can download the wheel
 import rti.connextdds as dds
 # Note: cannot do 'from async' because async is a keyword since Python 3.5 
 # therefore I have to update the name of async.idl to async_type.idl
@@ -28,7 +27,6 @@ def run_publisher_application(domain_id: int, sample_count: int):
     # Retrieve the default DataWriter QoS, from USER_QOS_PROFILES.xml
     writer_qos = dds.QosProvider.default.datawriter_qos
 
-    # Note: Update this to Python
     # If you want to change the DataWriter's QoS programmatically rather than
     # using the XML file, uncomment the following lines.
 
@@ -49,7 +47,7 @@ def run_publisher_application(domain_id: int, sample_count: int):
     #writer_qos.history.keep_all.keep_last(12)
 
     # Set flowcontroller for DataWriter
-    writer_qos.publish_mode.asynchronous()
+    # writer_qos.publish_mode.asynchronous()
     # Note figure out what FlowController::FIXED_RATE_NAME is
     # writer_qos << PublishMode::Asynchronous(FlowController::FIXED_RATE_NAME)
 

--- a/examples/connext_dds/asynchronous_publication/py/async_publisher.py
+++ b/examples/connext_dds/asynchronous_publication/py/async_publisher.py
@@ -34,8 +34,6 @@ def run_publisher_application(
         writer_qos.reliability = dds.Reliability.reliable(
             dds.Duration.from_seconds(60)
         )
-        # Note: Admin Console is reporting history depth of 1 still regardless of changes in the QoS file or programatically
-        # writer_qos.history. = dds.History.keep_last(12)
         writer_qos.history.kind = dds.HistoryKind.KEEP_LAST
         writer_qos.history.depth = 12
         writer_qos.data_writer_protocol.rtps_reliable_writer.min_send_window_size = (
@@ -45,7 +43,6 @@ def run_publisher_application(
             50
         )
 
-        # Note: Without specifying a name it defaults to DDS_DEFAULT_FLOW_CONTROLLER_NAME. Do I need to specify the name?
         writer_qos.publish_mode = dds.PublishMode.asynchronous(
             "DDS_FIXED_RATE_FLOW_CONTROLLER_NAME"
         )
@@ -123,7 +120,6 @@ def main():
     dds.Logger.instance.verbosity = verbosity
 
     try:
-        # Note: C# example doesn't seem to allow using the use_xml_qos option?
         run_publisher_application(args.domain, args.count, args.qos)
     except Exception as e:
         print(f"Exception in run_publisher_application(): {e}")

--- a/examples/connext_dds/asynchronous_publication/py/async_publisher.py
+++ b/examples/connext_dds/asynchronous_publication/py/async_publisher.py
@@ -68,7 +68,7 @@ def run_publisher_application(
     # You can wait until all written samples have been actually published
     # (note that this doesn't ensure that they have actually been received
     # if the sample required retransmission)
-    writer.wait_for_asynchronous_publishing()
+    writer.wait_for_asynchronous_publishing(dds.Duration(10))
     print("preparing to shut down...")
 
 

--- a/examples/connext_dds/asynchronous_publication/py/async_publisher.py
+++ b/examples/connext_dds/asynchronous_publication/py/async_publisher.py
@@ -29,28 +29,29 @@ def run_publisher_application(domain_id: int, sample_count: int):
     writer_qos = dds.QosProvider.default.datawriter_qos
 
     # Note: Update this to Python
-    """ # If you want to change the DataWriter's QoS programmatically rather than
+    # If you want to change the DataWriter's QoS programmatically rather than
     # using the XML file, uncomment the following lines.
 
     # In this case, we set the publish mode QoS to asynchronous publish mode,
     # which enables asynchronous publishing. We also set the flow controller
     # to be the fixed rate flow controller, and we increase the history depth.
-    writer_qos << Reliability::Reliable(Duration(60));
-
-    DataWriterProtocol writer_protocol_qos;
-    RtpsReliableWriterProtocol rtps_writer_protocol;
-    rtps_writer_protocol.min_send_window_size(50);
-    rtps_writer_protocol.max_send_window_size(50);
-    writer_protocol_qos.rtps_reliable_writer(rtps_writer_protocol);
-    writer_qos << writer_protocol_qos;
+    # writer_qos.reliability.reliable(dds.Duration(60))
+    # writer_qos.data_writer_protocol.rtps_reliable_writer.min_send_window_size = 50
+    # writer_qos.data_writer_protocol.rtps_reliable_writer.max_send_window_size = 50
 
     # Since samples are only being sent once per second, DataWriter will need
     # to keep them on queue.  History defaults to only keeping the last
     # sample enqueued, so we increase that here.
-    writer_qos << History::KeepLast(12);
+
+    # Note: Admin Console is reporting history depth of 1 still regardless of changes in the QoS file or programatically 
+    #writer_qos.history.depth = 12
+    #writer_qos.history.kind = dds.HistoryKind.KEEP_ALL
+    #writer_qos.history.keep_all.keep_last(12)
 
     # Set flowcontroller for DataWriter
-    writer_qos << PublishMode::Asynchronous(FlowController::FIXED_RATE_NAME); """
+    writer_qos.publish_mode.asynchronous()
+    # Note figure out what FlowController::FIXED_RATE_NAME is
+    # writer_qos << PublishMode::Asynchronous(FlowController::FIXED_RATE_NAME)
 
     # Create a DataWriter with the QoS in our profile
     writer = dds.DataWriter(participant.implicit_publisher, topic, writer_qos)

--- a/examples/connext_dds/asynchronous_publication/py/async_subscriber.py
+++ b/examples/connext_dds/asynchronous_publication/py/async_subscriber.py
@@ -47,7 +47,6 @@ def run_subscriber_application(
     try:
         print("async subscriber sleeping")
         rti.asyncio.run(process_data(reader))
-        # await process_data(reader)
     except KeyboardInterrupt:
         pass
 
@@ -105,7 +104,6 @@ def main():
     dds.Logger.instance.verbosity = verbosity
 
     try:
-        # rti.asyncio.run(run_subscriber_application(args.domain, args.count, args.qos))
         run_subscriber_application(args.domain, args.count, args.qos)
     except Exception as e:
         print(f"Exception in run_subscriber_application(): {e}")

--- a/examples/connext_dds/asynchronous_publication/py/async_subscriber.py
+++ b/examples/connext_dds/asynchronous_publication/py/async_subscriber.py
@@ -41,12 +41,11 @@ def run_subscriber_application(domain_id: int, sample_count: int):
     # Retrieve the default DataWriter QoS, from USER_QOS_PROFILES.xml
     reader_qos = dds.QosProvider.default.datareader_qos
 
-    # Note: Update this to Python
-    """ # If you want to change the DataWriter's QoS programmatically rather than
+    # If you want to change the DataReader's QoS programmatically rather than
     # using the XML file, uncomment the following lines.
 
-    reader_qos << Reliability::Reliable();
-    reader_qos << History::KeepAll();"""
+    # reader_qos.reliability.reliable()
+    # reader_qos.history.kind = dds.HistoryKind.KEEP_ALL
 
     # Create a DataReader with the QoS in our profile
     reader = dds.DataReader(participant.implicit_subscriber, topic, reader_qos)

--- a/examples/connext_dds/asynchronous_publication/py/async_subscriber.py
+++ b/examples/connext_dds/asynchronous_publication/py/async_subscriber.py
@@ -1,0 +1,143 @@
+#
+# (c) 2022 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+#
+# RTI grants Licensee a license to use, modify, compile, and create derivative
+# works of the Software solely for use with RTI products.  The Software is
+# provided "as is", with no warranty of any type, including any warranty for
+# fitness for any purpose. RTI is under no obligation to maintain or support
+# the Software.  RTI shall not be liable for any incidental or consequential
+# damages arising out of the use or inability to use the software.
+#
+import argparse
+
+# Note, I have not run this program yet. Need to pull on my local laptop so that I can download the wheel
+import rti.connextdds as dds
+# Note: cannot do 'from async' because async is a keyword since Python 3.5 
+# therefore I have to update the name of async.idl to async_type.idl
+from async_type import async_type
+
+
+def process_data(reader: dds.DataReader):
+    # Take all samples. Samples are loaned to application, loan is
+    # returned when LoanedSamples destructor is called or when you
+    # return the loan explicitly
+    samples_read = 0
+    samples = reader.take()
+
+    for (data, info) in samples:
+        if info.valid:
+            print("Received: {}".format(data))
+            samples_read += 1
+    return samples_read
+
+
+def run_subscriber_application(domain_id: int, sample_count: int):
+    # Start communicating in a domain, usually one participant per application
+    participant = dds.DomainParticipant(domain_id)
+
+    # Create a Topic
+    topic = dds.Topic(participant, "Example async", async_type)
+
+    # Retrieve the default DataWriter QoS, from USER_QOS_PROFILES.xml
+    reader_qos = dds.QosProvider.default.datareader_qos
+
+    # Note: Update this to Python
+    """ # If you want to change the DataWriter's QoS programmatically rather than
+    # using the XML file, uncomment the following lines.
+
+    reader_qos << Reliability::Reliable();
+    reader_qos << History::KeepAll();"""
+
+    # Create a DataReader with the QoS in our profile
+    reader = dds.DataReader(participant.implicit_subscriber, topic, reader_qos)
+
+    # Initialize samples_read to zero
+    samples_read = 0
+
+    # Assocaite a handler with the status condition. This will run when the
+    # condition is triggered, in the context of the dispatch call (see below)
+    # condition argument is not used 
+    def handler(_):
+        nonlocal samples_read
+        nonlocal reader
+        samples_read += process_data(reader)
+
+    # Obtain the DataReader's Status Condition
+    status_condition = dds.StatusCondition(reader)
+
+    # Enable the 'data_available' status and set the handler
+    status_condition.enabled_statuses = dds.StatusMask.DATA_AVAILABLE
+    status_condition.set_handler(handler)
+
+    # Create a WaitSet and attach the StatusCondition
+    waitset = dds.WaitSet()
+    waitset += status_condition
+
+    while samples_read < sample_count:
+        # Catch control c interrupt
+        try:
+            # Dispatch wil call the handlers associated to the WaitSet conditions
+            # when they activate
+            print("async subscriber sleeping up to 1 sec...")
+            waitset.dispatch(dds.Duration(1))  # Wait up to 1s each time
+        except KeyboardInterrupt:
+            break
+
+    print("preparing to shut down...")
+    reader.close()
+    topic.close()
+    participant.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="RTI Connext DDS Example: Using Asynchronous Publishing"
+    )
+    parser.add_argument(
+        "-d",
+        "--domain",
+        type=int,
+        default=0,
+        help="DDS Domain ID | Range: 0-232 | Default: 0",
+    )
+    parser.add_argument(
+        "-c",
+        "--count",
+        type=int,
+        default=50,
+        help="Number of samples to send | Default 50",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbosity",
+        type=int,
+        default=1,
+        help="How much debugging output to show | Range: 0-3 | Default: 1",
+    )
+
+    args = parser.parse_args()
+    assert 0 <= args.domain < 233
+    assert args.count >= 0
+    assert 0 <= args.verbosity < 4
+
+    verbosity_levels = {
+        0: dds.Verbosity.SILENT,
+        1: dds.Verbosity.EXCEPTION,
+        2: dds.Verbosity.WARNING,
+        3: dds.Verbosity.STATUS_ALL,
+    }
+
+    # Sets Connext verbosity to help debugging
+    verbosity = verbosity_levels.get(args.verbosity, dds.Verbosity.EXCEPTION)
+
+    dds.Logger.instance.verbosity = verbosity
+
+    try:
+        run_subscriber_application(args.domain, args.count)
+    except Exception as e:
+        print(f"Exception in run_subscriber_application(): {e}")
+    return
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/connext_dds/asynchronous_publication/py/async_subscriber.py
+++ b/examples/connext_dds/asynchronous_publication/py/async_subscriber.py
@@ -13,8 +13,6 @@ import rti.asyncio
 
 import rti.connextdds as dds
 
-# Note: cannot do 'from async' because async is a keyword since Python 3.5
-# therefore I have to update the name of async.idl to async_type.idl
 from async_type import async_type
 
 
@@ -40,7 +38,7 @@ def run_subscriber_application(
     else:
         # Configure the DataReaderQos in code, to the same effect as the XML file.
         reader_qos = participant.default_datareader_qos
-        reader_qos.reliability = dds.Reliability.reliable()
+        reader_qos.reliability.kind = dds.ReliabilityKind.RELIABLE
         reader_qos.history.kind = dds.HistoryKind.KEEP_ALL
 
     # Create a DataReader with the QoS in our profile or configured programatically
@@ -54,9 +52,6 @@ def run_subscriber_application(
         pass
 
     print("preparing to shut down...")
-    # rti.asyncio.close(process_data(reader))
-    # Note: Exception thrown here. I assume it's because the coroutine is still running
-    participant.close()
 
 
 def main():

--- a/examples/connext_dds/asynchronous_publication/py/async_subscriber.py
+++ b/examples/connext_dds/asynchronous_publication/py/async_subscriber.py
@@ -10,7 +10,6 @@
 #
 import argparse
 
-# Note, I have not run this program yet. Need to pull on my local laptop so that I can download the wheel
 import rti.connextdds as dds
 # Note: cannot do 'from async' because async is a keyword since Python 3.5 
 # therefore I have to update the name of async.idl to async_type.idl

--- a/examples/connext_dds/asynchronous_publication/py/async_type.idl
+++ b/examples/connext_dds/asynchronous_publication/py/async_type.idl
@@ -10,6 +10,6 @@
  * use or inability to use the software.
  */
 
- struct async {
+ struct async_type {
     int32 x;
 };

--- a/examples/connext_dds/asynchronous_publication/py/async_type.py
+++ b/examples/connext_dds/asynchronous_publication/py/async_type.py
@@ -1,0 +1,9 @@
+import sys
+import rti.idl as idl
+from enum import IntEnum, auto
+from typing import Sequence, Optional
+from dataclasses import field
+
+@idl.struct
+class async_type:
+    x: idl.int32 = 0

--- a/examples/connext_dds/asynchronous_publication/py/async_type.py
+++ b/examples/connext_dds/asynchronous_publication/py/async_type.py
@@ -1,0 +1,18 @@
+# WARNING: THIS FILE IS AUTO-GENERATED. DO NOT MODIFY.
+
+# This file was generated from async.idl
+# using RTI Code Generator (rtiddsgen) version 3.1.1.
+# The rtiddsgen tool is part of the RTI Connext DDS distribution.
+# For more information, type 'rtiddsgen -help' at a command shell
+# or consult the Code Generator User's Manual.
+
+import sys
+import rti.idl as idl
+from enum import IntEnum, auto
+from typing import Sequence, Optional
+from dataclasses import field
+
+
+@idl.struct
+class async_type:
+    x: idl.int32 = 0

--- a/examples/connext_dds/asynchronous_publication/py/async_type.py
+++ b/examples/connext_dds/asynchronous_publication/py/async_type.py
@@ -1,10 +1,13 @@
-# WARNING: THIS FILE IS AUTO-GENERATED. DO NOT MODIFY.
-
-# This file was generated from async.idl
-# using RTI Code Generator (rtiddsgen) version 3.1.1.
-# The rtiddsgen tool is part of the RTI Connext DDS distribution.
-# For more information, type 'rtiddsgen -help' at a command shell
-# or consult the Code Generator User's Manual.
+#
+# (c) 2022 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+#
+# RTI grants Licensee a license to use, modify, compile, and create derivative
+# works of the Software solely for use with RTI products.  The Software is
+# provided "as is", with no warranty of any type, including any warranty for
+# fitness for any purpose. RTI is under no obligation to maintain or support
+# the Software.  RTI shall not be liable for any incidental or consequential
+# damages arising out of the use or inability to use the software.
+#
 
 import sys
 import rti.idl as idl

--- a/examples/connext_dds/asynchronous_publication/py/async_type.py
+++ b/examples/connext_dds/asynchronous_publication/py/async_type.py
@@ -1,9 +1,0 @@
-import sys
-import rti.idl as idl
-from enum import IntEnum, auto
-from typing import Sequence, Optional
-from dataclasses import field
-
-@idl.struct
-class async_type:
-    x: idl.int32 = 0


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->

### Summary
Python example displaying async publication

### Details and comments
!important! This example is not ready yet, creating initial pull request for review purposes. 
Here is a list of things to review:
-Idl file and class cannot be called "async" for python since it's a keyword. Naming the struct async and running rtiddsgen won't cause an error, however you won't be able to "from async import async". I have renamed it to async_type. Let me know if this should be approached differently
-When checking the history depth with Admin Console for the DataWriter, it shows a depth of 1 when it should be 12. This is observable when setting the QoS via XML and/or setting it programatically
-When creating a flow controller, I'm not sure what FlowController::FIXED_RATE_NAME is and what the python equivalent would be, for now I've created a flow controller without specifying a name


### Checks

<!-- Change the space between the square brackets to an `x` -->
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.

<!-- Uncomment bellow if you added a C/C++ example and updated examples/connext_dds/CMakeList.txt -->
<!--
-   [ ] I have added a new C/C++ example and updated `examples/connext_dds/CMakeList.txt` accordingly.
-->
<!-- Uncomment bellow if you added a Java example and updated examples/connext_dds/settings.gradle -->
<!--
-   [ ] I have added a new Java example and updated `examples/connext_dds/settings.gradle` accordingly.
-->
