### PR TITLE
Fix wrench emoji in lbediscovery_xml_app_creation

### DIFF
--- a/examples/connext_dds/lbediscovery_xml_app_creation/c++11/README.md
+++ b/examples/connext_dds/lbediscovery_xml_app_creation/c++11/README.md
@@ -1,6 +1,6 @@
 # Example Code: LBED and XML-Based Application Creation
 
-## Building the Example :wrench
+## Building the Example :wrench:
 
 To build this example, first run CMake to generate the corresponding build
 files. We recommend you use a separate directory to store all the generated


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->

### Summary

Fix a wrong wrench emoji in LBED XML-Based Application Creation example.

### Details and comments


### Checks

<!-- Change te space between the square brackets to an `x` -->
-   [X] I have updated the documentation accordingly.
-   [X] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.

<!-- Uncomment bellow if you added a C/C++ example and updated examples/connext_dds/CMakeList.txt -->
<!--
-   [ ] I have added a new C/C++ example and updated `examples/connext_dds/CMakeList.txt` accordingly.
-->
<!-- Uncomment bellow if you added a Java example and updated examples/connext_dds/settings.gradle -->
<!--
-   [ ] I have added a new Java example and updated `examples/connext_dds/settings.gradle` accordingly.
-->
