### PR TITLE
(fix) Build on GCC 4.8.5

### DIFF
--- a/examples/recording_service/pluggable_storage/c++11/CMakeLists.txt
+++ b/examples/recording_service/pluggable_storage/c++11/CMakeLists.txt
@@ -13,6 +13,7 @@ cmake_minimum_required(VERSION 3.11)
 project (PluggableStorageC++11)
 
 set(CMAKE_DEBUG_POSTFIX "d")
+set(CMAKE_CXX_STANDARD 11)
 
 if(NOT BUILD_SHARED_LIBS)
     set(msg

--- a/examples/recording_service/pluggable_storage/c++11/HelloMsg_publisher.cxx
+++ b/examples/recording_service/pluggable_storage/c++11/HelloMsg_publisher.cxx
@@ -11,6 +11,7 @@
  */
 
 #include <iostream>
+#include <sstream>
 
 #include <dds/pub/ddspub.hpp>
 #include <rti/util/util.hpp>  // for sleep()


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->

### Summary

Fixes a compilation error with GCC 4.8.5

### Details and comments

Added explicit standard and `sstream` declaration.

### Checks

<!-- Change te space between the square brackets to an `x` -->
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.