### PR TITLE
Fixing the typos and formatting issues identified in #582

### DIFF
--- a/examples/cloud_discovery_service/library_api/c++11/README.md
+++ b/examples/cloud_discovery_service/library_api/c++11/README.md
@@ -68,24 +68,24 @@ in the Cloud Discovery Service User's Manual.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
@@ -94,18 +94,18 @@ cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 20
 ### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext architecture based on the default settings
-for your host platform.If you installed Connext in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,10 +123,10 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
@@ -134,5 +134,5 @@ documentation, in
 For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/cloud_discovery_service/library_api/c++11/README.md
+++ b/examples/cloud_discovery_service/library_api/c++11/README.md
@@ -68,7 +68,7 @@ in the Cloud Discovery Service User's Manual.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/cloud_discovery_service/library_api/c++11/README.md
+++ b/examples/cloud_discovery_service/library_api/c++11/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/cloud_discovery_service/library_api/c++11/README.md
+++ b/examples/cloud_discovery_service/library_api/c++11/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/cloud_discovery_service/library_api/c++11/README.md
+++ b/examples/cloud_discovery_service/library_api/c++11/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/cloud_discovery_service/library_api/c++11/README.md
+++ b/examples/cloud_discovery_service/library_api/c++11/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/cloud_discovery_service/library_api/c/README.md
+++ b/examples/cloud_discovery_service/library_api/c/README.md
@@ -68,24 +68,24 @@ in the Cloud Discovery Service User's Manual.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
@@ -94,18 +94,18 @@ cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 20
 ### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext architecture based on the default settings
-for your host platform.If you installed Connext in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,10 +123,10 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
@@ -134,5 +134,5 @@ documentation, in
 For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/cloud_discovery_service/library_api/c/README.md
+++ b/examples/cloud_discovery_service/library_api/c/README.md
@@ -68,7 +68,7 @@ in the Cloud Discovery Service User's Manual.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/cloud_discovery_service/library_api/c/README.md
+++ b/examples/cloud_discovery_service/library_api/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/cloud_discovery_service/library_api/c/README.md
+++ b/examples/cloud_discovery_service/library_api/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/cloud_discovery_service/library_api/c/README.md
+++ b/examples/cloud_discovery_service/library_api/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/cloud_discovery_service/library_api/c/README.md
+++ b/examples/cloud_discovery_service/library_api/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/asynchronous_publication/c++11/README.md
+++ b/examples/connext_dds/asynchronous_publication/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/asynchronous_publication/c++11/README.md
+++ b/examples/connext_dds/asynchronous_publication/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/asynchronous_publication/c++11/README.md
+++ b/examples/connext_dds/asynchronous_publication/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/asynchronous_publication/c++11/README.md
+++ b/examples/connext_dds/asynchronous_publication/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/asynchronous_publication/c++11/README.md
+++ b/examples/connext_dds/asynchronous_publication/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/asynchronous_publication/c++11/README.md
+++ b/examples/connext_dds/asynchronous_publication/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/asynchronous_publication/c++98/README.md
+++ b/examples/connext_dds/asynchronous_publication/c++98/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/asynchronous_publication/c++98/README.md
+++ b/examples/connext_dds/asynchronous_publication/c++98/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/asynchronous_publication/c++98/README.md
+++ b/examples/connext_dds/asynchronous_publication/c++98/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/asynchronous_publication/c++98/README.md
+++ b/examples/connext_dds/asynchronous_publication/c++98/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/asynchronous_publication/c++98/README.md
+++ b/examples/connext_dds/asynchronous_publication/c++98/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/asynchronous_publication/c++98/README.md
+++ b/examples/connext_dds/asynchronous_publication/c++98/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/asynchronous_publication/c/README.md
+++ b/examples/connext_dds/asynchronous_publication/c/README.md
@@ -68,44 +68,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/asynchronous_publication/c/README.md
+++ b/examples/connext_dds/asynchronous_publication/c/README.md
@@ -68,7 +68,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/asynchronous_publication/c/README.md
+++ b/examples/connext_dds/asynchronous_publication/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/asynchronous_publication/c/README.md
+++ b/examples/connext_dds/asynchronous_publication/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/asynchronous_publication/c/README.md
+++ b/examples/connext_dds/asynchronous_publication/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/asynchronous_publication/c/README.md
+++ b/examples/connext_dds/asynchronous_publication/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/asyncwaitset/c++11/README.md
+++ b/examples/connext_dds/asyncwaitset/c++11/README.md
@@ -120,8 +120,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/asyncwaitset/c++11/README.md
+++ b/examples/connext_dds/asyncwaitset/c++11/README.md
@@ -116,44 +116,44 @@ where the subscriber options are:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -162,8 +162,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -171,16 +171,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/asyncwaitset/c++11/README.md
+++ b/examples/connext_dds/asyncwaitset/c++11/README.md
@@ -127,6 +127,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/asyncwaitset/c++11/README.md
+++ b/examples/connext_dds/asyncwaitset/c++11/README.md
@@ -150,7 +150,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/asyncwaitset/c++11/README.md
+++ b/examples/connext_dds/asyncwaitset/c++11/README.md
@@ -116,7 +116,7 @@ where the subscriber options are:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/asyncwaitset/c++11/README.md
+++ b/examples/connext_dds/asyncwaitset/c++11/README.md
@@ -125,13 +125,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/batching/c++11/README.md
+++ b/examples/connext_dds/batching/c++11/README.md
@@ -74,19 +74,19 @@ your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
 Solutions on Windows), \. You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are Release
     and Debug. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are ON for
     dynamic linking and OFF for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 
--   `-G` -- CMake generator. The generator is the native build system used to
+-   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described described in the
     CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Section](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build a example in Debug/Static mode run CMake as follows:
 

--- a/examples/connext_dds/batching/c++11/README.md
+++ b/examples/connext_dds/batching/c++11/README.md
@@ -75,8 +75,8 @@ Solutions on Windows), \. You can use the following CMake variables to modify th
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and Debug. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are ON for
     dynamic linking and OFF for static linking. See [CMake documentation for

--- a/examples/connext_dds/batching/c++11/README.md
+++ b/examples/connext_dds/batching/c++11/README.md
@@ -71,7 +71,7 @@ the `--turbo` option.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+Solutions on Windows), \. You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release

--- a/examples/connext_dds/batching/c++11/README.md
+++ b/examples/connext_dds/batching/c++11/README.md
@@ -106,7 +106,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target rtipkg), you can use the
 CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/batching/c++98/README.md
