### PR TITLE
Fixing issue in Dynamic Data c++ examples

### DIFF
--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c++11/CMakeLists.txt
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c++11/CMakeLists.txt
@@ -11,11 +11,23 @@
 #
 cmake_minimum_required(VERSION 3.11)
 project(rtiexamples-dynamic-data-access-union-discriminator)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../resources/cmake/Modules"
 )
 include(ConnextDdsConfigureCmakeUtils)
 connextdds_configure_cmake_utils()
+
+# Find the ConnextDDS libraries. This will look for core and API libraries
+find_package(RTIConnextDDS
+    "7.0.0"
+    REQUIRED
+    COMPONENTS
+        core
+)
 
 add_executable(dynamic_data_union_example_cxx2
     "${CMAKE_CURRENT_SOURCE_DIR}/dynamic_data_union_example.cxx"

--- a/examples/connext_dds/dynamic_data_access_union_discriminator/c++98/CMakeLists.txt
+++ b/examples/connext_dds/dynamic_data_access_union_discriminator/c++98/CMakeLists.txt
@@ -17,6 +17,14 @@ list(APPEND CMAKE_MODULE_PATH
 include(ConnextDdsConfigureCmakeUtils)
 connextdds_configure_cmake_utils()
 
+# Find the ConnextDDS libraries. This will look for core and API libraries
+find_package(RTIConnextDDS
+    "7.0.0"
+    REQUIRED
+    COMPONENTS
+        core
+)
+
 add_executable(dynamic_data_union_example_cxx
     "${CMAKE_CURRENT_SOURCE_DIR}/dynamic_data_union_example.cxx"
 )

--- a/examples/connext_dds/dynamic_data_nested_structs/c++11/CMakeLists.txt
+++ b/examples/connext_dds/dynamic_data_nested_structs/c++11/CMakeLists.txt
@@ -11,6 +11,10 @@
 #
 cmake_minimum_required(VERSION 3.11)
 project(rtiexamples-dynamic-data-nested_struct)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../resources/cmake/Modules"
 )

--- a/examples/connext_dds/dynamic_data_request_reply/c++11/CMakeLists.txt
+++ b/examples/connext_dds/dynamic_data_request_reply/c++11/CMakeLists.txt
@@ -11,6 +11,10 @@
 #
 cmake_minimum_required(VERSION 3.11)
 project(rtiexamples-dynamic-data-request_reply)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../resources/cmake/Modules"
 )

--- a/examples/connext_dds/dynamic_data_sequences/c++11/CMakeLists.txt
+++ b/examples/connext_dds/dynamic_data_sequences/c++11/CMakeLists.txt
@@ -11,6 +11,10 @@
 #
 cmake_minimum_required(VERSION 3.11)
 project(rtiexamples-dynamic-data-sequences)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../resources/cmake/Modules"
 )


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->

### Summary
This PR fixes an issue in the dynamic data examples. It adds the `find_package` where it is needed as well as it sets the C++11 flags for CMake in those examples.

### Checks

<!-- Change the space between the square brackets to an `x` -->
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.

