### PR TITLE
Add dynamic_data_skip_serialization example

### DIFF
--- a/examples/connext_dds/dynamic_data_skip_serialization/README.md
+++ b/examples/connext_dds/dynamic_data_skip_serialization/README.md
@@ -17,7 +17,7 @@ where a custom Recording application may be useful.
 
 This example implements a simple recording application that uses the DynamicData
 API to receive data in CDR format and directly record it in a file. The example
-also provides an replay option that reads the data buffers from the file
+also provides a replay option that reads the data buffers from the file
 and publishes them back. For convenience, an option to publish a few samples
 to test the record and replay functionality is also provided.
 

--- a/examples/connext_dds/dynamic_data_skip_serialization/README.md
+++ b/examples/connext_dds/dynamic_data_skip_serialization/README.md
@@ -1,0 +1,29 @@
+# Example Code: Skip Data Serialization for Data Recording
+
+## Concept
+
+There are scenarios where the need to deserialize or inspect data is not necessary.
+A common example is recording data. In this case, the application can simply
+record the binary data as it is received, and then replay it later. This provides
+a significant performance improvement.
+
+The DynamicData API provides a mode that allows sending or receiving data in its
+CDR format, without serializing or deserializing it.
+
+Note that while Connext provides a Recording Service, there may be situations
+where a custom Recording application may be useful.
+
+## Example Description
+
+This example implements a simple recording application that uses the DynamicData
+API to receive data in CDR format and directly record it in a file. The example
+also provides an replay option that reads the data buffers from the file
+and publishes them back.
+
+The key parts of the example are implemented in the ``record()`` and
+``replay()`` functions in the example source code for each language.
+
+The example is very simple and uses a single type and topic, but it could be
+extended to use discovered types (see the
+[built-in topics example](../builtin_topics/)) to implement a more
+general-purpose recording application.

--- a/examples/connext_dds/dynamic_data_skip_serialization/README.md
+++ b/examples/connext_dds/dynamic_data_skip_serialization/README.md
@@ -18,7 +18,8 @@ where a custom Recording application may be useful.
 This example implements a simple recording application that uses the DynamicData
 API to receive data in CDR format and directly record it in a file. The example
 also provides an replay option that reads the data buffers from the file
-and publishes them back.
+and publishes them back. For convenience, an option to publish a few samples
+to test the record and replay functionality is also provided.
 
 The key parts of the example are implemented in the ``record()`` and
 ``replay()`` functions in the example source code for each language.

--- a/examples/connext_dds/dynamic_data_skip_serialization/c++11/CMakeLists.txt
+++ b/examples/connext_dds/dynamic_data_skip_serialization/c++11/CMakeLists.txt
@@ -1,0 +1,57 @@
+#
+# (c) 2018 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+#
+# RTI grants Licensee a license to use, modify, compile, and create derivative
+# works of the Software.  Licensee has the right to distribute object form
+# only for use with RTI products.  The Software is provided "as is", with no
+# warranty of any type, including any warranty for fitness for any purpose.
+# RTI is under no obligation to maintain or support the Software.  RTI shall
+# not be liable for any incidental or consequential damages arising out of the
+# use or inability to use the software.
+#
+cmake_minimum_required(VERSION 3.11)
+project(rtiexamples-dynamic-data-skip-serialization)
+list(APPEND CMAKE_MODULE_PATH
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../resources/cmake/Modules"
+)
+include(ConnextDdsConfigureCmakeUtils)
+connextdds_configure_cmake_utils()
+
+# Find the RTI Connext DDS libraries
+if(NOT RTIConnextDDS_FOUND)
+    find_package(RTIConnextDDS
+        "7.3.0"
+        REQUIRED
+        COMPONENTS
+            core
+    )
+endif()
+
+set(CMAKE_CXX_STANDARD 11)
+set(PLATFORM_MODERN_CXX_STANDARD 11)
+
+add_executable(recorder_cxx2
+    "${CMAKE_CURRENT_SOURCE_DIR}/util.cxx"
+    "${CMAKE_CURRENT_SOURCE_DIR}/recorder.cxx"
+)
+
+target_link_libraries(recorder_cxx2
+    PUBLIC
+        RTIConnextDDS::cpp2_api
+)
+
+target_include_directories(recorder_cxx2
+    PRIVATE
+        "${CMAKE_CURRENT_BINARY_DIR}/src"
+)
+
+set_target_properties(recorder_cxx2
+    PROPERTIES
+        OUTPUT_NAME "recorder")
+
+
+if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    set_target_properties(recorder_cxx2
+        PROPERTIES
+            LINK_FLAGS -Wl,--no-as-needed)
+endif()

--- a/examples/connext_dds/dynamic_data_skip_serialization/c++11/CMakeLists.txt
+++ b/examples/connext_dds/dynamic_data_skip_serialization/c++11/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# (c) 2018 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+# (c) 2024 Copyright, Real-Time Innovations, Inc.  All rights reserved.
 #
 # RTI grants Licensee a license to use, modify, compile, and create derivative
 # works of the Software.  Licensee has the right to distribute object form