+++ b/examples/connext_dds/batching/c++98/README.md
@@ -104,7 +104,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/batching/c++98/README.md
+++ b/examples/connext_dds/batching/c++98/README.md
@@ -81,6 +81,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/batching/c++98/README.md
+++ b/examples/connext_dds/batching/c++98/README.md
@@ -74,8 +74,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/batching/c++98/README.md
+++ b/examples/connext_dds/batching/c++98/README.md
@@ -79,13 +79,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/batching/c++98/README.md
+++ b/examples/connext_dds/batching/c++98/README.md
@@ -70,7 +70,7 @@ communicate. The default is 0.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/batching/c++98/README.md
+++ b/examples/connext_dds/batching/c++98/README.md
@@ -70,44 +70,44 @@ communicate. The default is 0.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -116,8 +116,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -125,16 +125,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/batching/c/README.md
+++ b/examples/connext_dds/batching/c/README.md
@@ -106,7 +106,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/batching/c/README.md
+++ b/examples/connext_dds/batching/c/README.md
@@ -72,7 +72,7 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/batching/c/README.md
+++ b/examples/connext_dds/batching/c/README.md
@@ -76,8 +76,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/batching/c/README.md
+++ b/examples/connext_dds/batching/c/README.md
@@ -72,44 +72,44 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -118,8 +118,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -127,16 +127,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/batching/c/README.md
+++ b/examples/connext_dds/batching/c/README.md
@@ -83,6 +83,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/batching/c/README.md
+++ b/examples/connext_dds/batching/c/README.md
@@ -81,13 +81,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/build_systems/cmake/README.md
+++ b/examples/connext_dds/build_systems/cmake/README.md
@@ -55,44 +55,44 @@ HelloWorld_subscriber <domain_id> <number_samples>
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -101,8 +101,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -110,16 +110,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/build_systems/cmake/README.md
+++ b/examples/connext_dds/build_systems/cmake/README.md
@@ -89,7 +89,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/build_systems/cmake/README.md
+++ b/examples/connext_dds/build_systems/cmake/README.md
@@ -55,7 +55,7 @@ HelloWorld_subscriber <domain_id> <number_samples>
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/build_systems/cmake/README.md
+++ b/examples/connext_dds/build_systems/cmake/README.md
@@ -66,6 +66,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/build_systems/cmake/README.md
+++ b/examples/connext_dds/build_systems/cmake/README.md
@@ -59,8 +59,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/build_systems/cmake/README.md
+++ b/examples/connext_dds/build_systems/cmake/README.md
@@ -64,13 +64,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/builtin_qos_profiles/c++11/README.md
+++ b/examples/connext_dds/builtin_qos_profiles/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/builtin_qos_profiles/c++11/README.md
+++ b/examples/connext_dds/builtin_qos_profiles/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/builtin_qos_profiles/c++11/README.md
+++ b/examples/connext_dds/builtin_qos_profiles/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/builtin_qos_profiles/c++11/README.md
+++ b/examples/connext_dds/builtin_qos_profiles/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/builtin_qos_profiles/c++11/README.md
+++ b/examples/connext_dds/builtin_qos_profiles/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/builtin_qos_profiles/c++11/README.md
+++ b/examples/connext_dds/builtin_qos_profiles/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/builtin_qos_profiles/c++98/README.md
+++ b/examples/connext_dds/builtin_qos_profiles/c++98/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/builtin_qos_profiles/c++98/README.md
+++ b/examples/connext_dds/builtin_qos_profiles/c++98/README.md
@@ -67,44 +67,44 @@ The applications accept two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/builtin_qos_profiles/c++98/README.md
+++ b/examples/connext_dds/builtin_qos_profiles/c++98/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/builtin_qos_profiles/c++98/README.md
+++ b/examples/connext_dds/builtin_qos_profiles/c++98/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/builtin_qos_profiles/c++98/README.md
+++ b/examples/connext_dds/builtin_qos_profiles/c++98/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/builtin_qos_profiles/c++98/README.md
+++ b/examples/connext_dds/builtin_qos_profiles/c++98/README.md
@@ -67,7 +67,7 @@ The applications accept two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/builtin_qos_profiles/c/README.md
+++ b/examples/connext_dds/builtin_qos_profiles/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/builtin_qos_profiles/c/README.md
+++ b/examples/connext_dds/builtin_qos_profiles/c/README.md
@@ -68,7 +68,7 @@ The applications accept two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/builtin_qos_profiles/c/README.md
+++ b/examples/connext_dds/builtin_qos_profiles/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/builtin_qos_profiles/c/README.md
+++ b/examples/connext_dds/builtin_qos_profiles/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/builtin_qos_profiles/c/README.md
+++ b/examples/connext_dds/builtin_qos_profiles/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/builtin_qos_profiles/c/README.md
+++ b/examples/connext_dds/builtin_qos_profiles/c/README.md
@@ -68,44 +68,44 @@ The applications accept two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/builtin_topics/c++11/README.md
+++ b/examples/connext_dds/builtin_topics/c++11/README.md
@@ -114,6 +114,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/builtin_topics/c++11/README.md
+++ b/examples/connext_dds/builtin_topics/c++11/README.md
@@ -103,7 +103,7 @@ Subscriber Output
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/builtin_topics/c++11/README.md
+++ b/examples/connext_dds/builtin_topics/c++11/README.md
@@ -107,8 +107,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/builtin_topics/c++11/README.md
+++ b/examples/connext_dds/builtin_topics/c++11/README.md
@@ -137,7 +137,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/builtin_topics/c++11/README.md
+++ b/examples/connext_dds/builtin_topics/c++11/README.md
@@ -103,44 +103,44 @@ Subscriber Output
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -149,8 +149,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -158,16 +158,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/builtin_topics/c++11/README.md
+++ b/examples/connext_dds/builtin_topics/c++11/README.md
@@ -112,13 +112,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/builtin_topics/c++98/README.md
+++ b/examples/connext_dds/builtin_topics/c++98/README.md
@@ -114,6 +114,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/builtin_topics/c++98/README.md
+++ b/examples/connext_dds/builtin_topics/c++98/README.md
@@ -103,7 +103,7 @@ Subscriber Output
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/builtin_topics/c++98/README.md
+++ b/examples/connext_dds/builtin_topics/c++98/README.md
@@ -107,8 +107,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/builtin_topics/c++98/README.md
+++ b/examples/connext_dds/builtin_topics/c++98/README.md
@@ -137,7 +137,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/builtin_topics/c++98/README.md
+++ b/examples/connext_dds/builtin_topics/c++98/README.md
@@ -103,44 +103,44 @@ Subscriber Output
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -149,8 +149,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -158,16 +158,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/builtin_topics/c++98/README.md
+++ b/examples/connext_dds/builtin_topics/c++98/README.md
@@ -112,13 +112,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/builtin_topics/c/README.md
+++ b/examples/connext_dds/builtin_topics/c/README.md
@@ -104,44 +104,44 @@ Subscriber Output
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -150,8 +150,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -159,16 +159,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/builtin_topics/c/README.md
+++ b/examples/connext_dds/builtin_topics/c/README.md
@@ -138,7 +138,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/builtin_topics/c/README.md
+++ b/examples/connext_dds/builtin_topics/c/README.md
@@ -113,13 +113,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/builtin_topics/c/README.md
+++ b/examples/connext_dds/builtin_topics/c/README.md
@@ -104,7 +104,7 @@ Subscriber Output
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/builtin_topics/c/README.md
+++ b/examples/connext_dds/builtin_topics/c/README.md
@@ -108,8 +108,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/builtin_topics/c/README.md
+++ b/examples/connext_dds/builtin_topics/c/README.md
@@ -115,6 +115,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/coherent_presentation/c++11/README.md
+++ b/examples/connext_dds/coherent_presentation/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/coherent_presentation/c++11/README.md
+++ b/examples/connext_dds/coherent_presentation/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/coherent_presentation/c++11/README.md
+++ b/examples/connext_dds/coherent_presentation/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/coherent_presentation/c++11/README.md
+++ b/examples/connext_dds/coherent_presentation/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/coherent_presentation/c++11/README.md
+++ b/examples/connext_dds/coherent_presentation/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/coherent_presentation/c++11/README.md
+++ b/examples/connext_dds/coherent_presentation/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/coherent_presentation/c++98/README.md
+++ b/examples/connext_dds/coherent_presentation/c++98/README.md
@@ -67,44 +67,44 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/coherent_presentation/c++98/README.md
+++ b/examples/connext_dds/coherent_presentation/c++98/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/coherent_presentation/c++98/README.md
+++ b/examples/connext_dds/coherent_presentation/c++98/README.md
@@ -67,7 +67,7 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/coherent_presentation/c++98/README.md
+++ b/examples/connext_dds/coherent_presentation/c++98/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/coherent_presentation/c++98/README.md
+++ b/examples/connext_dds/coherent_presentation/c++98/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/coherent_presentation/c++98/README.md
+++ b/examples/connext_dds/coherent_presentation/c++98/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/coherent_presentation/c/README.md
+++ b/examples/connext_dds/coherent_presentation/c/README.md
@@ -68,7 +68,7 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/coherent_presentation/c/README.md
+++ b/examples/connext_dds/coherent_presentation/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/coherent_presentation/c/README.md
+++ b/examples/connext_dds/coherent_presentation/c/README.md
@@ -68,44 +68,44 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/coherent_presentation/c/README.md
+++ b/examples/connext_dds/coherent_presentation/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/coherent_presentation/c/README.md
+++ b/examples/connext_dds/coherent_presentation/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/coherent_presentation/c/README.md
+++ b/examples/connext_dds/coherent_presentation/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/compression/c++11/README.md
+++ b/examples/connext_dds/compression/c++11/README.md
@@ -86,6 +86,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/compression/c++11/README.md
+++ b/examples/connext_dds/compression/c++11/README.md
@@ -79,8 +79,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/compression/c++11/README.md
+++ b/examples/connext_dds/compression/c++11/README.md
@@ -75,7 +75,7 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/compression/c++11/README.md
+++ b/examples/connext_dds/compression/c++11/README.md
@@ -84,13 +84,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/compression/c++11/README.md
+++ b/examples/connext_dds/compression/c++11/README.md
@@ -75,44 +75,44 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -121,8 +121,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -130,16 +130,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/compression/c++11/README.md
+++ b/examples/connext_dds/compression/c++11/README.md
@@ -109,7 +109,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/compression/c++98/README.md
+++ b/examples/connext_dds/compression/c++98/README.md
@@ -86,6 +86,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/compression/c++98/README.md
+++ b/examples/connext_dds/compression/c++98/README.md
@@ -79,8 +79,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/compression/c++98/README.md
+++ b/examples/connext_dds/compression/c++98/README.md
@@ -75,7 +75,7 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/compression/c++98/README.md
+++ b/examples/connext_dds/compression/c++98/README.md
@@ -84,13 +84,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/compression/c++98/README.md
+++ b/examples/connext_dds/compression/c++98/README.md
@@ -75,44 +75,44 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -121,8 +121,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -130,16 +130,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/compression/c++98/README.md
+++ b/examples/connext_dds/compression/c++98/README.md
@@ -109,7 +109,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/content_filtered_topic/c++11/README.md
+++ b/examples/connext_dds/content_filtered_topic/c++11/README.md
@@ -104,7 +104,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/content_filtered_topic/c++11/README.md
+++ b/examples/connext_dds/content_filtered_topic/c++11/README.md
@@ -70,7 +70,7 @@ normal *Topic* instead of a *Content Filtered Topic*.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/content_filtered_topic/c++11/README.md
+++ b/examples/connext_dds/content_filtered_topic/c++11/README.md
@@ -70,44 +70,44 @@ normal *Topic* instead of a *Content Filtered Topic*.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -116,8 +116,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -125,16 +125,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/content_filtered_topic/c++11/README.md
+++ b/examples/connext_dds/content_filtered_topic/c++11/README.md
@@ -81,6 +81,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/content_filtered_topic/c++11/README.md
+++ b/examples/connext_dds/content_filtered_topic/c++11/README.md
@@ -74,8 +74,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/content_filtered_topic/c++11/README.md
+++ b/examples/connext_dds/content_filtered_topic/c++11/README.md
@@ -79,13 +79,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/content_filtered_topic/c++98/README.md
+++ b/examples/connext_dds/content_filtered_topic/c++98/README.md
@@ -104,7 +104,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/content_filtered_topic/c++98/README.md
+++ b/examples/connext_dds/content_filtered_topic/c++98/README.md
@@ -81,6 +81,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/content_filtered_topic/c++98/README.md
+++ b/examples/connext_dds/content_filtered_topic/c++98/README.md
@@ -74,8 +74,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/content_filtered_topic/c++98/README.md
+++ b/examples/connext_dds/content_filtered_topic/c++98/README.md
@@ -79,13 +79,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/content_filtered_topic/c++98/README.md
+++ b/examples/connext_dds/content_filtered_topic/c++98/README.md
@@ -70,7 +70,7 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/content_filtered_topic/c++98/README.md
+++ b/examples/connext_dds/content_filtered_topic/c++98/README.md
@@ -70,44 +70,44 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -116,8 +116,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -125,16 +125,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/content_filtered_topic/c/README.md
+++ b/examples/connext_dds/content_filtered_topic/c/README.md
@@ -106,7 +106,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/content_filtered_topic/c/README.md
+++ b/examples/connext_dds/content_filtered_topic/c/README.md
@@ -72,7 +72,7 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/content_filtered_topic/c/README.md
+++ b/examples/connext_dds/content_filtered_topic/c/README.md
@@ -76,8 +76,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/content_filtered_topic/c/README.md
+++ b/examples/connext_dds/content_filtered_topic/c/README.md
@@ -72,44 +72,44 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -118,8 +118,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -127,16 +127,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/content_filtered_topic/c/README.md
+++ b/examples/connext_dds/content_filtered_topic/c/README.md
@@ -83,6 +83,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/content_filtered_topic/c/README.md
+++ b/examples/connext_dds/content_filtered_topic/c/README.md
@@ -81,13 +81,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/content_filtered_topic_string_filter/c++11/README.md
+++ b/examples/connext_dds/content_filtered_topic_string_filter/c++11/README.md
@@ -104,7 +104,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/content_filtered_topic_string_filter/c++11/README.md
+++ b/examples/connext_dds/content_filtered_topic_string_filter/c++11/README.md
@@ -70,7 +70,7 @@ normal *Topic* instead of a *Content Filtered Topic*.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/content_filtered_topic_string_filter/c++11/README.md
+++ b/examples/connext_dds/content_filtered_topic_string_filter/c++11/README.md
@@ -70,44 +70,44 @@ normal *Topic* instead of a *Content Filtered Topic*.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -116,8 +116,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -125,16 +125,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/content_filtered_topic_string_filter/c++11/README.md
+++ b/examples/connext_dds/content_filtered_topic_string_filter/c++11/README.md
@@ -81,6 +81,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/content_filtered_topic_string_filter/c++11/README.md
+++ b/examples/connext_dds/content_filtered_topic_string_filter/c++11/README.md
@@ -74,8 +74,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/content_filtered_topic_string_filter/c++11/README.md
+++ b/examples/connext_dds/content_filtered_topic_string_filter/c++11/README.md
@@ -79,13 +79,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/content_filtered_topic_string_filter/c++98/README.md
+++ b/examples/connext_dds/content_filtered_topic_string_filter/c++98/README.md
@@ -104,7 +104,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/content_filtered_topic_string_filter/c++98/README.md
+++ b/examples/connext_dds/content_filtered_topic_string_filter/c++98/README.md
@@ -81,6 +81,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/content_filtered_topic_string_filter/c++98/README.md
+++ b/examples/connext_dds/content_filtered_topic_string_filter/c++98/README.md
@@ -74,8 +74,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/content_filtered_topic_string_filter/c++98/README.md
+++ b/examples/connext_dds/content_filtered_topic_string_filter/c++98/README.md
@@ -79,13 +79,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/content_filtered_topic_string_filter/c++98/README.md
+++ b/examples/connext_dds/content_filtered_topic_string_filter/c++98/README.md
@@ -70,7 +70,7 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/content_filtered_topic_string_filter/c++98/README.md
+++ b/examples/connext_dds/content_filtered_topic_string_filter/c++98/README.md
@@ -70,44 +70,44 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -116,8 +116,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -125,16 +125,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/content_filtered_topic_string_filter/c/README.md
+++ b/examples/connext_dds/content_filtered_topic_string_filter/c/README.md
@@ -106,7 +106,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/content_filtered_topic_string_filter/c/README.md
+++ b/examples/connext_dds/content_filtered_topic_string_filter/c/README.md
@@ -72,7 +72,7 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/content_filtered_topic_string_filter/c/README.md
+++ b/examples/connext_dds/content_filtered_topic_string_filter/c/README.md
@@ -76,8 +76,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/content_filtered_topic_string_filter/c/README.md
+++ b/examples/connext_dds/content_filtered_topic_string_filter/c/README.md
@@ -72,44 +72,44 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -118,8 +118,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -127,16 +127,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/content_filtered_topic_string_filter/c/README.md
+++ b/examples/connext_dds/content_filtered_topic_string_filter/c/README.md
@@ -83,6 +83,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/content_filtered_topic_string_filter/c/README.md
+++ b/examples/connext_dds/content_filtered_topic_string_filter/c/README.md
@@ -81,13 +81,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/custom_content_filter/c++11/README.md
+++ b/examples/connext_dds/custom_content_filter/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/custom_content_filter/c++11/README.md
+++ b/examples/connext_dds/custom_content_filter/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/custom_content_filter/c++11/README.md
+++ b/examples/connext_dds/custom_content_filter/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/custom_content_filter/c++11/README.md
+++ b/examples/connext_dds/custom_content_filter/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/custom_content_filter/c++11/README.md
+++ b/examples/connext_dds/custom_content_filter/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/custom_content_filter/c++11/README.md
+++ b/examples/connext_dds/custom_content_filter/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/custom_content_filter/c++98/README.md
+++ b/examples/connext_dds/custom_content_filter/c++98/README.md
@@ -100,7 +100,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/custom_content_filter/c++98/README.md
+++ b/examples/connext_dds/custom_content_filter/c++98/README.md
@@ -77,6 +77,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/custom_content_filter/c++98/README.md
+++ b/examples/connext_dds/custom_content_filter/c++98/README.md
@@ -70,8 +70,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/custom_content_filter/c++98/README.md
+++ b/examples/connext_dds/custom_content_filter/c++98/README.md
@@ -66,44 +66,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -112,8 +112,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -121,16 +121,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/custom_content_filter/c++98/README.md
+++ b/examples/connext_dds/custom_content_filter/c++98/README.md
@@ -75,13 +75,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/custom_content_filter/c++98/README.md
+++ b/examples/connext_dds/custom_content_filter/c++98/README.md
@@ -66,7 +66,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/custom_content_filter/c/README.md
+++ b/examples/connext_dds/custom_content_filter/c/README.md
@@ -68,44 +68,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/custom_content_filter/c/README.md
+++ b/examples/connext_dds/custom_content_filter/c/README.md
@@ -68,7 +68,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/custom_content_filter/c/README.md
+++ b/examples/connext_dds/custom_content_filter/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/custom_content_filter/c/README.md
+++ b/examples/connext_dds/custom_content_filter/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/custom_content_filter/c/README.md
+++ b/examples/connext_dds/custom_content_filter/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/custom_content_filter/c/README.md
+++ b/examples/connext_dds/custom_content_filter/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/custom_flow_controller/c++11/README.md
+++ b/examples/connext_dds/custom_flow_controller/c++11/README.md
@@ -141,8 +141,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/custom_flow_controller/c++11/README.md
+++ b/examples/connext_dds/custom_flow_controller/c++11/README.md
@@ -171,7 +171,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/custom_flow_controller/c++11/README.md
+++ b/examples/connext_dds/custom_flow_controller/c++11/README.md
@@ -146,13 +146,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/custom_flow_controller/c++11/README.md
+++ b/examples/connext_dds/custom_flow_controller/c++11/README.md
@@ -137,7 +137,7 @@ Writing cfc, sample 29
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/custom_flow_controller/c++11/README.md
+++ b/examples/connext_dds/custom_flow_controller/c++11/README.md
@@ -148,6 +148,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/custom_flow_controller/c++11/README.md
+++ b/examples/connext_dds/custom_flow_controller/c++11/README.md
@@ -137,44 +137,44 @@ Writing cfc, sample 29
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -183,8 +183,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -192,16 +192,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/custom_flow_controller/c++98/README.md
+++ b/examples/connext_dds/custom_flow_controller/c++98/README.md
@@ -133,44 +133,44 @@ Writing cfc, sample 39
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -179,8 +179,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -188,16 +188,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/custom_flow_controller/c++98/README.md
+++ b/examples/connext_dds/custom_flow_controller/c++98/README.md
@@ -142,13 +142,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/custom_flow_controller/c++98/README.md
+++ b/examples/connext_dds/custom_flow_controller/c++98/README.md
@@ -133,7 +133,7 @@ Writing cfc, sample 39
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/custom_flow_controller/c++98/README.md
+++ b/examples/connext_dds/custom_flow_controller/c++98/README.md
@@ -144,6 +144,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/custom_flow_controller/c++98/README.md
+++ b/examples/connext_dds/custom_flow_controller/c++98/README.md
@@ -167,7 +167,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/custom_flow_controller/c++98/README.md
+++ b/examples/connext_dds/custom_flow_controller/c++98/README.md
@@ -137,8 +137,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/custom_flow_controller/c/README.md
+++ b/examples/connext_dds/custom_flow_controller/c/README.md
@@ -134,7 +134,7 @@ Writing cfc, sample 39
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/custom_flow_controller/c/README.md
+++ b/examples/connext_dds/custom_flow_controller/c/README.md
@@ -134,44 +134,44 @@ Writing cfc, sample 39
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -180,8 +180,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -189,16 +189,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/custom_flow_controller/c/README.md
+++ b/examples/connext_dds/custom_flow_controller/c/README.md
@@ -145,6 +145,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/custom_flow_controller/c/README.md
+++ b/examples/connext_dds/custom_flow_controller/c/README.md
@@ -138,8 +138,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/custom_flow_controller/c/README.md
+++ b/examples/connext_dds/custom_flow_controller/c/README.md
@@ -143,13 +143,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/custom_flow_controller/c/README.md
+++ b/examples/connext_dds/custom_flow_controller/c/README.md
@@ -168,7 +168,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/custom_transport/c/README.md
+++ b/examples/connext_dds/custom_transport/c/README.md
@@ -229,7 +229,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/custom_transport/c/README.md
+++ b/examples/connext_dds/custom_transport/c/README.md
@@ -195,7 +195,7 @@ CustomTransport subscriber sleeping for 4 sec...
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/custom_transport/c/README.md
+++ b/examples/connext_dds/custom_transport/c/README.md
@@ -199,8 +199,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/custom_transport/c/README.md
+++ b/examples/connext_dds/custom_transport/c/README.md
@@ -206,6 +206,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/custom_transport/c/README.md
+++ b/examples/connext_dds/custom_transport/c/README.md
@@ -204,13 +204,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/custom_transport/c/README.md
+++ b/examples/connext_dds/custom_transport/c/README.md
@@ -195,44 +195,44 @@ CustomTransport subscriber sleeping for 4 sec...
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -241,8 +241,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -250,16 +250,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/deadline_contentfilter/c++11/README.md
+++ b/examples/connext_dds/deadline_contentfilter/c++11/README.md
@@ -171,7 +171,7 @@ Missed deadline @ t=0.058816s on instance code = 1
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/deadline_contentfilter/c++11/README.md
+++ b/examples/connext_dds/deadline_contentfilter/c++11/README.md
@@ -205,7 +205,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/deadline_contentfilter/c++11/README.md
+++ b/examples/connext_dds/deadline_contentfilter/c++11/README.md
@@ -175,8 +175,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/deadline_contentfilter/c++11/README.md
+++ b/examples/connext_dds/deadline_contentfilter/c++11/README.md
@@ -171,44 +171,44 @@ Missed deadline @ t=0.058816s on instance code = 1
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -217,8 +217,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -226,16 +226,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/deadline_contentfilter/c++11/README.md
+++ b/examples/connext_dds/deadline_contentfilter/c++11/README.md
@@ -182,6 +182,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/deadline_contentfilter/c++11/README.md
+++ b/examples/connext_dds/deadline_contentfilter/c++11/README.md
@@ -180,13 +180,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/deadline_contentfilter/c++98/README.md
+++ b/examples/connext_dds/deadline_contentfilter/c++98/README.md
@@ -142,8 +142,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/deadline_contentfilter/c++98/README.md
+++ b/examples/connext_dds/deadline_contentfilter/c++98/README.md
@@ -172,7 +172,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/deadline_contentfilter/c++98/README.md
+++ b/examples/connext_dds/deadline_contentfilter/c++98/README.md
@@ -147,13 +147,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/deadline_contentfilter/c++98/README.md
+++ b/examples/connext_dds/deadline_contentfilter/c++98/README.md
@@ -138,44 +138,44 @@ Missed deadline @ t=21.88s on instance code = 1
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -184,8 +184,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -193,16 +193,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/deadline_contentfilter/c++98/README.md
+++ b/examples/connext_dds/deadline_contentfilter/c++98/README.md
@@ -149,6 +149,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/deadline_contentfilter/c++98/README.md
+++ b/examples/connext_dds/deadline_contentfilter/c++98/README.md
@@ -138,7 +138,7 @@ Missed deadline @ t=21.88s on instance code = 1
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/deadline_contentfilter/c/README.md
+++ b/examples/connext_dds/deadline_contentfilter/c/README.md
@@ -142,44 +142,44 @@ Missed deadline @ t=18.00s on instance code = 1
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -188,8 +188,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -197,16 +197,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/deadline_contentfilter/c/README.md
+++ b/examples/connext_dds/deadline_contentfilter/c/README.md
@@ -176,7 +176,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/deadline_contentfilter/c/README.md
+++ b/examples/connext_dds/deadline_contentfilter/c/README.md
@@ -142,7 +142,7 @@ Missed deadline @ t=18.00s on instance code = 1
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/deadline_contentfilter/c/README.md
+++ b/examples/connext_dds/deadline_contentfilter/c/README.md
@@ -153,6 +153,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/deadline_contentfilter/c/README.md
+++ b/examples/connext_dds/deadline_contentfilter/c/README.md
@@ -146,8 +146,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/deadline_contentfilter/c/README.md
+++ b/examples/connext_dds/deadline_contentfilter/c/README.md
@@ -151,13 +151,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/detect_samples_dropped/c++11/README.md
+++ b/examples/connext_dds/detect_samples_dropped/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/detect_samples_dropped/c++11/README.md
+++ b/examples/connext_dds/detect_samples_dropped/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/detect_samples_dropped/c++11/README.md
+++ b/examples/connext_dds/detect_samples_dropped/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/detect_samples_dropped/c++11/README.md
+++ b/examples/connext_dds/detect_samples_dropped/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/detect_samples_dropped/c++11/README.md
+++ b/examples/connext_dds/detect_samples_dropped/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/detect_samples_dropped/c++11/README.md
+++ b/examples/connext_dds/detect_samples_dropped/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/detect_samples_dropped/c++98/README.md
+++ b/examples/connext_dds/detect_samples_dropped/c++98/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/detect_samples_dropped/c++98/README.md
+++ b/examples/connext_dds/detect_samples_dropped/c++98/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/detect_samples_dropped/c++98/README.md
+++ b/examples/connext_dds/detect_samples_dropped/c++98/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/detect_samples_dropped/c++98/README.md
+++ b/examples/connext_dds/detect_samples_dropped/c++98/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/detect_samples_dropped/c++98/README.md
+++ b/examples/connext_dds/detect_samples_dropped/c++98/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/detect_samples_dropped/c++98/README.md
+++ b/examples/connext_dds/detect_samples_dropped/c++98/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/detect_samples_dropped/c/README.md
+++ b/examples/connext_dds/detect_samples_dropped/c/README.md
@@ -68,44 +68,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/detect_samples_dropped/c/README.md
+++ b/examples/connext_dds/detect_samples_dropped/c/README.md
@@ -68,7 +68,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/detect_samples_dropped/c/README.md
+++ b/examples/connext_dds/detect_samples_dropped/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/detect_samples_dropped/c/README.md
+++ b/examples/connext_dds/detect_samples_dropped/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/detect_samples_dropped/c/README.md
+++ b/examples/connext_dds/detect_samples_dropped/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/detect_samples_dropped/c/README.md
+++ b/examples/connext_dds/detect_samples_dropped/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/discovery_snapshot/c++11/README.md
+++ b/examples/connext_dds/discovery_snapshot/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/discovery_snapshot/c++11/README.md
+++ b/examples/connext_dds/discovery_snapshot/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/discovery_snapshot/c++11/README.md
+++ b/examples/connext_dds/discovery_snapshot/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/discovery_snapshot/c++11/README.md
+++ b/examples/connext_dds/discovery_snapshot/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/discovery_snapshot/c++11/README.md
+++ b/examples/connext_dds/discovery_snapshot/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/discovery_snapshot/c++11/README.md
+++ b/examples/connext_dds/discovery_snapshot/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/discovery_snapshot/c/README.md
+++ b/examples/connext_dds/discovery_snapshot/c/README.md
@@ -68,44 +68,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/discovery_snapshot/c/README.md
+++ b/examples/connext_dds/discovery_snapshot/c/README.md
@@ -68,7 +68,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/discovery_snapshot/c/README.md
+++ b/examples/connext_dds/discovery_snapshot/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/discovery_snapshot/c/README.md
+++ b/examples/connext_dds/discovery_snapshot/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/discovery_snapshot/c/README.md
+++ b/examples/connext_dds/discovery_snapshot/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/discovery_snapshot/c/README.md
+++ b/examples/connext_dds/discovery_snapshot/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c++11/README.md
@@ -55,7 +55,7 @@ dynamic_data_union_example
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c++11/README.md
@@ -55,44 +55,44 @@ dynamic_data_union_example
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -101,8 +101,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -110,16 +110,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c++11/README.md
@@ -89,7 +89,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c++11/README.md
@@ -66,6 +66,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c++11/README.md
@@ -59,8 +59,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c++11/README.md
@@ -64,13 +64,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c++98/README.md
@@ -55,7 +55,7 @@ dynamic_data_union_example
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c++98/README.md
@@ -55,44 +55,44 @@ dynamic_data_union_example
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -101,8 +101,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -110,16 +110,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c++98/README.md
@@ -89,7 +89,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c++98/README.md
@@ -66,6 +66,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c++98/README.md
@@ -59,8 +59,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c++98/README.md
@@ -64,13 +64,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c/README.md
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c/README.md
@@ -55,7 +55,7 @@ dynamic_data_union_example
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c/README.md
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c/README.md
@@ -55,44 +55,44 @@ dynamic_data_union_example
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -101,8 +101,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -110,16 +110,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c/README.md
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c/README.md
@@ -89,7 +89,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c/README.md
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c/README.md
@@ -66,6 +66,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c/README.md
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c/README.md
@@ -59,8 +59,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c/README.md
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c/README.md
@@ -64,13 +64,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/dynamic_data_nested_structs/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_nested_structs/c++11/README.md
@@ -117,6 +117,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/dynamic_data_nested_structs/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_nested_structs/c++11/README.md
@@ -106,44 +106,44 @@ loan/unloan API
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -152,8 +152,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -161,16 +161,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/dynamic_data_nested_structs/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_nested_structs/c++11/README.md
@@ -115,13 +115,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/dynamic_data_nested_structs/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_nested_structs/c++11/README.md
@@ -106,7 +106,7 @@ loan/unloan API
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/dynamic_data_nested_structs/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_nested_structs/c++11/README.md
@@ -140,7 +140,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/dynamic_data_nested_structs/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_nested_structs/c++11/README.md
@@ -110,8 +110,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/dynamic_data_nested_structs/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_nested_structs/c++98/README.md
@@ -129,13 +129,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/dynamic_data_nested_structs/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_nested_structs/c++98/README.md
@@ -124,8 +124,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/dynamic_data_nested_structs/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_nested_structs/c++98/README.md
@@ -120,7 +120,7 @@ Creating a new dynamic data called bounded_data
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/dynamic_data_nested_structs/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_nested_structs/c++98/README.md
@@ -131,6 +131,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/dynamic_data_nested_structs/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_nested_structs/c++98/README.md
@@ -120,44 +120,44 @@ Creating a new dynamic data called bounded_data
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -166,8 +166,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -175,16 +175,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/dynamic_data_nested_structs/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_nested_structs/c++98/README.md
@@ -154,7 +154,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/dynamic_data_nested_structs/c/README.md
+++ b/examples/connext_dds/dynamic_data_nested_structs/c/README.md
@@ -129,13 +129,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/dynamic_data_nested_structs/c/README.md
+++ b/examples/connext_dds/dynamic_data_nested_structs/c/README.md
@@ -124,8 +124,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/dynamic_data_nested_structs/c/README.md
+++ b/examples/connext_dds/dynamic_data_nested_structs/c/README.md
@@ -120,7 +120,7 @@ Creating a new dynamic data called bounded_data
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/dynamic_data_nested_structs/c/README.md
+++ b/examples/connext_dds/dynamic_data_nested_structs/c/README.md
@@ -131,6 +131,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/dynamic_data_nested_structs/c/README.md
+++ b/examples/connext_dds/dynamic_data_nested_structs/c/README.md
@@ -120,44 +120,44 @@ Creating a new dynamic data called bounded_data
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -166,8 +166,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -175,16 +175,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/dynamic_data_nested_structs/c/README.md
+++ b/examples/connext_dds/dynamic_data_nested_structs/c/README.md
@@ -154,7 +154,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/dynamic_data_sequences/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_sequences/c++11/README.md
@@ -55,44 +55,44 @@ dynamic_data_sequences
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -101,8 +101,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -110,16 +110,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/dynamic_data_sequences/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_sequences/c++11/README.md
@@ -55,7 +55,7 @@ dynamic_data_sequences
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/dynamic_data_sequences/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_sequences/c++11/README.md
@@ -89,7 +89,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/dynamic_data_sequences/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_sequences/c++11/README.md
@@ -66,6 +66,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/dynamic_data_sequences/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_sequences/c++11/README.md
@@ -59,8 +59,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/dynamic_data_sequences/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_sequences/c++11/README.md
@@ -64,13 +64,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/dynamic_data_sequences/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_sequences/c++98/README.md
@@ -55,44 +55,44 @@ dynamic_data_sequences
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -101,8 +101,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -110,16 +110,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/dynamic_data_sequences/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_sequences/c++98/README.md
@@ -55,7 +55,7 @@ dynamic_data_sequences
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/dynamic_data_sequences/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_sequences/c++98/README.md
@@ -89,7 +89,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/dynamic_data_sequences/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_sequences/c++98/README.md
@@ -66,6 +66,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/dynamic_data_sequences/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_sequences/c++98/README.md
@@ -59,8 +59,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/dynamic_data_sequences/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_sequences/c++98/README.md
@@ -64,13 +64,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/dynamic_data_sequences/c/README.md
+++ b/examples/connext_dds/dynamic_data_sequences/c/README.md
@@ -55,44 +55,44 @@ dynamic_data_sequences
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -101,8 +101,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -110,16 +110,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/dynamic_data_sequences/c/README.md
+++ b/examples/connext_dds/dynamic_data_sequences/c/README.md
@@ -55,7 +55,7 @@ dynamic_data_sequences
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/dynamic_data_sequences/c/README.md
+++ b/examples/connext_dds/dynamic_data_sequences/c/README.md
@@ -89,7 +89,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/dynamic_data_sequences/c/README.md
+++ b/examples/connext_dds/dynamic_data_sequences/c/README.md
@@ -66,6 +66,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/dynamic_data_sequences/c/README.md
+++ b/examples/connext_dds/dynamic_data_sequences/c/README.md
@@ -59,8 +59,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/dynamic_data_sequences/c/README.md
+++ b/examples/connext_dds/dynamic_data_sequences/c/README.md
@@ -64,13 +64,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++11/README.md
@@ -105,6 +105,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++11/README.md
@@ -103,13 +103,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++11/README.md
@@ -94,7 +94,7 @@ Demo* and your command prompt.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++11/README.md
@@ -98,8 +98,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++11/README.md
@@ -128,7 +128,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++11/README.md
@@ -94,44 +94,44 @@ Demo* and your command prompt.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -140,8 +140,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -149,16 +149,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++98/README.md
@@ -127,7 +127,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++98/README.md
@@ -102,13 +102,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++98/README.md
@@ -104,6 +104,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++98/README.md
@@ -93,7 +93,7 @@ Demo* and your command prompt.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++98/README.md
@@ -97,8 +97,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++98/README.md
+++ b/examples/connext_dds/dynamic_data_using_publisher_subscriber/c++98/README.md
@@ -93,44 +93,44 @@ Demo* and your command prompt.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -139,8 +139,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -148,16 +148,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/dynamic_data_using_publisher_subscriber/c/README.md
+++ b/examples/connext_dds/dynamic_data_using_publisher_subscriber/c/README.md
@@ -105,6 +105,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/dynamic_data_using_publisher_subscriber/c/README.md
+++ b/examples/connext_dds/dynamic_data_using_publisher_subscriber/c/README.md
@@ -103,13 +103,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/dynamic_data_using_publisher_subscriber/c/README.md
+++ b/examples/connext_dds/dynamic_data_using_publisher_subscriber/c/README.md
@@ -94,7 +94,7 @@ Demo* and your command prompt.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/dynamic_data_using_publisher_subscriber/c/README.md
+++ b/examples/connext_dds/dynamic_data_using_publisher_subscriber/c/README.md
@@ -98,8 +98,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/dynamic_data_using_publisher_subscriber/c/README.md
+++ b/examples/connext_dds/dynamic_data_using_publisher_subscriber/c/README.md
@@ -128,7 +128,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/dynamic_data_using_publisher_subscriber/c/README.md
+++ b/examples/connext_dds/dynamic_data_using_publisher_subscriber/c/README.md
@@ -94,44 +94,44 @@ Demo* and your command prompt.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -140,8 +140,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -149,16 +149,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/flat_data_api/c++11/README.md
+++ b/examples/connext_dds/flat_data_api/c++11/README.md
@@ -92,8 +92,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/flat_data_api/c++11/README.md
+++ b/examples/connext_dds/flat_data_api/c++11/README.md
@@ -97,13 +97,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/flat_data_api/c++11/README.md
+++ b/examples/connext_dds/flat_data_api/c++11/README.md
@@ -122,7 +122,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/flat_data_api/c++11/README.md
+++ b/examples/connext_dds/flat_data_api/c++11/README.md
@@ -99,6 +99,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/flat_data_api/c++11/README.md
+++ b/examples/connext_dds/flat_data_api/c++11/README.md
@@ -88,44 +88,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -134,8 +134,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -143,16 +143,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/flat_data_api/c++11/README.md
+++ b/examples/connext_dds/flat_data_api/c++11/README.md
@@ -88,7 +88,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/flat_data_api/c++98/README.md
+++ b/examples/connext_dds/flat_data_api/c++98/README.md
@@ -113,8 +113,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/flat_data_api/c++98/README.md
+++ b/examples/connext_dds/flat_data_api/c++98/README.md
@@ -109,44 +109,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -155,8 +155,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -164,16 +164,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/flat_data_api/c++98/README.md
+++ b/examples/connext_dds/flat_data_api/c++98/README.md
@@ -109,7 +109,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/flat_data_api/c++98/README.md
+++ b/examples/connext_dds/flat_data_api/c++98/README.md
@@ -118,13 +118,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/flat_data_api/c++98/README.md
+++ b/examples/connext_dds/flat_data_api/c++98/README.md
@@ -143,7 +143,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/flat_data_api/c++98/README.md
+++ b/examples/connext_dds/flat_data_api/c++98/README.md
@@ -120,6 +120,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/flat_data_latency/c++11/README.md
+++ b/examples/connext_dds/flat_data_latency/c++11/README.md
@@ -165,7 +165,7 @@ Discovery complete
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/flat_data_latency/c++11/README.md
+++ b/examples/connext_dds/flat_data_latency/c++11/README.md
@@ -165,44 +165,44 @@ Discovery complete
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -211,8 +211,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -220,16 +220,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/flat_data_latency/c++11/README.md
+++ b/examples/connext_dds/flat_data_latency/c++11/README.md
@@ -174,13 +174,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/flat_data_latency/c++11/README.md
+++ b/examples/connext_dds/flat_data_latency/c++11/README.md
@@ -169,8 +169,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/flat_data_latency/c++11/README.md
+++ b/examples/connext_dds/flat_data_latency/c++11/README.md
@@ -199,7 +199,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/flat_data_latency/c++11/README.md
+++ b/examples/connext_dds/flat_data_latency/c++11/README.md
@@ -176,6 +176,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/fragmented_data_statistics/c++11/README.md
+++ b/examples/connext_dds/fragmented_data_statistics/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/fragmented_data_statistics/c++11/README.md
+++ b/examples/connext_dds/fragmented_data_statistics/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/fragmented_data_statistics/c++11/README.md
+++ b/examples/connext_dds/fragmented_data_statistics/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/fragmented_data_statistics/c++11/README.md
+++ b/examples/connext_dds/fragmented_data_statistics/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/fragmented_data_statistics/c++11/README.md
+++ b/examples/connext_dds/fragmented_data_statistics/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/fragmented_data_statistics/c++11/README.md
+++ b/examples/connext_dds/fragmented_data_statistics/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/fragmented_data_statistics/c++98/README.md
+++ b/examples/connext_dds/fragmented_data_statistics/c++98/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/fragmented_data_statistics/c++98/README.md
+++ b/examples/connext_dds/fragmented_data_statistics/c++98/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/fragmented_data_statistics/c++98/README.md
+++ b/examples/connext_dds/fragmented_data_statistics/c++98/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/fragmented_data_statistics/c++98/README.md
+++ b/examples/connext_dds/fragmented_data_statistics/c++98/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/fragmented_data_statistics/c++98/README.md
+++ b/examples/connext_dds/fragmented_data_statistics/c++98/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/fragmented_data_statistics/c++98/README.md
+++ b/examples/connext_dds/fragmented_data_statistics/c++98/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/fragmented_data_statistics/c/README.md
+++ b/examples/connext_dds/fragmented_data_statistics/c/README.md
@@ -68,44 +68,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/fragmented_data_statistics/c/README.md
+++ b/examples/connext_dds/fragmented_data_statistics/c/README.md
@@ -68,7 +68,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/fragmented_data_statistics/c/README.md
+++ b/examples/connext_dds/fragmented_data_statistics/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/fragmented_data_statistics/c/README.md
+++ b/examples/connext_dds/fragmented_data_statistics/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/fragmented_data_statistics/c/README.md
+++ b/examples/connext_dds/fragmented_data_statistics/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/fragmented_data_statistics/c/README.md
+++ b/examples/connext_dds/fragmented_data_statistics/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/get_publishers/c++11/README.md
+++ b/examples/connext_dds/get_publishers/c++11/README.md
@@ -73,6 +73,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/get_publishers/c++11/README.md
+++ b/examples/connext_dds/get_publishers/c++11/README.md
@@ -66,8 +66,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/get_publishers/c++11/README.md
+++ b/examples/connext_dds/get_publishers/c++11/README.md
@@ -96,7 +96,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/get_publishers/c++11/README.md
+++ b/examples/connext_dds/get_publishers/c++11/README.md
@@ -62,44 +62,44 @@ The applications accept one argument:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -108,8 +108,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -117,16 +117,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/get_publishers/c++11/README.md
+++ b/examples/connext_dds/get_publishers/c++11/README.md
@@ -71,13 +71,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/get_publishers/c++11/README.md
+++ b/examples/connext_dds/get_publishers/c++11/README.md
@@ -62,7 +62,7 @@ The applications accept one argument:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/get_publishers/c++98/README.md
+++ b/examples/connext_dds/get_publishers/c++98/README.md
@@ -73,6 +73,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/get_publishers/c++98/README.md
+++ b/examples/connext_dds/get_publishers/c++98/README.md
@@ -66,8 +66,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/get_publishers/c++98/README.md
+++ b/examples/connext_dds/get_publishers/c++98/README.md
@@ -96,7 +96,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/get_publishers/c++98/README.md
+++ b/examples/connext_dds/get_publishers/c++98/README.md
@@ -62,44 +62,44 @@ The applications accept one argument:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -108,8 +108,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -117,16 +117,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/get_publishers/c++98/README.md
+++ b/examples/connext_dds/get_publishers/c++98/README.md
@@ -71,13 +71,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/get_publishers/c++98/README.md
+++ b/examples/connext_dds/get_publishers/c++98/README.md
@@ -62,7 +62,7 @@ The applications accept one argument:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/get_publishers/c/README.md
+++ b/examples/connext_dds/get_publishers/c/README.md
@@ -73,6 +73,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/get_publishers/c/README.md
+++ b/examples/connext_dds/get_publishers/c/README.md
@@ -66,8 +66,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/get_publishers/c/README.md
+++ b/examples/connext_dds/get_publishers/c/README.md
@@ -96,7 +96,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/get_publishers/c/README.md
+++ b/examples/connext_dds/get_publishers/c/README.md
@@ -62,44 +62,44 @@ The applications accept one argument:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -108,8 +108,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -117,16 +117,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/get_publishers/c/README.md
+++ b/examples/connext_dds/get_publishers/c/README.md
@@ -71,13 +71,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/get_publishers/c/README.md
+++ b/examples/connext_dds/get_publishers/c/README.md
@@ -62,7 +62,7 @@ The applications accept one argument:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/group_coherent_presentation/c++11/README.md
+++ b/examples/connext_dds/group_coherent_presentation/c++11/README.md
@@ -75,8 +75,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/group_coherent_presentation/c++11/README.md
+++ b/examples/connext_dds/group_coherent_presentation/c++11/README.md
@@ -71,44 +71,44 @@ The applications accept up to four arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -117,8 +117,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -126,16 +126,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/group_coherent_presentation/c++11/README.md
+++ b/examples/connext_dds/group_coherent_presentation/c++11/README.md
@@ -71,7 +71,7 @@ The applications accept up to four arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/group_coherent_presentation/c++11/README.md
+++ b/examples/connext_dds/group_coherent_presentation/c++11/README.md
@@ -82,6 +82,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/group_coherent_presentation/c++11/README.md
+++ b/examples/connext_dds/group_coherent_presentation/c++11/README.md
@@ -80,13 +80,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/group_coherent_presentation/c++11/README.md
+++ b/examples/connext_dds/group_coherent_presentation/c++11/README.md
@@ -105,7 +105,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/high_priority_first_flow_controller/c++98/README.md
+++ b/examples/connext_dds/high_priority_first_flow_controller/c++98/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/high_priority_first_flow_controller/c++98/README.md
+++ b/examples/connext_dds/high_priority_first_flow_controller/c++98/README.md
@@ -67,44 +67,44 @@ The applications accept two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/high_priority_first_flow_controller/c++98/README.md
+++ b/examples/connext_dds/high_priority_first_flow_controller/c++98/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/high_priority_first_flow_controller/c++98/README.md
+++ b/examples/connext_dds/high_priority_first_flow_controller/c++98/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/high_priority_first_flow_controller/c++98/README.md
+++ b/examples/connext_dds/high_priority_first_flow_controller/c++98/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/high_priority_first_flow_controller/c++98/README.md
+++ b/examples/connext_dds/high_priority_first_flow_controller/c++98/README.md
@@ -67,7 +67,7 @@ The applications accept two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/instance_statistics/c++11/README.md
+++ b/examples/connext_dds/instance_statistics/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/instance_statistics/c++11/README.md
+++ b/examples/connext_dds/instance_statistics/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/instance_statistics/c++11/README.md
+++ b/examples/connext_dds/instance_statistics/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/instance_statistics/c++11/README.md
+++ b/examples/connext_dds/instance_statistics/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/instance_statistics/c++11/README.md
+++ b/examples/connext_dds/instance_statistics/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/instance_statistics/c++11/README.md
+++ b/examples/connext_dds/instance_statistics/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/instance_statistics/c++98/README.md
+++ b/examples/connext_dds/instance_statistics/c++98/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/instance_statistics/c++98/README.md
+++ b/examples/connext_dds/instance_statistics/c++98/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/instance_statistics/c++98/README.md
+++ b/examples/connext_dds/instance_statistics/c++98/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/instance_statistics/c++98/README.md
+++ b/examples/connext_dds/instance_statistics/c++98/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/instance_statistics/c++98/README.md
+++ b/examples/connext_dds/instance_statistics/c++98/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/instance_statistics/c++98/README.md
+++ b/examples/connext_dds/instance_statistics/c++98/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/instance_statistics/c/README.md
+++ b/examples/connext_dds/instance_statistics/c/README.md
@@ -68,44 +68,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/instance_statistics/c/README.md
+++ b/examples/connext_dds/instance_statistics/c/README.md
@@ -68,7 +68,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/instance_statistics/c/README.md
+++ b/examples/connext_dds/instance_statistics/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/instance_statistics/c/README.md
+++ b/examples/connext_dds/instance_statistics/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/instance_statistics/c/README.md
+++ b/examples/connext_dds/instance_statistics/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/instance_statistics/c/README.md
+++ b/examples/connext_dds/instance_statistics/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/keyed_data/c++11/README.md
+++ b/examples/connext_dds/keyed_data/c++11/README.md
@@ -153,19 +153,18 @@ your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
 Solutions on Windows), \. You can use the following CMake variables to modify
 the default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are Release
     and Debug. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are ON for
     dynamic linking and OFF for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
