### PR TITLE
Feature/ironside 388

### DIFF
--- a/examples/routing_service/file_adapter/c++11/RsFileAdapter.xml
+++ b/examples/routing_service/file_adapter/c++11/RsFileAdapter.xml
@@ -17,7 +17,7 @@
                 - Executable directory
                 - Environment library path
             -->
-            <dll>fileadapter</dll>
+            <dll>FileAdapterC++11</dll>
             <create_function>FileAdapter_create_adapter_plugin</create_function>
         </adapter_plugin>
     </plugin_library>


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->

### Summary

Fixing IRONSIDE-388. Wrong library name in Routing Service XML configuration for File Adapter C++ example.

### Details and comments


### Checks

<!-- Change te space between the square brackets to an `x` -->
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.

<!-- Uncomment bellow if you added a C/C++ example and updated examples/connext_dds/CMakeList.txt -->
<!--
-   [ ] I have added a new C/C++ example and updated `examples/connext_dds/CMakeList.txt` accordingly.
-->
<!-- Uncomment bellow if you added a Java example and updated examples/connext_dds/settings.gradle -->
<!--
-   [ ] I have added a new Java example and updated `examples/connext_dds/settings.gradle` accordingly.
-->