--- a/examples/connext_dds/dynamic_data_skip_serialization/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_skip_serialization/c++11/README.md
@@ -67,4 +67,3 @@ Now run the application that replays the data recorded in  `data.bin`:
 ```
 
 The subscriber will print the data that is being replayed.
-

--- a/examples/connext_dds/dynamic_data_skip_serialization/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_skip_serialization/c++11/README.md
@@ -68,4 +68,3 @@ Now run the application that replays the data recorded in  `data.bin`:
 
 The subscriber will print the data that is being replayed.
 
-

--- a/examples/connext_dds/dynamic_data_skip_serialization/c++11/README.md
+++ b/examples/connext_dds/dynamic_data_skip_serialization/c++11/README.md
@@ -1,0 +1,71 @@
+# Example Code: Skip Data Serialization for Data Recording
+
+## Building the Example :wrench:
+
+To build this example, first run CMake to generate the corresponding build
+files. We recommend you use a separate directory to store all the generated
+files (e.g., ./build).
+
+```sh
+mkdir build
+cd build
+cmake ..
+```
+
+Once you have run CMake, you will find a number of new files in your build
+directory (the list of generated files will depend on the specific CMake
+Generator). To build the example, run CMake as follows:
+
+```sh
+cmake --build .
+```
+
+**Note**: if you are using a multi-configuration generator, such as Visual
+Studio solutions, you can specify the configuration mode to build as follows:
+
+```sh
+cmake --build . --config Release|Debug
+```
+
+Alternatively, you can use directly the generated infrastructure (e.g.,
+Makefiles or Visual Studio Solutions) to build the example. If you generated
+Makefiles in the configuration process, run make to build the example. Likewise,
+if you generated a Visual Studio solution, open the solution and follow the
+regular build process.
+
+## Running the Example
+
+From the build directory, in one command prompt run the recorder:
+
+```sh
+./recorder --record data.bin
+```
+
+In a second command prompt run the publisher:
+
+```sh
+./recorder --publish
+```
+
+The recorder application will print a message each time a sample is recorded.
+
+Now kill the recorder and run the replay application. A file called `data.bin`
+will have been created in the current directory.
+
+Now we will run a subscriber and a reply application.
+
+To subscribe to the data we will simply use **rtiddsspy**:
+
+```sh
+<Connext installation>/bin/rtiddsspy -printSample
+```
+
+Now run the application that replays the data recorded in  `data.bin`:
+
+```sh
+./recorder --replay data.bin
+```
+
+The subscriber will print the data that is being replayed.
+
+

--- a/examples/connext_dds/dynamic_data_skip_serialization/c++11/recorder.cxx
+++ b/examples/connext_dds/dynamic_data_skip_serialization/c++11/recorder.cxx
@@ -109,7 +109,8 @@ void replay(const std::string &file_name, int domain_id)
     dds::domain::DomainParticipant participant(domain_id);
 
     // For the replay application we don't need to register the type with any
-    // particular property
+    // particular property because DynamicData DataWriters are always prepared
+    // to write serialized buffers directly
     dds::topic::Topic<DynamicData> topic(
             participant,
             "Example Record",

--- a/examples/connext_dds/dynamic_data_skip_serialization/c++11/recorder.cxx
+++ b/examples/connext_dds/dynamic_data_skip_serialization/c++11/recorder.cxx
@@ -123,12 +123,16 @@ void replay(const std::string &file_name, int domain_id)
     DynamicData sample(create_type());
     while (!in_file.eof()) {
         // read length and data
-        in_file.read(reinterpret_cast<char *>(&length), sizeof(length));
+        if (!in_file.read(reinterpret_cast<char *>(&length), sizeof(length))) {
+            break;
+        }
 
         std::cout << "Replaying data sample (" << length << " bytes)"
                   << std::endl;
         buffer.resize(length);
-        in_file.read(buffer.data(), length);
+        if (!in_file.read(buffer.data(), length)) {
+            break;
+        }
 
         // By calling the set_cdr_buffer method we override the contents
         // of the DynamicData object with the new serialized data. After

--- a/examples/connext_dds/dynamic_data_skip_serialization/c++11/recorder.cxx
+++ b/examples/connext_dds/dynamic_data_skip_serialization/c++11/recorder.cxx
@@ -21,10 +21,11 @@ dds::core::xtypes::StructType create_type()
 {
     using namespace dds::core::xtypes;
 
-    StructType type("RecordExample", {
-        Member("id", StringType(128)),
-        Member("payload", SequenceType(primitive_type<int32_t>(), 1024))
-    });
+    StructType type(
+            "RecordExample",
+            { Member("id", StringType(128)),
+              Member("payload",
+                     SequenceType(primitive_type<int32_t>(), 1024)) });
 
     return type;
 }

--- a/examples/connext_dds/dynamic_data_skip_serialization/c++11/recorder.cxx
+++ b/examples/connext_dds/dynamic_data_skip_serialization/c++11/recorder.cxx
@@ -1,4 +1,14 @@
-
+/*
+ * (c) Copyright, Real-Time Innovations, 2023.  All rights reserved.
+ * RTI grants Licensee a license to use, modify, compile, and create derivative
+ * works of the software solely for use with RTI Connext DDS. Licensee may
+ * redistribute copies of the software provided that all such copies are subject
+ * to this license. The software is provided "as is", with no warranty of any
+ * type, including any warranty for fitness for any purpose. RTI is under no
+ * obligation to maintain or support the software. RTI shall not be liable for
+ * any incidental or consequential damages arising out of the use or inability
+ * to use the software.
+ */
 
 #include <fstream>
 #include <iostream>

--- a/examples/connext_dds/dynamic_data_skip_serialization/c++11/recorder.cxx
+++ b/examples/connext_dds/dynamic_data_skip_serialization/c++11/recorder.cxx
@@ -1,0 +1,179 @@
+
+
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <rti/rti.hpp>
+
+#include "util.hpp"
+
+dds::core::xtypes::StructType create_type()
+{
+    using namespace dds::core::xtypes;
+
+    StructType type("RecordExample", {
+        Member("id", StringType(128)),
+        Member("payload", SequenceType(primitive_type<int32_t>(), 1024))
+    });
+
+    return type;
+}
+
+void record(const std::string &file_name, int domain_id)
+{
+    using dds::core::xtypes::DynamicData;
+
+    // To disable the deserialization on the DataReader and get direct access
+    // to the serialized CDR buffer, we need to register the DataReader type
+    // with the DynamicDataTypeSerializationProperty::skip_deserialization set
+    // to true, and then create the DataReader with the name used to register
+    // the type.
+    dds::domain::DomainParticipant participant(domain_id);
+    const std::string type_name = "RecordExample";
+    rti::core::xtypes::DynamicDataTypeSerializationProperty property;
+    property.skip_deserialization(true);
+    rti::domain::register_type(participant, type_name, create_type(), property);
+
+    dds::topic::Topic<DynamicData> topic(
+            participant,
+            "Example Record",
+            type_name);  // specify the registered type name
+
+    auto qos = dds::core::QosProvider::Default().datareader_qos(
+            rti::core::builtin_profiles::qos_lib::generic_strict_reliable());
+    dds::sub::DataReader<DynamicData> reader(topic, qos);
+    if (!util::wait_for_writer(reader)) {
+        return;
+    }
+
+    // File setup
+    std::ofstream out_file(file_name, std::ios::binary);
+    if (!out_file) {
+        std::cerr << "Failed to open file for recording: " << file_name
+                  << std::endl;
+        return;
+    }
+
+    auto record_data = [&out_file, &reader]() {
+        auto samples = reader.take();
+        for (auto sample : samples) {
+            if (!sample.info().valid()) {
+                continue;
+            }
+
+            // Now the only way to access the data is to call get_cdr_buffer,
+            // any other field accessor will fail.
+            auto buffer_info = sample.data().get_cdr_buffer();
+            auto buffer = buffer_info.first;
+            auto buffer_length = buffer_info.second;
+            std::cout << "Recording data sample (" << buffer_length << " bytes)"
+                      << std::endl;
+            out_file.write(
+                    reinterpret_cast<const char *>(&buffer_length),
+                    sizeof(buffer_length));
+            out_file.write(
+                    reinterpret_cast<const char *>(buffer),
+                    buffer_length);
+        }
+    };
+
+    // Set up a ReadCondition to trigger the record_data function when
+    // data is available
+    dds::core::cond::WaitSet waitset;
+    dds::sub::cond::ReadCondition read_condition(
+            reader,
+            dds::sub::status::DataState::any(),
+            record_data);
+    waitset += read_condition;
+
+    while (!application::shutdown_requested) {
+        waitset.dispatch(dds::core::Duration(1));
+    }
+}
+
+void replay(const std::string &file_name, int domain_id)
+{
+    using dds::core::xtypes::DynamicData;
+
+    dds::domain::DomainParticipant participant(domain_id);
+
+    // For the replay application we don't need to register the type with any
+    // particular property
+    dds::topic::Topic<DynamicData> topic(
+            participant,
+            "Example Record",
+            create_type());
+
+    auto qos = dds::core::QosProvider::Default().datawriter_qos(
+            rti::core::builtin_profiles::qos_lib::generic_strict_reliable());
+    dds::pub::DataWriter<DynamicData> writer(topic, qos);
+    if (!util::wait_for_reader(writer)) {
+        return;
+    }
+
+    std::ifstream in_file(file_name, std::ios::binary);
+    if (!in_file) {
+        std::cerr << "Failed to open file for replay: " << file_name
+                  << std::endl;
+        return;
+    }
+
+    uint32_t length;
+    std::vector<char> buffer;
+    DynamicData sample(create_type());
+    while (!in_file.eof()) {
+        // read length and data
+        in_file.read(reinterpret_cast<char *>(&length), sizeof(length));
+
+        std::cout << "Replaying data sample (" << length << " bytes)"
+                  << std::endl;
+        buffer.resize(length);
+        in_file.read(buffer.data(), length);
+
+        // By calling the set_cdr_buffer method we override the contents
+        // of the DynamicData object with the new serialized data. After
+        // setting a cdr buffer we can't use any field getters or setters.
+        sample.set_cdr_buffer(buffer.data(), length);
+        writer.write(sample);
+    }
+
+    in_file.close();
+    writer.wait_for_acknowledgments(dds::core::Duration(10));
+}
+
+int main(int argc, char *argv[])
+{
+    using namespace application;
+
+    // Parse arguments and handle control-C
+    auto arguments = parse_arguments(argc, argv);
+    if (arguments.parse_result == ParseReturn::exit) {
+        return EXIT_SUCCESS;
+    } else if (arguments.parse_result == ParseReturn::failure) {
+        return EXIT_FAILURE;
+    }
+    setup_signal_handlers();
+
+    // Sets Connext verbosity to help debugging
+    rti::config::Logger::instance().verbosity(arguments.verbosity);
+
+    try {
+        if (arguments.application_type == ApplicationType::record) {
+            record(arguments.file_name, arguments.domain_id);
+        } else if (arguments.application_type == ApplicationType::replay) {
+            replay(arguments.file_name, arguments.domain_id);
+        } else if (arguments.application_type == ApplicationType::publish) {
+            util::publish_example_data(arguments.domain_id, create_type());
+        }
+
+    } catch (const std::exception &ex) {
+        std::cerr << "Exception in application: " << ex.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    // Releases the memory used by the participant factory.  Optional at
+    // application exit
+    dds::domain::DomainParticipant::finalize_participant_factory();
+
+    return EXIT_SUCCESS;
+}

--- a/examples/connext_dds/dynamic_data_skip_serialization/c++11/util.cxx
+++ b/examples/connext_dds/dynamic_data_skip_serialization/c++11/util.cxx
@@ -97,21 +97,20 @@ ApplicationArguments parse_arguments(int argc, char *argv[])
 
     while (arg_processing < argc) {
         if ((argc > arg_processing + 1)
-                && (strcmp(argv[arg_processing], "-d") == 0
-                        || strcmp(argv[arg_processing], "--domain") == 0)) {
+            && (strcmp(argv[arg_processing], "-d") == 0
+                || strcmp(argv[arg_processing], "--domain") == 0)) {
             domain_id = atoi(argv[arg_processing + 1]);
             arg_processing += 2;
         } else if (
                 (argc > arg_processing + 1)
                 && (strcmp(argv[arg_processing], "-s") == 0
-                        || strcmp(argv[arg_processing], "--sample-count")
-                                == 0)) {
+                    || strcmp(argv[arg_processing], "--sample-count") == 0)) {
             sample_count = atoi(argv[arg_processing + 1]);
             arg_processing += 2;
         } else if (
                 (argc > arg_processing + 1)
                 && (strcmp(argv[arg_processing], "-v") == 0
-                        || strcmp(argv[arg_processing], "--verbosity") == 0)) {
+                    || strcmp(argv[arg_processing], "--verbosity") == 0)) {
             set_verbosity(verbosity, atoi(argv[arg_processing + 1]));
             arg_processing += 2;
             // parse file_name

--- a/examples/connext_dds/dynamic_data_skip_serialization/c++11/util.cxx
+++ b/examples/connext_dds/dynamic_data_skip_serialization/c++11/util.cxx
@@ -1,0 +1,176 @@
+/*
+ * (c) Copyright, Real-Time Innovations, 2023.  All rights reserved.
+ * RTI grants Licensee a license to use, modify, compile, and create derivative
+ * works of the software solely for use with RTI Connext DDS. Licensee may
+ * redistribute copies of the software provided that all such copies are subject
+ * to this license. The software is provided "as is", with no warranty of any
+ * type, including any warranty for fitness for any purpose. RTI is under no
+ * obligation to maintain or support the software. RTI shall not be liable for
+ * any incidental or consequential damages arising out of the use or inability
+ * to use the software.
+ */
+
+#include "util.hpp"
+
+namespace util {
+
+void publish_example_data(
+        unsigned int domain_id,
+        const dds::core::xtypes::DynamicType &type)
+{
+    // Start communicating in a domain, usually one participant per application
+    dds::domain::DomainParticipant participant(domain_id);
+
+    // Create a Topic with a name and a datatype
+    dds::topic::Topic<dds::core::xtypes::DynamicData> topic(
+            participant,
+            "Example Record",
+            type);
+
+    // Create a DataWriter with default QoS
+    dds::pub::DataWriter<dds::core::xtypes::DynamicData> writer(
+            dds::pub::Publisher(participant),
+            topic);
+    if (!wait_for_reader(writer)) {
+        return;
+    }
+
+    rti::util::sleep(dds::core::Duration::from_secs(1));
+
+    // Write a few data samples
+    dds::core::xtypes::DynamicData data(type);
+    data.value("id", std::string("Example"));
+
+    std::vector<int32_t> payload;
+    for (int i = 0; i < 10; i++) {
+        payload.push_back(i);
+    }
+
+    data.set_values("payload", payload);
+    writer.write(data);
+
+    rti::util::sleep(dds::core::Duration::from_secs(1));
+
+    writer.wait_for_acknowledgments(dds::core::Duration(5));
+}
+
+}  // namespace util
+
+namespace application {
+    bool shutdown_requested = false;
+
+    void set_verbosity(
+            rti::config::Verbosity & verbosity,
+            int verbosity_value)
+    {
+        switch (verbosity_value) {
+        case 0:
+            verbosity = rti::config::Verbosity::SILENT;
+            break;
+        case 1:
+            verbosity = rti::config::Verbosity::EXCEPTION;
+            break;
+        case 2:
+            verbosity = rti::config::Verbosity::WARNING;
+            break;
+        case 3:
+            verbosity = rti::config::Verbosity::STATUS_ALL;
+            break;
+        default:
+            verbosity = rti::config::Verbosity::EXCEPTION;
+            break;
+        }
+    }
+
+    ApplicationArguments parse_arguments(int argc, char *argv[])
+    {
+        int arg_processing = 1;
+        bool show_usage = false;
+        ParseReturn parse_result = ParseReturn::ok;
+        unsigned int domain_id = 0;
+        unsigned int sample_count = (std::numeric_limits<unsigned int>::max)();
+        ApplicationType app_type = ApplicationType::unknown;
+        std::string file_name;
+        rti::config::Verbosity verbosity(rti::config::Verbosity::EXCEPTION);
+
+        while (arg_processing < argc) {
+            if ((argc > arg_processing + 1)
+                    && (strcmp(argv[arg_processing], "-d") == 0
+                            || strcmp(argv[arg_processing], "--domain") == 0)) {
+                domain_id = atoi(argv[arg_processing + 1]);
+                arg_processing += 2;
+            } else if (
+                    (argc > arg_processing + 1)
+                    && (strcmp(argv[arg_processing], "-s") == 0
+                            || strcmp(argv[arg_processing], "--sample-count")
+                                    == 0)) {
+                sample_count = atoi(argv[arg_processing + 1]);
+                arg_processing += 2;
+            } else if (
+                    (argc > arg_processing + 1)
+                    && (strcmp(argv[arg_processing], "-v") == 0
+                            || strcmp(argv[arg_processing], "--verbosity")
+                                    == 0)) {
+                set_verbosity(verbosity, atoi(argv[arg_processing + 1]));
+                arg_processing += 2;
+                // parse file_name
+            } else if (
+                    (argc > arg_processing + 1)
+                    && (strcmp(argv[arg_processing], "--record") == 0)) {
+                file_name = argv[arg_processing + 1];
+                app_type = ApplicationType::record;
+                arg_processing += 2;
+            } else if (
+                    (argc > arg_processing + 1)
+                    && (strcmp(argv[arg_processing], "--replay") == 0)) {
+                file_name = argv[arg_processing + 1];
+                app_type = ApplicationType::replay;
+                arg_processing += 2;
+            } else if (strcmp(argv[arg_processing], "--publish") == 0) {
+                app_type = ApplicationType::publish;
+                arg_processing += 1;
+            } else if (
+                    strcmp(argv[arg_processing], "-h") == 0
+                    || strcmp(argv[arg_processing], "--help") == 0) {
+                std::cout << "Example application." << std::endl;
+                show_usage = true;
+                parse_result = ParseReturn::exit;
+                break;
+            } else {
+                std::cout << "Bad parameter." << std::endl;
+                show_usage = true;
+                parse_result = ParseReturn::failure;
+                break;
+            }
+        }
+
+        if (app_type == ApplicationType::unknown) {
+            std::cout << "Must specify --record, --replay, or --publish."
+                      << std::endl;
+            show_usage = true;
+            parse_result = ParseReturn::failure;
+        }
+
+        if (show_usage) {
+            std::cout
+                    << "Options:\n"
+                       "    --record <file name>       Record to a file.\n"
+                       "    --replay <file name>       Replay from a file.\n"
+                       "    --publish                  Publish example data.\n"
+                       "    -d, --domain <int>         Domain ID this "
+                       "application will\n"
+                       "                               publish or subscribe "
+                       "in.  \n"
+                       "                               Default: 0\n"
+                    << std::endl;
+        }
+
+        return ApplicationArguments(
+                parse_result,
+                domain_id,
+                sample_count,
+                app_type,
+                file_name,
+                verbosity);
+    }
+}

--- a/examples/connext_dds/dynamic_data_skip_serialization/c++11/util.cxx
+++ b/examples/connext_dds/dynamic_data_skip_serialization/c++11/util.cxx
@@ -57,120 +57,116 @@ void publish_example_data(
 }  // namespace util
 
 namespace application {
-    bool shutdown_requested = false;
+bool shutdown_requested = false;
 
-    void set_verbosity(
-            rti::config::Verbosity & verbosity,
-            int verbosity_value)
-    {
-        switch (verbosity_value) {
-        case 0:
-            verbosity = rti::config::Verbosity::SILENT;
-            break;
-        case 1:
-            verbosity = rti::config::Verbosity::EXCEPTION;
-            break;
-        case 2:
-            verbosity = rti::config::Verbosity::WARNING;
-            break;
-        case 3:
-            verbosity = rti::config::Verbosity::STATUS_ALL;
-            break;
-        default:
-            verbosity = rti::config::Verbosity::EXCEPTION;
-            break;
-        }
-    }
-
-    ApplicationArguments parse_arguments(int argc, char *argv[])
-    {
-        int arg_processing = 1;
-        bool show_usage = false;
-        ParseReturn parse_result = ParseReturn::ok;
-        unsigned int domain_id = 0;
-        unsigned int sample_count = (std::numeric_limits<unsigned int>::max)();
-        ApplicationType app_type = ApplicationType::unknown;
-        std::string file_name;
-        rti::config::Verbosity verbosity(rti::config::Verbosity::EXCEPTION);
-
-        while (arg_processing < argc) {
-            if ((argc > arg_processing + 1)
-                    && (strcmp(argv[arg_processing], "-d") == 0
-                            || strcmp(argv[arg_processing], "--domain") == 0)) {
-                domain_id = atoi(argv[arg_processing + 1]);
-                arg_processing += 2;
-            } else if (
-                    (argc > arg_processing + 1)
-                    && (strcmp(argv[arg_processing], "-s") == 0
-                            || strcmp(argv[arg_processing], "--sample-count")
-                                    == 0)) {
-                sample_count = atoi(argv[arg_processing + 1]);
-                arg_processing += 2;
-            } else if (
-                    (argc > arg_processing + 1)
-                    && (strcmp(argv[arg_processing], "-v") == 0
-                            || strcmp(argv[arg_processing], "--verbosity")
-                                    == 0)) {
-                set_verbosity(verbosity, atoi(argv[arg_processing + 1]));
-                arg_processing += 2;
-                // parse file_name
-            } else if (
-                    (argc > arg_processing + 1)
-                    && (strcmp(argv[arg_processing], "--record") == 0)) {
-                file_name = argv[arg_processing + 1];
-                app_type = ApplicationType::record;
-                arg_processing += 2;
-            } else if (
-                    (argc > arg_processing + 1)
-                    && (strcmp(argv[arg_processing], "--replay") == 0)) {
-                file_name = argv[arg_processing + 1];
-                app_type = ApplicationType::replay;
-                arg_processing += 2;
-            } else if (strcmp(argv[arg_processing], "--publish") == 0) {
-                app_type = ApplicationType::publish;
-                arg_processing += 1;
-            } else if (
-                    strcmp(argv[arg_processing], "-h") == 0
-                    || strcmp(argv[arg_processing], "--help") == 0) {
-                std::cout << "Example application." << std::endl;
-                show_usage = true;
-                parse_result = ParseReturn::exit;
-                break;
-            } else {
-                std::cout << "Bad parameter." << std::endl;
-                show_usage = true;
-                parse_result = ParseReturn::failure;
-                break;
-            }
-        }
-
-        if (app_type == ApplicationType::unknown) {
-            std::cout << "Must specify --record, --replay, or --publish."
-                      << std::endl;
-            show_usage = true;
-            parse_result = ParseReturn::failure;
-        }
-
-        if (show_usage) {
-            std::cout
-                    << "Options:\n"
-                       "    --record <file name>       Record to a file.\n"
-                       "    --replay <file name>       Replay from a file.\n"
-                       "    --publish                  Publish example data.\n"
-                       "    -d, --domain <int>         Domain ID this "
-                       "application will\n"
-                       "                               publish or subscribe "
-                       "in.  \n"
-                       "                               Default: 0\n"
-                    << std::endl;
-        }
-
-        return ApplicationArguments(
-                parse_result,
-                domain_id,
-                sample_count,
-                app_type,
-                file_name,
-                verbosity);
+void set_verbosity(rti::config::Verbosity &verbosity, int verbosity_value)
+{
+    switch (verbosity_value) {
+    case 0:
+        verbosity = rti::config::Verbosity::SILENT;
+        break;
+    case 1:
+        verbosity = rti::config::Verbosity::EXCEPTION;
+        break;
+    case 2:
+        verbosity = rti::config::Verbosity::WARNING;
+        break;
+    case 3:
+        verbosity = rti::config::Verbosity::STATUS_ALL;
+        break;
+    default:
+        verbosity = rti::config::Verbosity::EXCEPTION;
+        break;
     }
 }
+
+ApplicationArguments parse_arguments(int argc, char *argv[])
+{
+    int arg_processing = 1;
+    bool show_usage = false;
+    ParseReturn parse_result = ParseReturn::ok;
+    unsigned int domain_id = 0;
+    unsigned int sample_count = (std::numeric_limits<unsigned int>::max)();
+    ApplicationType app_type = ApplicationType::unknown;
+    std::string file_name;
+    rti::config::Verbosity verbosity(rti::config::Verbosity::EXCEPTION);
+
+    while (arg_processing < argc) {
+        if ((argc > arg_processing + 1)
+                && (strcmp(argv[arg_processing], "-d") == 0
+                        || strcmp(argv[arg_processing], "--domain") == 0)) {
+            domain_id = atoi(argv[arg_processing + 1]);
+            arg_processing += 2;
+        } else if (
+                (argc > arg_processing + 1)
+                && (strcmp(argv[arg_processing], "-s") == 0
+                        || strcmp(argv[arg_processing], "--sample-count")
+                                == 0)) {
+            sample_count = atoi(argv[arg_processing + 1]);
+            arg_processing += 2;
+        } else if (
+                (argc > arg_processing + 1)
+                && (strcmp(argv[arg_processing], "-v") == 0
+                        || strcmp(argv[arg_processing], "--verbosity") == 0)) {
+            set_verbosity(verbosity, atoi(argv[arg_processing + 1]));
+            arg_processing += 2;
+            // parse file_name
+        } else if (
+                (argc > arg_processing + 1)
+                && (strcmp(argv[arg_processing], "--record") == 0)) {
+            file_name = argv[arg_processing + 1];
+            app_type = ApplicationType::record;
+            arg_processing += 2;
+        } else if (
+                (argc > arg_processing + 1)
+                && (strcmp(argv[arg_processing], "--replay") == 0)) {
+            file_name = argv[arg_processing + 1];
+            app_type = ApplicationType::replay;
+            arg_processing += 2;
+        } else if (strcmp(argv[arg_processing], "--publish") == 0) {
+            app_type = ApplicationType::publish;
+            arg_processing += 1;
+        } else if (
+                strcmp(argv[arg_processing], "-h") == 0
+                || strcmp(argv[arg_processing], "--help") == 0) {
+            std::cout << "Example application." << std::endl;
+            show_usage = true;
+            parse_result = ParseReturn::exit;
+            break;
+        } else {
+            std::cout << "Bad parameter." << std::endl;
+            show_usage = true;
+            parse_result = ParseReturn::failure;
+            break;
+        }
+    }
+
+    if (app_type == ApplicationType::unknown) {
+        std::cout << "Must specify --record, --replay, or --publish."
+                  << std::endl;
+        show_usage = true;
+        parse_result = ParseReturn::failure;
+    }
+
+    if (show_usage) {
+        std::cout << "Options:\n"
+                     "    --record <file name>       Record to a file.\n"
+                     "    --replay <file name>       Replay from a file.\n"
+                     "    --publish                  Publish example data.\n"
+                     "    -d, --domain <int>         Domain ID this "
+                     "application will\n"
+                     "                               publish or subscribe "
+                     "in.  \n"
+                     "                               Default: 0\n"
+                  << std::endl;
+    }
+
+    return ApplicationArguments(
+            parse_result,
+            domain_id,
+            sample_count,
+            app_type,
+            file_name,
+            verbosity);
+}
+}  // namespace application

--- a/examples/connext_dds/dynamic_data_skip_serialization/c++11/util.hpp
+++ b/examples/connext_dds/dynamic_data_skip_serialization/c++11/util.hpp
@@ -1,0 +1,123 @@
+/*
+ * (c) Copyright, Real-Time Innovations, 2020.  All rights reserved.
+ * RTI grants Licensee a license to use, modify, compile, and create derivative
+ * works of the software solely for use with RTI Connext DDS. Licensee may
+ * redistribute copies of the software provided that all such copies are subject
+ * to this license. The software is provided "as is", with no warranty of any
+ * type, including any warranty for fitness for any purpose. RTI is under no
+ * obligation to maintain or support the software. RTI shall not be liable for
+ * any incidental or consequential damages arising out of the use or inability
+ * to use the software.
+ */
+
+#ifndef APPLICATION_HPP
+#define APPLICATION_HPP
+
+
+#include <iostream>
+#include <string>
+#include <csignal>
+#include <dds/core/ddscore.hpp>
+#include <dds/pub/ddspub.hpp>
+#include <dds/sub/ddssub.hpp>
+#include <rti/util/util.hpp>  // for sleep()
+
+
+namespace application
+{
+    // Catch control-C and tell application to shut down
+    extern bool shutdown_requested;
+
+    inline void stop_handler(int)
+    {
+        shutdown_requested = true;
+        std::cout << "preparing to shut down..." << std::endl;
+    }
+
+    inline void setup_signal_handlers()
+    {
+        signal(SIGINT, stop_handler);
+        signal(SIGTERM, stop_handler);
+    }
+
+    enum class ParseReturn { ok, failure, exit };
+
+    enum class ApplicationType { unknown, record, replay, publish };
+
+    struct ApplicationArguments {
+        ParseReturn parse_result;
+        unsigned int domain_id;
+        unsigned int sample_count;
+        ApplicationType application_type = ApplicationType::unknown;
+        std::string file_name;
+        rti::config::Verbosity verbosity;
+
+        ApplicationArguments(
+                ParseReturn parse_result_param,
+                unsigned int domain_id_param,
+                unsigned int sample_count_param,
+                ApplicationType application_type_param,
+                const std::string &file_name_param,
+                rti::config::Verbosity verbosity_param)
+                : parse_result(parse_result_param),
+                  domain_id(domain_id_param),
+                  sample_count(sample_count_param),
+                  application_type(application_type_param),
+                  file_name(file_name_param),
+                  verbosity(verbosity_param)
+        {
+        }
+    };
+
+    inline void set_verbosity(
+            rti::config::Verbosity & verbosity,
+            int verbosity_value);
+
+    // Parses application arguments for example.
+    ApplicationArguments parse_arguments(int argc, char *argv[]);
+
+}  // namespace application
+
+namespace util {
+
+template<typename T>
+bool wait_for_writer(const dds::sub::DataReader<T> &reader)
+{
+    std::cout << "Waiting for a matching DataWriter..." << std::endl;
+    while (!application::shutdown_requested
+            && dds::sub::matched_publications(reader).empty()) {
+        rti::util::sleep(dds::core::Duration::from_millisecs(100));
+    }
+
+    if (application::shutdown_requested) {
+        return false;
+    }
+
+    std::cout << "DataWriter found" << std::endl;
+    return true;
+}
+
+template<typename T>
+bool wait_for_reader(const dds::pub::DataWriter<T> &writer)
+{
+    std::cout << "Waiting for a matching DataReader..." << std::endl;
+    while (!application::shutdown_requested
+            && dds::pub::matched_subscriptions(writer).empty()) {
+        rti::util::sleep(dds::core::Duration::from_millisecs(100));
+    }
+
+    if (application::shutdown_requested) {
+        return false;
+    }
+
+    std::cout << "DataReader found" << std::endl;
+    return true;
+}
+
+void publish_example_data(
+        unsigned int domain_id,
+        const dds::core::xtypes::DynamicType &type);
+
+}  // namespace util
+
+#endif  // APPLICATION_HPP

--- a/examples/connext_dds/dynamic_data_skip_serialization/c++11/util.hpp
+++ b/examples/connext_dds/dynamic_data_skip_serialization/c++11/util.hpp
@@ -23,58 +23,57 @@
 #include <rti/util/util.hpp>  // for sleep()
 
 
-namespace application
+namespace application {
+// Catch control-C and tell application to shut down
+extern bool shutdown_requested;
+
+inline void stop_handler(int)
 {
-    // Catch control-C and tell application to shut down
-    extern bool shutdown_requested;
+    shutdown_requested = true;
+    std::cout << "preparing to shut down..." << std::endl;
+}
 
-    inline void stop_handler(int)
+inline void setup_signal_handlers()
+{
+    signal(SIGINT, stop_handler);
+    signal(SIGTERM, stop_handler);
+}
+
+enum class ParseReturn { ok, failure, exit };
+
+enum class ApplicationType { unknown, record, replay, publish };
+
+struct ApplicationArguments {
+    ParseReturn parse_result;
+    unsigned int domain_id;
+    unsigned int sample_count;
+    ApplicationType application_type = ApplicationType::unknown;
+    std::string file_name;
+    rti::config::Verbosity verbosity;
+
+    ApplicationArguments(
+            ParseReturn parse_result_param,
+            unsigned int domain_id_param,
+            unsigned int sample_count_param,
+            ApplicationType application_type_param,
+            const std::string &file_name_param,
+            rti::config::Verbosity verbosity_param)
+            : parse_result(parse_result_param),
+              domain_id(domain_id_param),
+              sample_count(sample_count_param),
+              application_type(application_type_param),
+              file_name(file_name_param),
+              verbosity(verbosity_param)
     {
-        shutdown_requested = true;
-        std::cout << "preparing to shut down..." << std::endl;
     }
+};
 
-    inline void setup_signal_handlers()
-    {
-        signal(SIGINT, stop_handler);
-        signal(SIGTERM, stop_handler);
-    }
+inline void set_verbosity(
+        rti::config::Verbosity &verbosity,
+        int verbosity_value);
 
-    enum class ParseReturn { ok, failure, exit };
-
-    enum class ApplicationType { unknown, record, replay, publish };
-
-    struct ApplicationArguments {
-        ParseReturn parse_result;
-        unsigned int domain_id;
-        unsigned int sample_count;
-        ApplicationType application_type = ApplicationType::unknown;
-        std::string file_name;
-        rti::config::Verbosity verbosity;
-
-        ApplicationArguments(
-                ParseReturn parse_result_param,
-                unsigned int domain_id_param,
-                unsigned int sample_count_param,
-                ApplicationType application_type_param,
-                const std::string &file_name_param,
-                rti::config::Verbosity verbosity_param)
-                : parse_result(parse_result_param),
-                  domain_id(domain_id_param),
-                  sample_count(sample_count_param),
-                  application_type(application_type_param),
-                  file_name(file_name_param),
-                  verbosity(verbosity_param)
-        {
-        }
-    };
-
-    inline void set_verbosity(
-            rti::config::Verbosity & verbosity,
-            int verbosity_value);
-
-    // Parses application arguments for example.
-    ApplicationArguments parse_arguments(int argc, char *argv[]);
+// Parses application arguments for example.
+ApplicationArguments parse_arguments(int argc, char *argv[]);
 
 }  // namespace application
 

--- a/examples/connext_dds/dynamic_data_skip_serialization/c++11/util.hpp
+++ b/examples/connext_dds/dynamic_data_skip_serialization/c++11/util.hpp
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright, Real-Time Innovations, 2020.  All rights reserved.
+ * (c) Copyright, Real-Time Innovations, 2023.  All rights reserved.
  * RTI grants Licensee a license to use, modify, compile, and create derivative
  * works of the software solely for use with RTI Connext DDS. Licensee may
  * redistribute copies of the software provided that all such copies are subject

--- a/examples/connext_dds/dynamic_data_skip_serialization/py/README.md
+++ b/examples/connext_dds/dynamic_data_skip_serialization/py/README.md
@@ -1,0 +1,36 @@
+# Example Code: Skip Data Serialization for Data Recording
+
+## Running the Example
+
+In one command prompt run the recorder:
+
+```sh
+python record.py --record data.bin
+```
+
+In a second command prompt run the publisher:
+
+```sh
+python record.py --publish
+```
+
+The recorder application will print a message each time a sample is recorded.
+
+Now kill the recorder and run the replay application. A file called `data.bin`
+will have been created in the current directory.
+
+Now we will run a subscriber and a reply application.
+
+To subscribe to the data we will simply use **rtiddsspy**:
+
+```sh
+<Connext installation>/bin/rtiddsspy -printSample
+```
+
+Now run the application that replays the data recorded in  `data.bin`:
+
+```sh
+python record.py --replay data.bin
+```
+
+The subscriber will print the data that is being replayed.

--- a/examples/connext_dds/dynamic_data_skip_serialization/py/recorder.py
+++ b/examples/connext_dds/dynamic_data_skip_serialization/py/recorder.py
@@ -1,0 +1,141 @@
+# (c) 2023 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+#
+# RTI grants Licensee a license to use, modify, compile, and create derivative
+# works of the Software solely for use with RTI products.  The Software is
+# provided "as is", with no warranty of any type, including any warranty for
+# fitness for any purpose. RTI is under no obligation to maintain or support
+# the Software.  RTI shall not be liable for any incidental or consequential
+# damages arising out of the use or inability to use the software.
+#
+
+import rti.connextdds as dds
+from util import wait_for_reader, wait_for_writer, publish_example_data
+
+EXAMPLE_TYPE = dds.StructType(
+    "RecordExample",
+    dds.MemberSeq(
+        [
+            dds.Member("id", dds.StringType(128)),
+            dds.Member("payload", dds.SequenceType(dds.Int32Type(), 1024)),
+        ]
+    ),
+)
+
+def record(file_name: str, domain_id: int):
+    participant = dds.DomainParticipant(domain_id)
+
+    # To disable the deserialization on the DataReader and get direct access
+    # to the serialized CDR buffer, we need to register the DataReader type
+    # with the DynamicDataTypeSerializationProperty.skip_deserialization set 
+    # to True, and then create the DataReader with the name used to register
+    # the type.
+    dd_property = dds.DynamicDataTypeSerializationProperty()
+    dd_property.skip_deserialization = True
+    type_name = "RecordExample"
+    participant.register_type(type_name, EXAMPLE_TYPE, dd_property)
+
+    topic = dds.DynamicData.Topic(
+        participant,
+        topic_name="Example Record",
+        type_name=type_name, # Specify the registered type name
+        qos=participant.default_topic_qos,
+    )
+
+    qos = dds.QosProvider.default.datareader_qos_from_profile(
+        dds.BuiltinProfiles.generic_strict_reliable)
+    reader = dds.DynamicData.DataReader(topic, qos)
+    wait_for_writer(reader)
+
+    # open a file for binary writing:
+    out_file = open(file_name, "wb")
+
+    # Define the function that will take the data and record it
+    def record_data(_) -> None:
+        # When the skip_deserialization property is set to True the data must
+        # be taken as a loaned collection, since copying the data is not allowed.
+        with reader.take_loaned() as samples:
+            for data, info in samples:
+                if not info.valid:
+                    continue
+
+                # Now the only way to access the data is to call get_cdr_buffer,
+                # any other field accessor will fail.
+                buffer = data.get_cdr_buffer()
+                print(f"Recording data sample ({len(buffer)} bytes)")
+
+                # Write the length and the data
+                out_file.write(len(buffer).to_bytes(4, byteorder="little"))
+                out_file.write(buffer)
+
+    # Set up a ReadCondition to trigger the record_data function when
+    # data is available
+    read_condition = dds.ReadCondition(reader, dds.DataState.any, record_data)
+    waitset = dds.WaitSet()
+    waitset += read_condition
+
+    while True:
+        try:
+            waitset.dispatch(dds.Duration(1))
+        except KeyboardInterrupt:
+            break
+
+    print("preparing to shut down...")
+
+
+def replay(file_name: str, domain_id: int):
+    participant = dds.DomainParticipant(domain_id)
+
+    # For the replay application we don't need to register the type with any
+    # particular property
+    topic = dds.DynamicData.Topic(participant, "Example Record", EXAMPLE_TYPE)
+
+    qos = dds.QosProvider.default.datawriter_qos_from_profile(
+        dds.BuiltinProfiles.generic_strict_reliable)
+    writer = dds.DynamicData.DataWriter(topic, qos)
+    wait_for_reader(writer)
+
+    data = writer.create_data()
+
+    with open(file_name, "rb") as in_file:
+        # read the binary file and write the data to the DataWriter:
+        while True:
+            length_bytes = in_file.read(4)
+            if length_bytes == b"":
+                break
+
+            length = int.from_bytes(length_bytes, byteorder="little")
+            print(f"Replaying data sample ({length} bytes)")
+            buffer = in_file.read(length)
+
+            # By calling the set_cdr_buffer method we override the contents
+            # of the DynamicData object with the new serialized data. After
+            # setting a cdr buffer we can't use any field getters or setters.
+            data.set_cdr_buffer(buffer)
+            writer.write(data)
+
+    writer.wait_for_acknowledgments(dds.Duration(10))
+
+
+def main():
+    # Parse command line for --record [output file], --replay [input file], --publish, and --domain_id options
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--record", nargs="?", const="recorded_data.bin")
+    parser.add_argument("--replay", nargs="?", const="recorded_data.bin")
+    parser.add_argument("--publish", action="store_true")
+    parser.add_argument("--domain_id", type=int, default=0)
+
+    args = parser.parse_args()
+    if args.record:
+        record(args.record, args.domain_id)
+    elif args.replay:
+        replay(args.replay, args.domain_id)
+    elif args.publish:
+        publish_example_data(args.domain_id, EXAMPLE_TYPE)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/connext_dds/dynamic_data_skip_serialization/py/recorder.py
+++ b/examples/connext_dds/dynamic_data_skip_serialization/py/recorder.py
@@ -88,7 +88,8 @@ def replay(file_name: str, domain_id: int):
     participant = dds.DomainParticipant(domain_id)
 
     # For the replay application we don't need to register the type with any
-    # particular property
+    # particular property because DynamicData DataWriters are always prepared
+    # to write serialized buffers directly
     topic = dds.DynamicData.Topic(participant, "Example Record", EXAMPLE_TYPE)
 
     qos = dds.QosProvider.default.datawriter_qos_from_profile(

--- a/examples/connext_dds/dynamic_data_skip_serialization/py/recorder.py
+++ b/examples/connext_dds/dynamic_data_skip_serialization/py/recorder.py
@@ -21,12 +21,13 @@ EXAMPLE_TYPE = dds.StructType(
     ),
 )
 
+
 def record(file_name: str, domain_id: int):
     participant = dds.DomainParticipant(domain_id)
 
     # To disable the deserialization on the DataReader and get direct access
     # to the serialized CDR buffer, we need to register the DataReader type
-    # with the DynamicDataTypeSerializationProperty.skip_deserialization set 
+    # with the DynamicDataTypeSerializationProperty.skip_deserialization set
     # to True, and then create the DataReader with the name used to register
     # the type.
     dd_property = dds.DynamicDataTypeSerializationProperty()
@@ -37,12 +38,13 @@ def record(file_name: str, domain_id: int):
     topic = dds.DynamicData.Topic(
         participant,
         topic_name="Example Record",
-        type_name=type_name, # Specify the registered type name
+        type_name=type_name,  # Specify the registered type name
         qos=participant.default_topic_qos,
     )
 
     qos = dds.QosProvider.default.datareader_qos_from_profile(
-        dds.BuiltinProfiles.generic_strict_reliable)
+        dds.BuiltinProfiles.generic_strict_reliable
+    )
     reader = dds.DynamicData.DataReader(topic, qos)
     wait_for_writer(reader)
 
@@ -90,7 +92,8 @@ def replay(file_name: str, domain_id: int):
     topic = dds.DynamicData.Topic(participant, "Example Record", EXAMPLE_TYPE)
 
     qos = dds.QosProvider.default.datawriter_qos_from_profile(
-        dds.BuiltinProfiles.generic_strict_reliable)
+        dds.BuiltinProfiles.generic_strict_reliable
+    )
     writer = dds.DynamicData.DataWriter(topic, qos)
     wait_for_reader(writer)
 

--- a/examples/connext_dds/dynamic_data_skip_serialization/py/util.py
+++ b/examples/connext_dds/dynamic_data_skip_serialization/py/util.py
@@ -1,0 +1,66 @@
+# (c) 2023 Copyright, Real-Time Innovations, Inc.  All rights reserved.
+#
+# RTI grants Licensee a license to use, modify, compile, and create derivative
+# works of the Software solely for use with RTI products.  The Software is
+# provided "as is", with no warranty of any type, including any warranty for
+# fitness for any purpose. RTI is under no obligation to maintain or support
+# the Software.  RTI shall not be liable for any incidental or consequential
+# damages arising out of the use or inability to use the software.
+#
+
+from time import sleep
+import rti.connextdds as dds
+
+
+def wait_for_writer(reader: dds.DynamicData.DataReader) -> None:
+    """Wait for a DataWriter to be matched with the input DataReader"""
+
+    print("Waiting for a matching DataWriter...")
+    while len(reader.matched_publications) == 0:
+        sleep(0.1)
+
+    print("DataWriter found")
+
+
+def wait_for_reader(writer: dds.DynamicData.DataWriter) -> None:
+    """Wait for a DataReader to be matched with the input DataWriter"""
+
+    print("Waiting for a matching DataReader...")
+    while len(writer.matched_subscriptions) == 0:
+        sleep(0.1)
+
+    print("DataReader found")
+
+
+def publish_example_data(domain_id: int, type: dds.DynamicType):
+    """Publishes a few data samples as an example"""
+
+    participant = dds.DomainParticipant(domain_id)
+    topic = dds.DynamicData.Topic(participant, "Example Record", type)
+
+    qos = dds.QosProvider.default.datawriter_qos_from_profile(
+        dds.BuiltinProfiles.generic_strict_reliable)
+    writer = dds.DynamicData.DataWriter(topic, qos)
+    wait_for_reader(writer)
+
+    sleep(1)
+
+    # Write a few data samples
+    data = writer.create_data()
+    data["id"] = "Example"
+    data["payload"] = dds.Int32Seq(range(10))
+    writer.write(data)
+
+    sleep(1)
+
+    data["id"] = "Example2"
+    data["payload"] = dds.Int32Seq([7, 11, 13, 17, 19])
+    writer.write(data)
+
+    sleep(1)
+
+    data["id"] = "Example3"
+    data["payload"] = dds.Int32Seq(range(100, 150, 5))
+    writer.write(data)
+
+    sleep(1)

--- a/examples/connext_dds/dynamic_data_skip_serialization/py/util.py
+++ b/examples/connext_dds/dynamic_data_skip_serialization/py/util.py
@@ -39,7 +39,8 @@ def publish_example_data(domain_id: int, type: dds.DynamicType):
     topic = dds.DynamicData.Topic(participant, "Example Record", type)
 
     qos = dds.QosProvider.default.datawriter_qos_from_profile(
-        dds.BuiltinProfiles.generic_strict_reliable)
+        dds.BuiltinProfiles.generic_strict_reliable
+    )
     writer = dds.DynamicData.DataWriter(topic, qos)
     wait_for_reader(writer)
 


### PR DESCRIPTION

### Summary

An example for the upcoming DynamicData feature that allows skipping the serialization/deserialization of data.

### Details and comments

* Added README with example description
* Added C++11 example
* Added Python example

### Checks

* Tested all modes in both languages
* Tested interoperability between the examples in both languages