--   `-G` -- CMake generator. The generator is the native build system used to
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+-   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described described in the
     CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Section](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build a example in Debug/Static mode run CMake as follows:
 

--- a/examples/connext_dds/keyed_data/c++11/README.md
+++ b/examples/connext_dds/keyed_data/c++11/README.md
@@ -154,8 +154,8 @@ Solutions on Windows), \. You can use the following CMake variables to modify
 the default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and Debug. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are ON for
     dynamic linking and OFF for static linking. See [CMake documentation for

--- a/examples/connext_dds/keyed_data/c++11/README.md
+++ b/examples/connext_dds/keyed_data/c++11/README.md
@@ -150,7 +150,7 @@ Instance 0 has no writers
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify
+Solutions on Windows), \. You can use the following CMake variables to modify
 the default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release

--- a/examples/connext_dds/keyed_data/c++11/README.md
+++ b/examples/connext_dds/keyed_data/c++11/README.md
@@ -161,6 +161,7 @@ the default behavior:
     dynamic linking and OFF for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described described in the
     CMake documentation [CMake Generators

--- a/examples/connext_dds/keyed_data/c++98/README.md
+++ b/examples/connext_dds/keyed_data/c++98/README.md
@@ -150,44 +150,44 @@ Instance 0 has no writers
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -196,8 +196,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -205,16 +205,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/keyed_data/c++98/README.md
+++ b/examples/connext_dds/keyed_data/c++98/README.md
@@ -159,13 +159,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/keyed_data/c++98/README.md
+++ b/examples/connext_dds/keyed_data/c++98/README.md
@@ -184,7 +184,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/keyed_data/c++98/README.md
+++ b/examples/connext_dds/keyed_data/c++98/README.md
@@ -154,8 +154,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/keyed_data/c++98/README.md
+++ b/examples/connext_dds/keyed_data/c++98/README.md
@@ -161,6 +161,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/keyed_data/c++98/README.md
+++ b/examples/connext_dds/keyed_data/c++98/README.md
@@ -150,7 +150,7 @@ Instance 0 has no writers
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/keyed_data/c/README.md
+++ b/examples/connext_dds/keyed_data/c/README.md
@@ -143,7 +143,7 @@ Instance 0 has no writers
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify
+Solutions on Windows), \. You can use the following CMake variables to modify
 the default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release

