### PR TITLE
#651: Fix overflow on timestamp limit

### DIFF
--- a/examples/recording_service/pluggable_storage/c/FileStorageReader.c
+++ b/examples/recording_service/pluggable_storage/c/FileStorageReader.c
@@ -442,9 +442,14 @@ void FileStorageStreamReader_read(
     struct FileStorageStreamReader *stream_reader =
             (struct FileStorageStreamReader *) stream_reader_data;
     int i = 0;
-    long long timestamp_limit =
-            (long long) selector->time_range_end.sec * NANOSECS_PER_SEC
-            + selector->time_range_end.nanosec;
+    DDS_LongLong timestamp_limit;
+    if (selector->time_range_end.sec == DDS_TIME_MAX.sec
+            && selector->time_range_end.nanosec == DDS_TIME_MAX.nanosec) {
+        timestamp_limit = selector->time_range_end.sec;
+    } else {
+        timestamp_limit = selector->time_range_end.sec * NANOSECS_PER_SEC;
+        timestamp_limit += selector->time_range_end.nanosec;
+    }
     int read_samples = 0;
     /*
      * The value of the sample selector's max samples could be


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->
### Details and comments
Fix overflow provoked by the update of type DDS_Time_t.

### Checks

<!-- Change te space between the square brackets to an `x` -->
-   [x] I have updated the documentation accordingly. - It was not required.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.

<!-- Uncomment bellow if you added a C/C++ example and updated examples/connext_dds/CMakeList.txt -->
<!--
-   [ ] I have added a new C/C++ example and updated `examples/connext_dds/CMakeList.txt` accordingly.
-->
<!-- Uncomment bellow if you added a Java example and updated examples/connext_dds/settings.gradle -->
<!--
-   [ ] I have added a new Java example and updated `examples/connext_dds/settings.gradle` accordingly.
-->
