### PR TITLE
Replace zipfile for CMake -E tar in the linux_install.py script

### DIFF
--- a/resources/ci_cd/linux_static_analysis.py
+++ b/resources/ci_cd/linux_static_analysis.py
@@ -52,7 +52,7 @@ def find_connext_dir() -> Path:
 def parse_args() -> argparse.Namespace:
     """Parse the CLI options."""
     parser = argparse.ArgumentParser()
-    parser.add_argument("--build-dir", type=Path, default="examples/build")
+    parser.add_argument("--build-dir", type=Path, default="build")
     parser.add_argument("--connext-dir", type=Path)
     args = parser.parse_args()
 


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->

### Summary

Fix #614 

Fix the symbolic links from LM packages issue.

### Details and comments

Since we are using the LM bundles for CI, the building has been failing due to the existence of symbolic links in the civetweb third-party libraries. The Python module `zipfile` used in the linux_install.py script does not work well with symbolic links and instead, creates plain files on their place when unzipping the LM bundles. This PR aims to solve it by using the built-in CMake tar command-line tool.

### Checks

<!-- Change te space between the square brackets to an `x` -->
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.

<!-- Uncomment bellow if you added a C/C++ example and updated examples/connext_dds/CMakeList.txt -->
<!--
-   [ ] I have added a new C/C++ example and updated `examples/connext_dds/CMakeList.txt` accordingly.
-->
<!-- Uncomment bellow if you added a Java example and updated examples/connext_dds/settings.gradle -->
<!--
-   [ ] I have added a new Java example and updated `examples/connext_dds/settings.gradle` accordingly.
-->