--- a/examples/connext_dds/keyed_data/c/README.md
+++ b/examples/connext_dds/keyed_data/c/README.md
@@ -146,19 +146,18 @@ your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
 Solutions on Windows), \. You can use the following CMake variables to modify
 the default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are Release
     and Debug. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are ON for
     dynamic linking and OFF for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
--   `-G` -- CMake generator. The generator is the native build system used to
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+-   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described described in the
     CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Section](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build a example in Debug/Static mode run CMake as follows:
 

--- a/examples/connext_dds/keyed_data/c/README.md
+++ b/examples/connext_dds/keyed_data/c/README.md
@@ -154,6 +154,7 @@ the default behavior:
     dynamic linking and OFF for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described described in the
     CMake documentation [CMake Generators

--- a/examples/connext_dds/keyed_data/c/README.md
+++ b/examples/connext_dds/keyed_data/c/README.md
@@ -147,8 +147,8 @@ Solutions on Windows), \. You can use the following CMake variables to modify
 the default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and Debug. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are ON for
     dynamic linking and OFF for static linking. See [CMake documentation for

--- a/examples/connext_dds/keyed_data_advanced/c++11/README.md
+++ b/examples/connext_dds/keyed_data_advanced/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/keyed_data_advanced/c++11/README.md
+++ b/examples/connext_dds/keyed_data_advanced/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/keyed_data_advanced/c++11/README.md
+++ b/examples/connext_dds/keyed_data_advanced/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/keyed_data_advanced/c++11/README.md
+++ b/examples/connext_dds/keyed_data_advanced/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/keyed_data_advanced/c++11/README.md
+++ b/examples/connext_dds/keyed_data_advanced/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/keyed_data_advanced/c++11/README.md
+++ b/examples/connext_dds/keyed_data_advanced/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/keyed_data_advanced/c++98/README.md
+++ b/examples/connext_dds/keyed_data_advanced/c++98/README.md
@@ -176,44 +176,44 @@ Instance has no writers; code = 1
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -222,8 +222,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -231,16 +231,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/keyed_data_advanced/c++98/README.md
+++ b/examples/connext_dds/keyed_data_advanced/c++98/README.md
@@ -185,13 +185,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/keyed_data_advanced/c++98/README.md
+++ b/examples/connext_dds/keyed_data_advanced/c++98/README.md
@@ -187,6 +187,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/keyed_data_advanced/c++98/README.md
+++ b/examples/connext_dds/keyed_data_advanced/c++98/README.md
@@ -180,8 +180,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/keyed_data_advanced/c++98/README.md
+++ b/examples/connext_dds/keyed_data_advanced/c++98/README.md
@@ -176,7 +176,7 @@ Instance has no writers; code = 1
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/keyed_data_advanced/c++98/README.md
+++ b/examples/connext_dds/keyed_data_advanced/c++98/README.md
@@ -210,7 +210,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/keyed_data_advanced/c/README.md
+++ b/examples/connext_dds/keyed_data_advanced/c/README.md
@@ -178,13 +178,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/keyed_data_advanced/c/README.md
+++ b/examples/connext_dds/keyed_data_advanced/c/README.md
@@ -173,8 +173,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/keyed_data_advanced/c/README.md
+++ b/examples/connext_dds/keyed_data_advanced/c/README.md
@@ -203,7 +203,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/keyed_data_advanced/c/README.md
+++ b/examples/connext_dds/keyed_data_advanced/c/README.md
@@ -169,44 +169,44 @@ Instance has no writers; code = 1
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -215,8 +215,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -224,16 +224,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/keyed_data_advanced/c/README.md
+++ b/examples/connext_dds/keyed_data_advanced/c/README.md
@@ -180,6 +180,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/keyed_data_advanced/c/README.md
+++ b/examples/connext_dds/keyed_data_advanced/c/README.md
@@ -169,7 +169,7 @@ Instance has no writers; code = 1
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/lambda_content_filter/c++11/README.md
+++ b/examples/connext_dds/lambda_content_filter/c++11/README.md
@@ -65,7 +65,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/lambda_content_filter/c++11/README.md
+++ b/examples/connext_dds/lambda_content_filter/c++11/README.md
@@ -76,6 +76,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/lambda_content_filter/c++11/README.md
+++ b/examples/connext_dds/lambda_content_filter/c++11/README.md
@@ -74,13 +74,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/lambda_content_filter/c++11/README.md
+++ b/examples/connext_dds/lambda_content_filter/c++11/README.md
@@ -99,7 +99,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/lambda_content_filter/c++11/README.md
+++ b/examples/connext_dds/lambda_content_filter/c++11/README.md
@@ -65,44 +65,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -111,8 +111,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -120,16 +120,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/lambda_content_filter/c++11/README.md
+++ b/examples/connext_dds/lambda_content_filter/c++11/README.md
@@ -69,8 +69,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/lbediscovery_xml_app_creation/c++11/README.md
+++ b/examples/connext_dds/lbediscovery_xml_app_creation/c++11/README.md
@@ -71,7 +71,7 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+Solutions on Windows), \. You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release

--- a/examples/connext_dds/lbediscovery_xml_app_creation/c++11/README.md
+++ b/examples/connext_dds/lbediscovery_xml_app_creation/c++11/README.md
@@ -108,7 +108,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target rtipkg), you can use the
 CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/lbediscovery_xml_app_creation/c++11/README.md
