### PR TITLE
Fix Web Integration Service library api example.

### DIFF
--- a/examples/web_integration_service/library_api/c++11/web_integration_service_library_api.cxx
+++ b/examples/web_integration_service/library_api/c++11/web_integration_service_library_api.cxx
@@ -36,8 +36,10 @@ void service_main(
 {
     rti::webdds::ServiceProperty service_property;
 
-    service_property.cfgfile(cfg_file).cfgname(cfg_name).document_root(
-            document_root);
+    service_property
+            .cfgfile(cfg_file)
+            .cfgname(cfg_name)
+            .webserver_option("document_root", document_root);
 
     rti::webdds::Service service(std::move(service_property));
 

--- a/examples/web_integration_service/library_api/c++11/web_integration_service_library_api.cxx
+++ b/examples/web_integration_service/library_api/c++11/web_integration_service_library_api.cxx
@@ -36,10 +36,9 @@ void service_main(
 {
     rti::webdds::ServiceProperty service_property;
 
-    service_property
-            .cfgfile(cfg_file)
-            .cfgname(cfg_name)
-            .webserver_option("document_root", document_root);
+    service_property.cfgfile(cfg_file).cfgname(cfg_name).webserver_option(
+            "document_root",
+            document_root);
 
     rti::webdds::Service service(std::move(service_property));
 


### PR DESCRIPTION
### Summary
Web Integration Service library API changed a couple of methods of the Service Property, so we are just adjusting those to 7.3.0.

### Checks

-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.

<!-- Uncomment bellow if you added a C/C++ example and updated examples/connext_dds/CMakeList.txt -->
<!--
-   [ ] I have added a new C/C++ example and updated `examples/connext_dds/CMakeList.txt` accordingly.
-->
<!-- Uncomment bellow if you added a Java example and updated examples/connext_dds/settings.gradle -->
<!--
-   [ ] I have added a new Java example and updated `examples/connext_dds/settings.gradle` accordingly.
-->
