### PR TITLE
Fix/565: Pin ubuntu versions in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Build examples
 
     # This job will be executed if the "PR handler" finalized successfully or

--- a/.github/workflows/lint_markdown.yml
+++ b/.github/workflows/lint_markdown.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   lint-markdown:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     name: Lint job
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   lint-python:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     name: Lint job
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint_source.yml
+++ b/.github/workflows/lint_source.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   lint-sourcecode:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     name: Lint job
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/prhandler.yml
+++ b/.github/workflows/prhandler.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   upload:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Artifacts generation
 
     steps:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The examples contained in the
 [master](https://github.com/rticommunity/rticonnextdds-examples/tree/master)
 branch of this repository have been built and tested against RTI Connext DDS
 7.0.0. If you need examples that have been built and tested against older
+
 versions of RTI Connext DDS, please check out the appropriate branch:
 
 - [release/6.1.1](https://github.com/rticommunity/rticonnextdds-examples/tree/release/6.1.1)

--- a/examples/connext_dds/custom_transport/c/FileTransport.c
+++ b/examples/connext_dds/custom_transport/c/FileTransport.c
@@ -160,6 +160,7 @@ struct NDDS_Transport_RecvResource_FILE {
     FILE *_file;
     /* The port number associated with the resource */
     int _portNum;
+
     int _fileDescriptor;
     int _receiveMessageCount;
 };

--- a/resources/ci_cd/linux_build.py
+++ b/resources/ci_cd/linux_build.py
@@ -66,6 +66,7 @@ def main():
 
     rti_connext_dds_dir = found_rti_connext_dds[0]
     build_dir = examples_dir.joinpath("build")
+
     build_dir.mkdir(exist_ok=True)
     string_separator = f"\n{'*'*80}\n"
 


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->

### Summary

Pin workflows Ubuntu version.


### Details and comments


### Checks

<!-- Change te space between the square brackets to an `x` -->
-   [ ] I have updated the documentation accordingly.
-   [ ] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.

<!-- Uncomment bellow if you added a C/C++ example and updated examples/connext_dds/CMakeList.txt -->
<!--
-   [ ] I have added a new C/C++ example and updated `examples/connext_dds/CMakeList.txt` accordingly.
-->
<!-- Uncomment bellow if you added a Java example and updated examples/connext_dds/settings.gradle -->
<!--
-   [ ] I have added a new Java example and updated `examples/connext_dds/settings.gradle` accordingly.
-->
