### PR TITLE
fix: Included ConnextDdsAddExample in remote_admin's cmake

### DIFF
--- a/examples/routing_service/remote_admin/c++11/CMakeLists.txt
+++ b/examples/routing_service/remote_admin/c++11/CMakeLists.txt
@@ -32,6 +32,8 @@ find_package(
 set(CODEGEN_FLAGS UNBOUNDED)
 # Include the CodegenRTIConnextDDS cmake module
 include(ConnextDdsCodegen)
+# Include ConnextDdsAddExample.cmake from resources/cmake
+include(ConnextDdsAddExample)
 
 connextdds_rtiddsgen_run(
     IDL_FILE


### PR DESCRIPTION
### Summary

The example won't compile if this module is not included. Closes #622.

### Checks

- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.