+++ b/examples/connext_dds/lbediscovery_xml_app_creation/c++11/README.md
@@ -75,8 +75,8 @@ Solutions on Windows), \. You can use the following CMake variables to modify th
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and Debug. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are ON for
     dynamic linking and OFF for static linking. See [CMake documentation for

--- a/examples/connext_dds/lbediscovery_xml_app_creation/c++11/README.md
+++ b/examples/connext_dds/lbediscovery_xml_app_creation/c++11/README.md
@@ -74,20 +74,20 @@ your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
 Solutions on Windows), \. You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are Release
     and Debug. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are ON for
     dynamic linking and OFF for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
     **Note: LBED can only be linked dynamically.**
 
--   `-G` -- CMake generator. The generator is the native build system used to
+-   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the
     CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Section](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/listeners/c++11/README.md
+++ b/examples/connext_dds/listeners/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/listeners/c++11/README.md
+++ b/examples/connext_dds/listeners/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/listeners/c++11/README.md
+++ b/examples/connext_dds/listeners/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/listeners/c++11/README.md
+++ b/examples/connext_dds/listeners/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/listeners/c++11/README.md
+++ b/examples/connext_dds/listeners/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/listeners/c++11/README.md
+++ b/examples/connext_dds/listeners/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/listeners/c++98/README.md
+++ b/examples/connext_dds/listeners/c++98/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/listeners/c++98/README.md
+++ b/examples/connext_dds/listeners/c++98/README.md
@@ -67,44 +67,44 @@ The applications accept two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/listeners/c++98/README.md
+++ b/examples/connext_dds/listeners/c++98/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/listeners/c++98/README.md
+++ b/examples/connext_dds/listeners/c++98/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/listeners/c++98/README.md
+++ b/examples/connext_dds/listeners/c++98/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/listeners/c++98/README.md
+++ b/examples/connext_dds/listeners/c++98/README.md
@@ -67,7 +67,7 @@ The applications accept two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/listeners/c/README.md
+++ b/examples/connext_dds/listeners/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/listeners/c/README.md
+++ b/examples/connext_dds/listeners/c/README.md
@@ -68,7 +68,7 @@ The applications accept two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/listeners/c/README.md
+++ b/examples/connext_dds/listeners/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/listeners/c/README.md
+++ b/examples/connext_dds/listeners/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/listeners/c/README.md
+++ b/examples/connext_dds/listeners/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/listeners/c/README.md
+++ b/examples/connext_dds/listeners/c/README.md
@@ -68,44 +68,44 @@ The applications accept two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/logging_config/c++11/README.md
+++ b/examples/connext_dds/logging_config/c++11/README.md
@@ -65,7 +65,7 @@ instructs the application to run forever; this is the default.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/logging_config/c++11/README.md
+++ b/examples/connext_dds/logging_config/c++11/README.md
@@ -76,6 +76,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/logging_config/c++11/README.md
+++ b/examples/connext_dds/logging_config/c++11/README.md
@@ -74,13 +74,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/logging_config/c++11/README.md
+++ b/examples/connext_dds/logging_config/c++11/README.md
@@ -99,7 +99,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/logging_config/c++11/README.md
+++ b/examples/connext_dds/logging_config/c++11/README.md
@@ -65,44 +65,44 @@ instructs the application to run forever; this is the default.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -111,8 +111,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -120,16 +120,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/logging_config/c++11/README.md
+++ b/examples/connext_dds/logging_config/c++11/README.md
@@ -69,8 +69,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/logging_config/c++98/README.md
+++ b/examples/connext_dds/logging_config/c++98/README.md
@@ -73,6 +73,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/logging_config/c++98/README.md
+++ b/examples/connext_dds/logging_config/c++98/README.md
@@ -66,8 +66,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/logging_config/c++98/README.md
+++ b/examples/connext_dds/logging_config/c++98/README.md
@@ -96,7 +96,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/logging_config/c++98/README.md
+++ b/examples/connext_dds/logging_config/c++98/README.md
@@ -62,44 +62,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -108,8 +108,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -117,16 +117,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/logging_config/c++98/README.md
+++ b/examples/connext_dds/logging_config/c++98/README.md
@@ -62,7 +62,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/logging_config/c++98/README.md
+++ b/examples/connext_dds/logging_config/c++98/README.md
@@ -71,13 +71,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/logging_config/c/README.md
+++ b/examples/connext_dds/logging_config/c/README.md
@@ -100,7 +100,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/logging_config/c/README.md
+++ b/examples/connext_dds/logging_config/c/README.md
@@ -77,6 +77,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/logging_config/c/README.md
+++ b/examples/connext_dds/logging_config/c/README.md
@@ -70,8 +70,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/logging_config/c/README.md
+++ b/examples/connext_dds/logging_config/c/README.md
@@ -66,44 +66,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -112,8 +112,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -121,16 +121,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/logging_config/c/README.md
+++ b/examples/connext_dds/logging_config/c/README.md
@@ -75,13 +75,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/logging_config/c/README.md
+++ b/examples/connext_dds/logging_config/c/README.md
@@ -66,7 +66,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/multichannel/c++11/README.md
+++ b/examples/connext_dds/multichannel/c++11/README.md
@@ -150,7 +150,7 @@ changed filter to Symbol MATCH 'D'
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/multichannel/c++11/README.md
+++ b/examples/connext_dds/multichannel/c++11/README.md
@@ -159,13 +159,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/multichannel/c++11/README.md
+++ b/examples/connext_dds/multichannel/c++11/README.md
@@ -184,7 +184,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/multichannel/c++11/README.md
+++ b/examples/connext_dds/multichannel/c++11/README.md
@@ -154,8 +154,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/multichannel/c++11/README.md
+++ b/examples/connext_dds/multichannel/c++11/README.md
@@ -161,6 +161,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/multichannel/c++11/README.md
+++ b/examples/connext_dds/multichannel/c++11/README.md
@@ -150,44 +150,44 @@ changed filter to Symbol MATCH 'D'
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -196,8 +196,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -205,16 +205,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/multichannel/c++98/README.md
+++ b/examples/connext_dds/multichannel/c++98/README.md
@@ -150,7 +150,7 @@ changed filter to Symbol MATCH 'D'
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/multichannel/c++98/README.md
+++ b/examples/connext_dds/multichannel/c++98/README.md
@@ -159,13 +159,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/multichannel/c++98/README.md
+++ b/examples/connext_dds/multichannel/c++98/README.md
@@ -184,7 +184,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/multichannel/c++98/README.md
+++ b/examples/connext_dds/multichannel/c++98/README.md
@@ -154,8 +154,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/multichannel/c++98/README.md
+++ b/examples/connext_dds/multichannel/c++98/README.md
@@ -161,6 +161,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/multichannel/c++98/README.md
+++ b/examples/connext_dds/multichannel/c++98/README.md
@@ -150,44 +150,44 @@ changed filter to Symbol MATCH 'D'
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -196,8 +196,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -205,16 +205,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/multichannel/c/README.md
+++ b/examples/connext_dds/multichannel/c/README.md
@@ -177,7 +177,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/multichannel/c/README.md
+++ b/examples/connext_dds/multichannel/c/README.md
@@ -154,6 +154,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/multichannel/c/README.md
+++ b/examples/connext_dds/multichannel/c/README.md
@@ -152,13 +152,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/multichannel/c/README.md
+++ b/examples/connext_dds/multichannel/c/README.md
@@ -143,7 +143,7 @@ changed filter to Symbol MATCH 'D'
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/multichannel/c/README.md
+++ b/examples/connext_dds/multichannel/c/README.md
@@ -147,8 +147,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/multichannel/c/README.md
+++ b/examples/connext_dds/multichannel/c/README.md
@@ -143,44 +143,44 @@ changed filter to Symbol MATCH 'D'
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -189,8 +189,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -198,16 +198,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++11/README.md
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++11/README.md
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++11/README.md
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++11/README.md
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++11/README.md
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++11/README.md
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++98/README.md
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++98/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++98/README.md
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++98/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++98/README.md
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++98/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++98/README.md
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++98/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++98/README.md
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++98/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++98/README.md
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c++98/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c/README.md
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c/README.md
@@ -68,44 +68,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c/README.md
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c/README.md
@@ -68,7 +68,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c/README.md
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c/README.md
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c/README.md
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/network_capture/01_shared_memory_and_udp/c/README.md
+++ b/examples/connext_dds/network_capture/01_shared_memory_and_udp/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/network_capture/02_tcp/c/README.md
+++ b/examples/connext_dds/network_capture/02_tcp/c/README.md
@@ -104,7 +104,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/network_capture/02_tcp/c/README.md
+++ b/examples/connext_dds/network_capture/02_tcp/c/README.md
@@ -81,6 +81,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/network_capture/02_tcp/c/README.md
+++ b/examples/connext_dds/network_capture/02_tcp/c/README.md
@@ -74,8 +74,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/network_capture/02_tcp/c/README.md
+++ b/examples/connext_dds/network_capture/02_tcp/c/README.md
@@ -70,44 +70,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -116,8 +116,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -125,16 +125,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/network_capture/02_tcp/c/README.md
+++ b/examples/connext_dds/network_capture/02_tcp/c/README.md
@@ -79,13 +79,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/network_capture/02_tcp/c/README.md
+++ b/examples/connext_dds/network_capture/02_tcp/c/README.md
@@ -70,7 +70,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/network_capture/03_security/c/README.md
+++ b/examples/connext_dds/network_capture/03_security/c/README.md
@@ -68,44 +68,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/network_capture/03_security/c/README.md
+++ b/examples/connext_dds/network_capture/03_security/c/README.md
@@ -68,7 +68,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/network_capture/03_security/c/README.md
+++ b/examples/connext_dds/network_capture/03_security/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/network_capture/03_security/c/README.md
+++ b/examples/connext_dds/network_capture/03_security/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/network_capture/03_security/c/README.md
+++ b/examples/connext_dds/network_capture/03_security/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/network_capture/03_security/c/README.md
+++ b/examples/connext_dds/network_capture/03_security/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/network_capture/04_advanced_api/c/README.md
+++ b/examples/connext_dds/network_capture/04_advanced_api/c/README.md
@@ -68,44 +68,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/network_capture/04_advanced_api/c/README.md
+++ b/examples/connext_dds/network_capture/04_advanced_api/c/README.md
@@ -68,7 +68,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/network_capture/04_advanced_api/c/README.md
+++ b/examples/connext_dds/network_capture/04_advanced_api/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/network_capture/04_advanced_api/c/README.md
+++ b/examples/connext_dds/network_capture/04_advanced_api/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/network_capture/04_advanced_api/c/README.md
+++ b/examples/connext_dds/network_capture/04_advanced_api/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/network_capture/04_advanced_api/c/README.md
+++ b/examples/connext_dds/network_capture/04_advanced_api/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/ordered_presentation/c++11/README.md
+++ b/examples/connext_dds/ordered_presentation/c++11/README.md
@@ -151,7 +151,7 @@ Reader 0: Instance1->value = 9
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/ordered_presentation/c++11/README.md
+++ b/examples/connext_dds/ordered_presentation/c++11/README.md
@@ -160,13 +160,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/ordered_presentation/c++11/README.md
+++ b/examples/connext_dds/ordered_presentation/c++11/README.md
@@ -151,44 +151,44 @@ Reader 0: Instance1->value = 9
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -197,8 +197,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -206,16 +206,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/ordered_presentation/c++11/README.md
+++ b/examples/connext_dds/ordered_presentation/c++11/README.md
@@ -162,6 +162,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/ordered_presentation/c++11/README.md
+++ b/examples/connext_dds/ordered_presentation/c++11/README.md
@@ -155,8 +155,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/ordered_presentation/c++11/README.md
+++ b/examples/connext_dds/ordered_presentation/c++11/README.md
@@ -185,7 +185,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/ordered_presentation/c++98/README.md
+++ b/examples/connext_dds/ordered_presentation/c++98/README.md
@@ -167,6 +167,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/ordered_presentation/c++98/README.md
+++ b/examples/connext_dds/ordered_presentation/c++98/README.md
@@ -190,7 +190,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/ordered_presentation/c++98/README.md
+++ b/examples/connext_dds/ordered_presentation/c++98/README.md
@@ -160,8 +160,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/ordered_presentation/c++98/README.md
+++ b/examples/connext_dds/ordered_presentation/c++98/README.md
@@ -165,13 +165,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/ordered_presentation/c++98/README.md
+++ b/examples/connext_dds/ordered_presentation/c++98/README.md
@@ -156,44 +156,44 @@ Reader 0: Instance1->value = 9
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -202,8 +202,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -211,16 +211,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/ordered_presentation/c++98/README.md
+++ b/examples/connext_dds/ordered_presentation/c++98/README.md
@@ -156,7 +156,7 @@ Reader 0: Instance1->value = 9
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/ordered_presentation/c/README.md
+++ b/examples/connext_dds/ordered_presentation/c/README.md
@@ -166,13 +166,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/ordered_presentation/c/README.md
+++ b/examples/connext_dds/ordered_presentation/c/README.md
@@ -161,8 +161,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/ordered_presentation/c/README.md
+++ b/examples/connext_dds/ordered_presentation/c/README.md
@@ -157,44 +157,44 @@ Reader 0: Instance1->value = 9
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -203,8 +203,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -212,16 +212,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/ordered_presentation/c/README.md
+++ b/examples/connext_dds/ordered_presentation/c/README.md
@@ -191,7 +191,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/ordered_presentation/c/README.md
+++ b/examples/connext_dds/ordered_presentation/c/README.md
@@ -157,7 +157,7 @@ Reader 0: Instance1->value = 9
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/ordered_presentation/c/README.md
+++ b/examples/connext_dds/ordered_presentation/c/README.md
@@ -168,6 +168,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/ordered_presentation_group/c++11/README.md
+++ b/examples/connext_dds/ordered_presentation_group/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/ordered_presentation_group/c++11/README.md
+++ b/examples/connext_dds/ordered_presentation_group/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/ordered_presentation_group/c++11/README.md
+++ b/examples/connext_dds/ordered_presentation_group/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/ordered_presentation_group/c++11/README.md
+++ b/examples/connext_dds/ordered_presentation_group/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/ordered_presentation_group/c++11/README.md
+++ b/examples/connext_dds/ordered_presentation_group/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/ordered_presentation_group/c++11/README.md
+++ b/examples/connext_dds/ordered_presentation_group/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/ordered_presentation_group/c++98/README.md
+++ b/examples/connext_dds/ordered_presentation_group/c++98/README.md
@@ -232,7 +232,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/ordered_presentation_group/c++98/README.md
+++ b/examples/connext_dds/ordered_presentation_group/c++98/README.md
@@ -198,7 +198,7 @@ ordered_group subscriber sleeping for 4 sec...
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/ordered_presentation_group/c++98/README.md
+++ b/examples/connext_dds/ordered_presentation_group/c++98/README.md
@@ -198,44 +198,44 @@ ordered_group subscriber sleeping for 4 sec...
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -244,8 +244,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -253,16 +253,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/ordered_presentation_group/c++98/README.md
+++ b/examples/connext_dds/ordered_presentation_group/c++98/README.md
@@ -202,8 +202,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/ordered_presentation_group/c++98/README.md
+++ b/examples/connext_dds/ordered_presentation_group/c++98/README.md
@@ -207,13 +207,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/ordered_presentation_group/c++98/README.md
+++ b/examples/connext_dds/ordered_presentation_group/c++98/README.md
@@ -209,6 +209,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/ordered_presentation_group/c/README.md
+++ b/examples/connext_dds/ordered_presentation_group/c/README.md
@@ -208,13 +208,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/ordered_presentation_group/c/README.md
+++ b/examples/connext_dds/ordered_presentation_group/c/README.md
@@ -199,44 +199,44 @@ ordered_group subscriber sleeping for 4 sec...
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -245,8 +245,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -254,16 +254,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/ordered_presentation_group/c/README.md
+++ b/examples/connext_dds/ordered_presentation_group/c/README.md
@@ -203,8 +203,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/ordered_presentation_group/c/README.md
+++ b/examples/connext_dds/ordered_presentation_group/c/README.md
@@ -233,7 +233,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/ordered_presentation_group/c/README.md
+++ b/examples/connext_dds/ordered_presentation_group/c/README.md
@@ -199,7 +199,7 @@ ordered_group subscriber sleeping for 4 sec...
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/ordered_presentation_group/c/README.md
+++ b/examples/connext_dds/ordered_presentation_group/c/README.md
@@ -210,6 +210,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/partitions/c++11/README.md
+++ b/examples/connext_dds/partitions/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/partitions/c++11/README.md
+++ b/examples/connext_dds/partitions/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/partitions/c++11/README.md
+++ b/examples/connext_dds/partitions/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/partitions/c++11/README.md
+++ b/examples/connext_dds/partitions/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/partitions/c++11/README.md
+++ b/examples/connext_dds/partitions/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/partitions/c++11/README.md
+++ b/examples/connext_dds/partitions/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/partitions/c++98/README.md
+++ b/examples/connext_dds/partitions/c++98/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/partitions/c++98/README.md
+++ b/examples/connext_dds/partitions/c++98/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/partitions/c++98/README.md
+++ b/examples/connext_dds/partitions/c++98/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/partitions/c++98/README.md
+++ b/examples/connext_dds/partitions/c++98/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/partitions/c++98/README.md
+++ b/examples/connext_dds/partitions/c++98/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/partitions/c++98/README.md
+++ b/examples/connext_dds/partitions/c++98/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/partitions/c/README.md
+++ b/examples/connext_dds/partitions/c/README.md
@@ -68,44 +68,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/partitions/c/README.md
+++ b/examples/connext_dds/partitions/c/README.md
@@ -68,7 +68,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/partitions/c/README.md
+++ b/examples/connext_dds/partitions/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/partitions/c/README.md
+++ b/examples/connext_dds/partitions/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/partitions/c/README.md
+++ b/examples/connext_dds/partitions/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/partitions/c/README.md
+++ b/examples/connext_dds/partitions/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/polling_querycondition/c++11/README.md
+++ b/examples/connext_dds/polling_querycondition/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/polling_querycondition/c++11/README.md
+++ b/examples/connext_dds/polling_querycondition/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/polling_querycondition/c++11/README.md
+++ b/examples/connext_dds/polling_querycondition/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/polling_querycondition/c++11/README.md
+++ b/examples/connext_dds/polling_querycondition/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/polling_querycondition/c++11/README.md
+++ b/examples/connext_dds/polling_querycondition/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/polling_querycondition/c++11/README.md
+++ b/examples/connext_dds/polling_querycondition/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/polling_querycondition/c++98/README.md
+++ b/examples/connext_dds/polling_querycondition/c++98/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/polling_querycondition/c++98/README.md
+++ b/examples/connext_dds/polling_querycondition/c++98/README.md
@@ -67,44 +67,44 @@ The applications accept two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/polling_querycondition/c++98/README.md
+++ b/examples/connext_dds/polling_querycondition/c++98/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/polling_querycondition/c++98/README.md
+++ b/examples/connext_dds/polling_querycondition/c++98/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/polling_querycondition/c++98/README.md
+++ b/examples/connext_dds/polling_querycondition/c++98/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/polling_querycondition/c++98/README.md
+++ b/examples/connext_dds/polling_querycondition/c++98/README.md
@@ -67,7 +67,7 @@ The applications accept two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/polling_querycondition/c/README.md
+++ b/examples/connext_dds/polling_querycondition/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/polling_querycondition/c/README.md
+++ b/examples/connext_dds/polling_querycondition/c/README.md
@@ -68,7 +68,7 @@ The applications accept two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/polling_querycondition/c/README.md
+++ b/examples/connext_dds/polling_querycondition/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/polling_querycondition/c/README.md
+++ b/examples/connext_dds/polling_querycondition/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/polling_querycondition/c/README.md
+++ b/examples/connext_dds/polling_querycondition/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/polling_querycondition/c/README.md
+++ b/examples/connext_dds/polling_querycondition/c/README.md
@@ -68,44 +68,44 @@ The applications accept two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/polling_read/c++11/README.md
+++ b/examples/connext_dds/polling_read/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/polling_read/c++11/README.md
+++ b/examples/connext_dds/polling_read/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/polling_read/c++11/README.md
+++ b/examples/connext_dds/polling_read/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/polling_read/c++11/README.md
+++ b/examples/connext_dds/polling_read/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/polling_read/c++11/README.md
+++ b/examples/connext_dds/polling_read/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/polling_read/c++11/README.md
+++ b/examples/connext_dds/polling_read/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/polling_read/c++98/README.md
+++ b/examples/connext_dds/polling_read/c++98/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/polling_read/c++98/README.md
+++ b/examples/connext_dds/polling_read/c++98/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/polling_read/c++98/README.md
+++ b/examples/connext_dds/polling_read/c++98/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/polling_read/c++98/README.md
+++ b/examples/connext_dds/polling_read/c++98/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/polling_read/c++98/README.md
+++ b/examples/connext_dds/polling_read/c++98/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/polling_read/c++98/README.md
+++ b/examples/connext_dds/polling_read/c++98/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/polling_read/c/README.md
+++ b/examples/connext_dds/polling_read/c/README.md
@@ -68,44 +68,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/polling_read/c/README.md
+++ b/examples/connext_dds/polling_read/c/README.md
@@ -68,7 +68,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/polling_read/c/README.md
+++ b/examples/connext_dds/polling_read/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/polling_read/c/README.md
+++ b/examples/connext_dds/polling_read/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/polling_read/c/README.md
+++ b/examples/connext_dds/polling_read/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/polling_read/c/README.md
+++ b/examples/connext_dds/polling_read/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/printing_qos/c++11/README.md
+++ b/examples/connext_dds/printing_qos/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/printing_qos/c++11/README.md
+++ b/examples/connext_dds/printing_qos/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/printing_qos/c++11/README.md
+++ b/examples/connext_dds/printing_qos/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/printing_qos/c++11/README.md
+++ b/examples/connext_dds/printing_qos/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/printing_qos/c++11/README.md
+++ b/examples/connext_dds/printing_qos/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/printing_qos/c++11/README.md
+++ b/examples/connext_dds/printing_qos/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/printing_qos/c++98/README.md
+++ b/examples/connext_dds/printing_qos/c++98/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/printing_qos/c++98/README.md
+++ b/examples/connext_dds/printing_qos/c++98/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/printing_qos/c++98/README.md
+++ b/examples/connext_dds/printing_qos/c++98/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/printing_qos/c++98/README.md
+++ b/examples/connext_dds/printing_qos/c++98/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/printing_qos/c++98/README.md
+++ b/examples/connext_dds/printing_qos/c++98/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/printing_qos/c++98/README.md
+++ b/examples/connext_dds/printing_qos/c++98/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/printing_qos/c/README.md
+++ b/examples/connext_dds/printing_qos/c/README.md
@@ -68,44 +68,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/printing_qos/c/README.md
+++ b/examples/connext_dds/printing_qos/c/README.md
@@ -68,7 +68,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/printing_qos/c/README.md
+++ b/examples/connext_dds/printing_qos/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/printing_qos/c/README.md
+++ b/examples/connext_dds/printing_qos/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/printing_qos/c/README.md
+++ b/examples/connext_dds/printing_qos/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/printing_qos/c/README.md
+++ b/examples/connext_dds/printing_qos/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/property_qos/c++98/README.md
+++ b/examples/connext_dds/property_qos/c++98/README.md
@@ -134,7 +134,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/property_qos/c++98/README.md
+++ b/examples/connext_dds/property_qos/c++98/README.md
@@ -100,44 +100,44 @@ numbers subscriber sleeping for 4 sec...
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -146,8 +146,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -155,16 +155,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/property_qos/c++98/README.md
+++ b/examples/connext_dds/property_qos/c++98/README.md
@@ -104,8 +104,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/property_qos/c++98/README.md
+++ b/examples/connext_dds/property_qos/c++98/README.md
@@ -111,6 +111,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/property_qos/c++98/README.md
+++ b/examples/connext_dds/property_qos/c++98/README.md
@@ -100,7 +100,7 @@ numbers subscriber sleeping for 4 sec...
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/property_qos/c++98/README.md
+++ b/examples/connext_dds/property_qos/c++98/README.md
@@ -109,13 +109,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/property_qos/c/README.md
+++ b/examples/connext_dds/property_qos/c/README.md
@@ -110,13 +110,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/property_qos/c/README.md
+++ b/examples/connext_dds/property_qos/c/README.md
@@ -135,7 +135,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/property_qos/c/README.md
+++ b/examples/connext_dds/property_qos/c/README.md
@@ -101,7 +101,7 @@ numbers subscriber sleeping for 4 sec...
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/property_qos/c/README.md
+++ b/examples/connext_dds/property_qos/c/README.md
@@ -105,8 +105,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/property_qos/c/README.md
+++ b/examples/connext_dds/property_qos/c/README.md
@@ -112,6 +112,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/property_qos/c/README.md
+++ b/examples/connext_dds/property_qos/c/README.md
@@ -101,44 +101,44 @@ numbers subscriber sleeping for 4 sec...
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -147,8 +147,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -156,16 +156,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/real_time_wan_transport/c++98/README.md
+++ b/examples/connext_dds/real_time_wan_transport/c++98/README.md
@@ -104,7 +104,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/real_time_wan_transport/c++98/README.md
+++ b/examples/connext_dds/real_time_wan_transport/c++98/README.md
@@ -81,6 +81,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/real_time_wan_transport/c++98/README.md
+++ b/examples/connext_dds/real_time_wan_transport/c++98/README.md
@@ -74,8 +74,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/real_time_wan_transport/c++98/README.md
+++ b/examples/connext_dds/real_time_wan_transport/c++98/README.md
@@ -70,44 +70,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -116,8 +116,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -125,16 +125,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/real_time_wan_transport/c++98/README.md
+++ b/examples/connext_dds/real_time_wan_transport/c++98/README.md
@@ -79,13 +79,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/real_time_wan_transport/c++98/README.md
+++ b/examples/connext_dds/real_time_wan_transport/c++98/README.md
@@ -70,7 +70,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/required_subscription/c++98/README.md
+++ b/examples/connext_dds/required_subscription/c++98/README.md
@@ -71,44 +71,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -117,8 +117,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -126,16 +126,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/required_subscription/c++98/README.md
+++ b/examples/connext_dds/required_subscription/c++98/README.md
@@ -75,8 +75,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/required_subscription/c++98/README.md
+++ b/examples/connext_dds/required_subscription/c++98/README.md
@@ -82,6 +82,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/required_subscription/c++98/README.md
+++ b/examples/connext_dds/required_subscription/c++98/README.md
@@ -71,7 +71,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/required_subscription/c++98/README.md
+++ b/examples/connext_dds/required_subscription/c++98/README.md
@@ -80,13 +80,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/required_subscription/c++98/README.md
+++ b/examples/connext_dds/required_subscription/c++98/README.md
@@ -105,7 +105,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/time_based_filter/c++11/README.md
+++ b/examples/connext_dds/time_based_filter/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/time_based_filter/c++11/README.md
+++ b/examples/connext_dds/time_based_filter/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/time_based_filter/c++11/README.md
+++ b/examples/connext_dds/time_based_filter/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/time_based_filter/c++11/README.md
+++ b/examples/connext_dds/time_based_filter/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/time_based_filter/c++11/README.md
+++ b/examples/connext_dds/time_based_filter/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/time_based_filter/c++11/README.md
+++ b/examples/connext_dds/time_based_filter/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/time_based_filter/c++98/README.md
+++ b/examples/connext_dds/time_based_filter/c++98/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/time_based_filter/c++98/README.md
+++ b/examples/connext_dds/time_based_filter/c++98/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/time_based_filter/c++98/README.md
+++ b/examples/connext_dds/time_based_filter/c++98/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/time_based_filter/c++98/README.md
+++ b/examples/connext_dds/time_based_filter/c++98/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/time_based_filter/c++98/README.md
+++ b/examples/connext_dds/time_based_filter/c++98/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/time_based_filter/c++98/README.md
+++ b/examples/connext_dds/time_based_filter/c++98/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/time_based_filter/c/README.md
+++ b/examples/connext_dds/time_based_filter/c/README.md
@@ -68,44 +68,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/time_based_filter/c/README.md
+++ b/examples/connext_dds/time_based_filter/c/README.md
@@ -68,7 +68,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/time_based_filter/c/README.md
+++ b/examples/connext_dds/time_based_filter/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/time_based_filter/c/README.md
+++ b/examples/connext_dds/time_based_filter/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/time_based_filter/c/README.md
+++ b/examples/connext_dds/time_based_filter/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/time_based_filter/c/README.md
+++ b/examples/connext_dds/time_based_filter/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/using_qos_profiles/c++11/README.md
+++ b/examples/connext_dds/using_qos_profiles/c++11/README.md
@@ -68,44 +68,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/using_qos_profiles/c++11/README.md
+++ b/examples/connext_dds/using_qos_profiles/c++11/README.md
@@ -68,7 +68,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/using_qos_profiles/c++11/README.md
+++ b/examples/connext_dds/using_qos_profiles/c++11/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/using_qos_profiles/c++11/README.md
+++ b/examples/connext_dds/using_qos_profiles/c++11/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/using_qos_profiles/c++11/README.md
+++ b/examples/connext_dds/using_qos_profiles/c++11/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/using_qos_profiles/c++11/README.md
+++ b/examples/connext_dds/using_qos_profiles/c++11/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/using_qos_profiles/c++98/README.md
+++ b/examples/connext_dds/using_qos_profiles/c++98/README.md
@@ -68,44 +68,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/using_qos_profiles/c++98/README.md
+++ b/examples/connext_dds/using_qos_profiles/c++98/README.md
@@ -68,7 +68,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/using_qos_profiles/c++98/README.md
+++ b/examples/connext_dds/using_qos_profiles/c++98/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/using_qos_profiles/c++98/README.md
+++ b/examples/connext_dds/using_qos_profiles/c++98/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/using_qos_profiles/c++98/README.md
+++ b/examples/connext_dds/using_qos_profiles/c++98/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/using_qos_profiles/c++98/README.md
+++ b/examples/connext_dds/using_qos_profiles/c++98/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/using_qos_profiles/c/README.md
+++ b/examples/connext_dds/using_qos_profiles/c/README.md
@@ -73,8 +73,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/using_qos_profiles/c/README.md
+++ b/examples/connext_dds/using_qos_profiles/c/README.md
@@ -80,6 +80,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/using_qos_profiles/c/README.md
+++ b/examples/connext_dds/using_qos_profiles/c/README.md
@@ -78,13 +78,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/using_qos_profiles/c/README.md
+++ b/examples/connext_dds/using_qos_profiles/c/README.md
@@ -103,7 +103,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/using_qos_profiles/c/README.md
+++ b/examples/connext_dds/using_qos_profiles/c/README.md
@@ -69,44 +69,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -115,8 +115,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -124,16 +124,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/using_qos_profiles/c/README.md
+++ b/examples/connext_dds/using_qos_profiles/c/README.md
@@ -69,7 +69,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/using_sequences/c++98/README.md
+++ b/examples/connext_dds/using_sequences/c++98/README.md
@@ -67,44 +67,44 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/using_sequences/c++98/README.md
+++ b/examples/connext_dds/using_sequences/c++98/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/using_sequences/c++98/README.md
+++ b/examples/connext_dds/using_sequences/c++98/README.md
@@ -67,7 +67,7 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/using_sequences/c++98/README.md
+++ b/examples/connext_dds/using_sequences/c++98/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/using_sequences/c++98/README.md
+++ b/examples/connext_dds/using_sequences/c++98/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/using_sequences/c++98/README.md
+++ b/examples/connext_dds/using_sequences/c++98/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/using_sequences/c/README.md
+++ b/examples/connext_dds/using_sequences/c/README.md
@@ -68,7 +68,7 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/using_sequences/c/README.md
+++ b/examples/connext_dds/using_sequences/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/using_sequences/c/README.md
+++ b/examples/connext_dds/using_sequences/c/README.md
@@ -68,44 +68,44 @@ The applications accept up to three arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/using_sequences/c/README.md
+++ b/examples/connext_dds/using_sequences/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/using_sequences/c/README.md
+++ b/examples/connext_dds/using_sequences/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/using_sequences/c/README.md
+++ b/examples/connext_dds/using_sequences/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/using_typecodes/c++11/README.md
+++ b/examples/connext_dds/using_typecodes/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/using_typecodes/c++11/README.md
+++ b/examples/connext_dds/using_typecodes/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/using_typecodes/c++11/README.md
+++ b/examples/connext_dds/using_typecodes/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/using_typecodes/c++11/README.md
+++ b/examples/connext_dds/using_typecodes/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/using_typecodes/c++11/README.md
+++ b/examples/connext_dds/using_typecodes/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/using_typecodes/c++11/README.md
+++ b/examples/connext_dds/using_typecodes/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/using_typecodes/c++98/README.md
+++ b/examples/connext_dds/using_typecodes/c++98/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/using_typecodes/c++98/README.md
+++ b/examples/connext_dds/using_typecodes/c++98/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/using_typecodes/c++98/README.md
+++ b/examples/connext_dds/using_typecodes/c++98/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/using_typecodes/c++98/README.md
+++ b/examples/connext_dds/using_typecodes/c++98/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/using_typecodes/c++98/README.md
+++ b/examples/connext_dds/using_typecodes/c++98/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/using_typecodes/c++98/README.md
+++ b/examples/connext_dds/using_typecodes/c++98/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/using_typecodes/c/README.md
+++ b/examples/connext_dds/using_typecodes/c/README.md
@@ -68,44 +68,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/using_typecodes/c/README.md
+++ b/examples/connext_dds/using_typecodes/c/README.md
@@ -68,7 +68,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/using_typecodes/c/README.md
+++ b/examples/connext_dds/using_typecodes/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/using_typecodes/c/README.md
+++ b/examples/connext_dds/using_typecodes/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/using_typecodes/c/README.md
+++ b/examples/connext_dds/using_typecodes/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/using_typecodes/c/README.md
+++ b/examples/connext_dds/using_typecodes/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/waitset_query_cond/c++11/README.md
+++ b/examples/connext_dds/waitset_query_cond/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/waitset_query_cond/c++11/README.md
+++ b/examples/connext_dds/waitset_query_cond/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/waitset_query_cond/c++11/README.md
+++ b/examples/connext_dds/waitset_query_cond/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/waitset_query_cond/c++11/README.md
+++ b/examples/connext_dds/waitset_query_cond/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/waitset_query_cond/c++11/README.md
+++ b/examples/connext_dds/waitset_query_cond/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/waitset_query_cond/c++11/README.md
+++ b/examples/connext_dds/waitset_query_cond/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/waitset_query_cond/c++98/README.md
+++ b/examples/connext_dds/waitset_query_cond/c++98/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/waitset_query_cond/c++98/README.md
+++ b/examples/connext_dds/waitset_query_cond/c++98/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/waitset_query_cond/c++98/README.md
+++ b/examples/connext_dds/waitset_query_cond/c++98/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/waitset_query_cond/c++98/README.md
+++ b/examples/connext_dds/waitset_query_cond/c++98/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/waitset_query_cond/c++98/README.md
+++ b/examples/connext_dds/waitset_query_cond/c++98/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/waitset_query_cond/c++98/README.md
+++ b/examples/connext_dds/waitset_query_cond/c++98/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/waitset_query_cond/c/README.md
+++ b/examples/connext_dds/waitset_query_cond/c/README.md
@@ -68,44 +68,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/waitset_query_cond/c/README.md
+++ b/examples/connext_dds/waitset_query_cond/c/README.md
@@ -68,7 +68,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/waitset_query_cond/c/README.md
+++ b/examples/connext_dds/waitset_query_cond/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/waitset_query_cond/c/README.md
+++ b/examples/connext_dds/waitset_query_cond/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/waitset_query_cond/c/README.md
+++ b/examples/connext_dds/waitset_query_cond/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/waitset_query_cond/c/README.md
+++ b/examples/connext_dds/waitset_query_cond/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/waitset_status_cond/c++11/README.md
+++ b/examples/connext_dds/waitset_status_cond/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/waitset_status_cond/c++11/README.md
+++ b/examples/connext_dds/waitset_status_cond/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/waitset_status_cond/c++11/README.md
+++ b/examples/connext_dds/waitset_status_cond/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/waitset_status_cond/c++11/README.md
+++ b/examples/connext_dds/waitset_status_cond/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/waitset_status_cond/c++11/README.md
+++ b/examples/connext_dds/waitset_status_cond/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/waitset_status_cond/c++11/README.md
+++ b/examples/connext_dds/waitset_status_cond/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/waitset_status_cond/c++98/README.md
+++ b/examples/connext_dds/waitset_status_cond/c++98/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/waitset_status_cond/c++98/README.md
+++ b/examples/connext_dds/waitset_status_cond/c++98/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/waitset_status_cond/c++98/README.md
+++ b/examples/connext_dds/waitset_status_cond/c++98/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/waitset_status_cond/c++98/README.md
+++ b/examples/connext_dds/waitset_status_cond/c++98/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/waitset_status_cond/c++98/README.md
+++ b/examples/connext_dds/waitset_status_cond/c++98/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/waitset_status_cond/c++98/README.md
+++ b/examples/connext_dds/waitset_status_cond/c++98/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/waitset_status_cond/c/README.md
+++ b/examples/connext_dds/waitset_status_cond/c/README.md
@@ -68,44 +68,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/waitset_status_cond/c/README.md
+++ b/examples/connext_dds/waitset_status_cond/c/README.md
@@ -68,7 +68,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/waitset_status_cond/c/README.md
+++ b/examples/connext_dds/waitset_status_cond/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/waitset_status_cond/c/README.md
+++ b/examples/connext_dds/waitset_status_cond/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/waitset_status_cond/c/README.md
+++ b/examples/connext_dds/waitset_status_cond/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/waitset_status_cond/c/README.md
+++ b/examples/connext_dds/waitset_status_cond/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/waitsets/c++11/README.md
+++ b/examples/connext_dds/waitsets/c++11/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/waitsets/c++11/README.md
+++ b/examples/connext_dds/waitsets/c++11/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/waitsets/c++11/README.md
+++ b/examples/connext_dds/waitsets/c++11/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/waitsets/c++11/README.md
+++ b/examples/connext_dds/waitsets/c++11/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/waitsets/c++11/README.md
+++ b/examples/connext_dds/waitsets/c++11/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/waitsets/c++11/README.md
+++ b/examples/connext_dds/waitsets/c++11/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/waitsets/c++98/README.md
+++ b/examples/connext_dds/waitsets/c++98/README.md
@@ -78,6 +78,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/waitsets/c++98/README.md
+++ b/examples/connext_dds/waitsets/c++98/README.md
@@ -67,44 +67,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -113,8 +113,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -122,16 +122,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/waitsets/c++98/README.md
+++ b/examples/connext_dds/waitsets/c++98/README.md
@@ -76,13 +76,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/waitsets/c++98/README.md
+++ b/examples/connext_dds/waitsets/c++98/README.md
@@ -67,7 +67,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/waitsets/c++98/README.md
+++ b/examples/connext_dds/waitsets/c++98/README.md
@@ -71,8 +71,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/waitsets/c++98/README.md
+++ b/examples/connext_dds/waitsets/c++98/README.md
@@ -101,7 +101,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/waitsets/c/README.md
+++ b/examples/connext_dds/waitsets/c/README.md
@@ -68,44 +68,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -123,16 +123,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/waitsets/c/README.md
+++ b/examples/connext_dds/waitsets/c/README.md
@@ -68,7 +68,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/connext_dds/waitsets/c/README.md
+++ b/examples/connext_dds/waitsets/c/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/waitsets/c/README.md
+++ b/examples/connext_dds/waitsets/c/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/waitsets/c/README.md
+++ b/examples/connext_dds/waitsets/c/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/waitsets/c/README.md
+++ b/examples/connext_dds/waitsets/c/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/connext_dds/xml_application_env/c++11/README.md
+++ b/examples/connext_dds/xml_application_env/c++11/README.md
@@ -68,44 +68,44 @@ This case the domain id is set to 10, but can be any number from 0-255.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -114,8 +114,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_application that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_application` that defines all the necessary constructs
 to:
 
 1.  Specify the target language.

--- a/examples/connext_dds/xml_application_env/c++11/README.md
+++ b/examples/connext_dds/xml_application_env/c++11/README.md
@@ -68,7 +68,7 @@ This case the domain id is set to 10, but can be any number from 0-255.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
@@ -122,9 +122,9 @@ to:
 
 2.  Build the application executable.
 
-3.  Copy the application.xml file into the directory where the executable is generated.
+3.  Copy the `application.xml` file into the directory where the executable is generated.
 
-You will find the definition of connextdds_add_application, along with detailed
+You will find the definition of `connextdds_add_application`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
@@ -132,5 +132,5 @@ documentation, in
 For a more comprehensive example on how to build an RTI Connext DDS application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/connext_dds/xml_application_env/c++11/README.md
+++ b/examples/connext_dds/xml_application_env/c++11/README.md
@@ -72,8 +72,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/connext_dds/xml_application_env/c++11/README.md
+++ b/examples/connext_dds/xml_application_env/c++11/README.md
@@ -79,6 +79,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/connext_dds/xml_application_env/c++11/README.md
+++ b/examples/connext_dds/xml_application_env/c++11/README.md
@@ -77,13 +77,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/connext_dds/xml_application_env/c++11/README.md
+++ b/examples/connext_dds/xml_application_env/c++11/README.md
@@ -102,7 +102,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/persistence_service/library_api/c/README.md
+++ b/examples/persistence_service/library_api/c/README.md
@@ -107,7 +107,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/persistence_service/library_api/c/README.md
+++ b/examples/persistence_service/library_api/c/README.md
@@ -73,24 +73,24 @@ under the top level `examples/persistence_service` directory.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system to use
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
@@ -99,18 +99,18 @@ cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 20
 ### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext architecture based on the default settings
-for your host platform.If you installed Connext in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -119,8 +119,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -128,15 +128,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
-[resources/cmake/ConnextDdsAddExample.cmake](../../../../resources/cmake/ConnextDdsAddExample.cmake).
+[resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
+](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
 For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/persistence_service/library_api/c/README.md
+++ b/examples/persistence_service/library_api/c/README.md
@@ -77,8 +77,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/persistence_service/library_api/c/README.md
+++ b/examples/persistence_service/library_api/c/README.md
@@ -73,7 +73,7 @@ under the top level `examples/persistence_service` directory.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/persistence_service/library_api/c/README.md
+++ b/examples/persistence_service/library_api/c/README.md
@@ -84,6 +84,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/persistence_service/library_api/c/README.md
+++ b/examples/persistence_service/library_api/c/README.md
@@ -82,13 +82,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/persistence_service/persistent_storage/c++11/README.md
+++ b/examples/persistence_service/persistent_storage/c++11/README.md
@@ -182,24 +182,24 @@ Before following the steps in this example make sure that you have set the
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
@@ -209,17 +209,17 @@ cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 20
 
 The CMake build infrastructure will try to guess the location of your Connext
 installation and the Connext architecture based on the default settings
-for your host platform.If you installed Connext in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -228,8 +228,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -237,10 +237,10 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
@@ -248,5 +248,5 @@ documentation, in
 For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/persistence_service/persistent_storage/c++11/README.md
+++ b/examples/persistence_service/persistent_storage/c++11/README.md
@@ -216,7 +216,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/persistence_service/persistent_storage/c++11/README.md
+++ b/examples/persistence_service/persistent_storage/c++11/README.md
@@ -191,13 +191,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/persistence_service/persistent_storage/c++11/README.md
+++ b/examples/persistence_service/persistent_storage/c++11/README.md
@@ -182,7 +182,7 @@ Before following the steps in this example make sure that you have set the
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/persistence_service/persistent_storage/c++11/README.md
+++ b/examples/persistence_service/persistent_storage/c++11/README.md
@@ -186,8 +186,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/persistence_service/persistent_storage/c++11/README.md
+++ b/examples/persistence_service/persistent_storage/c++11/README.md
@@ -193,6 +193,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/recording_service/pluggable_storage/c++11/README.md
+++ b/examples/recording_service/pluggable_storage/c++11/README.md
@@ -183,7 +183,7 @@ will be similar.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/recording_service/pluggable_storage/c++11/README.md
+++ b/examples/recording_service/pluggable_storage/c++11/README.md
@@ -187,8 +187,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/recording_service/pluggable_storage/c++11/README.md
+++ b/examples/recording_service/pluggable_storage/c++11/README.md
@@ -217,7 +217,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/recording_service/pluggable_storage/c++11/README.md
+++ b/examples/recording_service/pluggable_storage/c++11/README.md
@@ -183,44 +183,44 @@ will be similar.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh

--- a/examples/recording_service/pluggable_storage/c++11/README.md
+++ b/examples/recording_service/pluggable_storage/c++11/README.md
@@ -192,13 +192,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/recording_service/pluggable_storage/c++11/README.md
+++ b/examples/recording_service/pluggable_storage/c++11/README.md
@@ -194,6 +194,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/recording_service/pluggable_storage/c/README.md
+++ b/examples/recording_service/pluggable_storage/c/README.md
@@ -183,7 +183,7 @@ will be similar.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/recording_service/pluggable_storage/c/README.md
+++ b/examples/recording_service/pluggable_storage/c/README.md
@@ -187,8 +187,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/recording_service/pluggable_storage/c/README.md
+++ b/examples/recording_service/pluggable_storage/c/README.md
@@ -217,7 +217,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/recording_service/pluggable_storage/c/README.md
+++ b/examples/recording_service/pluggable_storage/c/README.md
@@ -183,44 +183,44 @@ will be similar.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh

--- a/examples/recording_service/pluggable_storage/c/README.md
+++ b/examples/recording_service/pluggable_storage/c/README.md
@@ -192,13 +192,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/recording_service/pluggable_storage/c/README.md
+++ b/examples/recording_service/pluggable_storage/c/README.md
@@ -194,6 +194,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/recording_service/service_admin/c++11/README.md
+++ b/examples/recording_service/service_admin/c++11/README.md
@@ -208,44 +208,44 @@ different commands to the service.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh

--- a/examples/recording_service/service_admin/c++11/README.md
+++ b/examples/recording_service/service_admin/c++11/README.md
@@ -208,7 +208,7 @@ different commands to the service.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/recording_service/service_admin/c++11/README.md
+++ b/examples/recording_service/service_admin/c++11/README.md
@@ -219,6 +219,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/recording_service/service_admin/c++11/README.md
+++ b/examples/recording_service/service_admin/c++11/README.md
@@ -217,13 +217,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/recording_service/service_admin/c++11/README.md
+++ b/examples/recording_service/service_admin/c++11/README.md
@@ -242,7 +242,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/recording_service/service_admin/c++11/README.md
+++ b/examples/recording_service/service_admin/c++11/README.md
@@ -212,8 +212,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/recording_service/service_as_lib/c++11/README.md
+++ b/examples/recording_service/service_as_lib/c++11/README.md
@@ -160,13 +160,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/recording_service/service_as_lib/c++11/README.md
+++ b/examples/recording_service/service_as_lib/c++11/README.md
@@ -162,6 +162,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/recording_service/service_as_lib/c++11/README.md
+++ b/examples/recording_service/service_as_lib/c++11/README.md
@@ -151,44 +151,44 @@ cd <binary directory>
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh

--- a/examples/recording_service/service_as_lib/c++11/README.md
+++ b/examples/recording_service/service_as_lib/c++11/README.md
@@ -155,8 +155,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/recording_service/service_as_lib/c++11/README.md
+++ b/examples/recording_service/service_as_lib/c++11/README.md
@@ -185,7 +185,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/recording_service/service_as_lib/c++11/README.md
+++ b/examples/recording_service/service_as_lib/c++11/README.md
@@ -151,7 +151,7 @@ cd <binary directory>
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/routing_service/monitoring/c++11/README.md
+++ b/examples/routing_service/monitoring/c++11/README.md
@@ -74,6 +74,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/routing_service/monitoring/c++11/README.md
+++ b/examples/routing_service/monitoring/c++11/README.md
@@ -97,7 +97,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/routing_service/monitoring/c++11/README.md
+++ b/examples/routing_service/monitoring/c++11/README.md
@@ -63,44 +63,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -109,20 +109,19 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses two generic CMake
-functions called **connextdds_rtiddsgen_run** and **connextdds_add_application**
-that defines all the necessary constructs
-to:
+The `CMakeLists.txt` script that builds this example uses two generic CMake
+functions called `connextdds_rtiddsgen_run` and `connextdds_add_application`
+that defines all the necessary constructs to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
     for the types defined in the IDL file associated with the example.
 
 2.  Build the corresponding Subscriber application.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the subscriber
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the subscriber
 executable is generated.
 
-You will find the definition of connextdds_add_application, along with detailed
+You will find the definition of `connextdds_add_application`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).

--- a/examples/routing_service/monitoring/c++11/README.md
+++ b/examples/routing_service/monitoring/c++11/README.md
@@ -72,13 +72,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/routing_service/monitoring/c++11/README.md
+++ b/examples/routing_service/monitoring/c++11/README.md
@@ -67,8 +67,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/routing_service/monitoring/c++11/README.md
+++ b/examples/routing_service/monitoring/c++11/README.md
@@ -63,7 +63,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
@@ -126,12 +126,12 @@ documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-You will find the definition of connextdds_rtiddsgen_run, along with detailed
+You will find the definition of `connextdds_rtiddsgen_run`, along with detailed
 documentation, in
 [resources/cmake/ConnextDdsCodegen.cmake](../../../../resources/cmake/ConnextDdsCodegen.cmake).
 
 For a more comprehensive example on how to build an RTI Connext DDS application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/routing_service/remote_admin/c++11/README.md
+++ b/examples/routing_service/remote_admin/c++11/README.md
@@ -89,6 +89,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/routing_service/remote_admin/c++11/README.md
+++ b/examples/routing_service/remote_admin/c++11/README.md
@@ -87,13 +87,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/routing_service/remote_admin/c++11/README.md
+++ b/examples/routing_service/remote_admin/c++11/README.md
@@ -82,8 +82,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/routing_service/remote_admin/c++11/README.md
+++ b/examples/routing_service/remote_admin/c++11/README.md
@@ -78,7 +78,7 @@ cmake -DCONNEXTDDS_DIR=<connext dir> \
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/routing_service/remote_admin/c++11/README.md
+++ b/examples/routing_service/remote_admin/c++11/README.md
@@ -78,44 +78,44 @@ cmake -DCONNEXTDDS_DIR=<connext dir> \
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform. If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh

--- a/examples/routing_service/remote_admin/c++11/README.md
+++ b/examples/routing_service/remote_admin/c++11/README.md
@@ -112,7 +112,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/routing_service/shapes_processor/c++11/README.md
+++ b/examples/routing_service/shapes_processor/c++11/README.md
@@ -159,13 +159,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/examples/routing_service/shapes_processor/c++11/README.md
+++ b/examples/routing_service/shapes_processor/c++11/README.md
@@ -184,7 +184,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/routing_service/shapes_processor/c++11/README.md
+++ b/examples/routing_service/shapes_processor/c++11/README.md
@@ -154,8 +154,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/routing_service/shapes_processor/c++11/README.md
+++ b/examples/routing_service/shapes_processor/c++11/README.md
@@ -161,6 +161,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/routing_service/shapes_processor/c++11/README.md
+++ b/examples/routing_service/shapes_processor/c++11/README.md
@@ -150,44 +150,44 @@ the example in the previous step.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -196,8 +196,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -205,16 +205,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/routing_service/shapes_processor/c++11/README.md
+++ b/examples/routing_service/shapes_processor/c++11/README.md
@@ -150,7 +150,7 @@ the example in the previous step.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/routing_service/struct_array_transf/c++11/README.md
+++ b/examples/routing_service/struct_array_transf/c++11/README.md
@@ -127,44 +127,44 @@ the example in the previous step.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -173,8 +173,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -182,16 +182,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/examples/routing_service/struct_array_transf/c++11/README.md
+++ b/examples/routing_service/struct_array_transf/c++11/README.md
@@ -127,7 +127,7 @@ the example in the previous step.
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/examples/routing_service/struct_array_transf/c++11/README.md
+++ b/examples/routing_service/struct_array_transf/c++11/README.md
@@ -131,8 +131,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for

--- a/examples/routing_service/struct_array_transf/c++11/README.md
+++ b/examples/routing_service/struct_array_transf/c++11/README.md
@@ -161,7 +161,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/examples/routing_service/struct_array_transf/c++11/README.md
+++ b/examples/routing_service/struct_array_transf/c++11/README.md
@@ -138,6 +138,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/examples/routing_service/struct_array_transf/c++11/README.md
+++ b/examples/routing_service/struct_array_transf/c++11/README.md
@@ -136,13 +136,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/resources/markdown_templates/CExampleTemplate.md
+++ b/resources/markdown_templates/CExampleTemplate.md
@@ -74,6 +74,7 @@ default behavior:
     dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
+
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake

--- a/resources/markdown_templates/CExampleTemplate.md
+++ b/resources/markdown_templates/CExampleTemplate.md
@@ -63,44 +63,44 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows), \. You can use the following CMake variables to modify the
+solution on Windows). You can use the following CMake variables to modify the
 default behavior:
 
--   `-DCMAKE_BUILD_TYPE` -- specifies the build mode. Valid values are Release
-    and Debug. See the [CMake documentation for more details.
+-   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
+    and `Debug`. See the [CMake documentation for more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 
--   `-DBUILD_SHARED_LIBS` -- specifies the link mode. Valid values are ON for
-    dynamic linking and OFF for static linking. See [CMake documentation for
+-   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
+    dynamic linking and `OFF` for static linking. See [CMake documentation for
     more details.
     (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
 
--   `-G` -- CMake generator. The generator is the native build system used to
-    build the source code. All the valid values are described described in the
-    CMake documentation [CMake Generators
-    Section.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+-   `-G` - CMake generator. The generator is the native build system used to
+    build the source code. All the valid values are described in the CMake
+    documentation for [CMake
+    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
 
-For example, to build a example in Debug/Static mode run CMake as follows:
+For example, to build an example in Debug/Dynamic mode run CMake as follows:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. -G "Visual Studio 15 2017" -A x64
 ```
 
-### Configuring Connext DDS Installation Path and Architecture
+### Configuring Connext Installation Path and Architecture
 
 The CMake build infrastructure will try to guess the location of your Connext
-DDS installation and the Connext DDS architecture based on the default settings
-for your host platform.If you installed Connext DDS in a custom location, you
-can use the CONNEXTDDS_DIR variable to indicate the path to your RTI Connext DDS
+installation and the Connext architecture based on the default settings
+for your host platform. If you installed Connext in a custom location, you
+can use the `CONNEXTDDS_DIR` variable to indicate the path to your RTI Connext
 installation folder. For example:
 
 ```sh
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, If you installed libraries for multiple target architecture on your system
-(i.e., you installed more than one target rtipkg), you can use the
-CONNEXTDDS_ARCH variable to indicate the architecture of the specific libraries
+Also, if you installed libraries for multiple target architecture on your system
+(i.e., you installed more than one target `.rtipkg` file), you can use the
+`CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:
 
 ```sh
@@ -109,8 +109,8 @@ cmake -DCONNEXTDDS_ARCH=x64Linux3gcc5.4.0 ..
 
 ### CMake Build Infrastructure
 
-The CMakeListst.txt script that builds this example uses a generic CMake
-function called connextdds_add_example that defines all the necessary constructs
+The `CMakeListst.txt` script that builds this example uses a generic CMake
+function called `connextdds_add_example` that defines all the necessary constructs
 to:
 
 1.  Run RTI Code Generator to generate the serialization/deserialization code
@@ -118,16 +118,16 @@ to:
 
 2.  Build the corresponding Publisher and Subscriber applications.
 
-3.  Copy the USER_QOS_PROFILES.xml file into the directory where the publisher
+3.  Copy the `USER_QOS_PROFILES.xml` file into the directory where the publisher
     and subscriber executables are generated.
 
-You will find the definition of connextdds_add_example, along with detailed
+You will find the definition of `connextdds_add_example`, along with detailed
 documentation, in
 [resources/cmake/rticonnextdds-cmake-utils/cmake/Modules/ConnextDdsAddExample.cmake
 ](https://github.com/rticommunity/rticonnextdds-cmake-utils/blob/main/cmake/Modules/ConnextDdsAddExample.cmake).
 
-For a more comprehensive example on how to build an RTI Connext DDS application
+For a more comprehensive example on how to build an RTI Connext application
 using CMake, please refer to the
 [hello_world](../../../connext_dds/build_systems/cmake/) example, which includes
-a comprehensive CMakeLists.txt script with all the steps and instructions
+a comprehensive `CMakeLists.txt` script with all the steps and instructions
 described in detail.

--- a/resources/markdown_templates/CExampleTemplate.md
+++ b/resources/markdown_templates/CExampleTemplate.md
@@ -63,7 +63,7 @@ The applications accept up to two arguments:
 
 By default, CMake will generate build files using the most common generator for
 your host platform (e.g., Makefiles on Unix-like systems and Visual Studio
-solution on Windows). You can use the following CMake variables to modify the
+Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`

--- a/resources/markdown_templates/CExampleTemplate.md
+++ b/resources/markdown_templates/CExampleTemplate.md
@@ -97,7 +97,7 @@ installation folder. For example:
 cmake -DCONNEXTDDS_DIR=/home/rti/rti_connext_dds-x.y.z ..
 ```
 
-Also, if you installed libraries for multiple target architecture on your system
+Also, if you installed libraries for multiple target architectures on your system
 (i.e., you installed more than one target `.rtipkg` file), you can use the
 `CONNEXTDDS_ARCH` variable to indicate the architecture of the specific libraries
 you want to link against. For example:

--- a/resources/markdown_templates/CExampleTemplate.md
+++ b/resources/markdown_templates/CExampleTemplate.md
@@ -72,13 +72,12 @@ default behavior:
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for
-    more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
-
+    more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).
 -   `-G` - CMake generator. The generator is the native build system used to
     build the source code. All the valid values are described in the CMake
     documentation for [CMake
-    Generators.](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)
+    Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
 For example, to build an example in Debug/Dynamic mode run CMake as follows:
 

--- a/resources/markdown_templates/CExampleTemplate.md
+++ b/resources/markdown_templates/CExampleTemplate.md
@@ -67,8 +67,8 @@ Solutions on Windows). You can use the following CMake variables to modify the
 default behavior:
 
 -   `-DCMAKE_BUILD_TYPE` - specifies the build mode. Valid values are `Release`
-    and `Debug`. See the [CMake documentation for more details.
-    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+    and `Debug`. See the [CMake documentation for more details
+    (Optional)](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 -   `-DBUILD_SHARED_LIBS` - specifies the link mode. Valid values are `ON` for
     dynamic linking and `OFF` for static linking. See [CMake documentation for


### PR DESCRIPTION
### Summary
Fixed the 'Customizing the Build' section present in the README.md files of examples for typos and formatting.

### Checks
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.