### PR TITLE
Log start timestamp on Recording Service init, fixes #547

### DIFF
--- a/examples/recording_service/pluggable_storage/c/FileStorageWriter.c
+++ b/examples/recording_service/pluggable_storage/c/FileStorageWriter.c
@@ -248,6 +248,7 @@ int FileStorageWriter_connect(void *storage_writer_data)
     fprintf(writer->info_file.file,
             "Start timestamp: %" PRIi64 "\n",
             current_time);
+    fflush(writer->info_file.file);
     return TRUE;
 }
 


### PR DESCRIPTION
### Summary

See: #547

### Details and comments

Just added an `fflush` statement.

### Checks

<!-- Change te space between the square brackets to an `x` -->
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.
