### PR TITLE
Remove LBED add-on reference from example README

### DIFF
--- a/examples/connext_dds/lbediscovery_xml_app_creation/README.md
+++ b/examples/connext_dds/lbediscovery_xml_app_creation/README.md
@@ -25,9 +25,6 @@ automatically infer which RTPS object ID Connext will assign to each endpoint.
 
 ## Example description
 
-**Note:** For running this example, you need to have installed the
-*RTI Limited Bandwidth Endpoint Discovery Plugin* add-on product.
-
 This example shows how to configure LBED when your application uses XML-Based
 Application Creation. You will learn that, in this specific case, you don't need
 to define an RTPS object ID for every endpoint, and that you can use the DDS-XML


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->

### Summary

Update the `README` file of the `lbediscovery_xml_app_creation` example.

### Details and comments

When this example was written, the LBED plugin was a separate add-on product. This changed in 7.1.0. Now, LBED is shipped as part of the RTI Connext Professional bundle. I have removed the sentence in the `README` file that stated that you needed to install a separate add-on product to build and run the example. It is no longer needed.

### Checks

<!-- Change te space between the square brackets to an `x` -->
-   [X] I have updated the documentation accordingly.
-   [X] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.

<!-- Uncomment bellow if you added a C/C++ example and updated examples/connext_dds/CMakeList.txt -->
<!--
-   [ ] I have added a new C/C++ example and updated `examples/connext_dds/CMakeList.txt` accordingly.
-->
<!-- Uncomment bellow if you added a Java example and updated examples/connext_dds/settings.gradle -->
<!--
-   [ ] I have added a new Java example and updated `examples/connext_dds/settings.gradle` accordingly.
-->
