### PR TITLE
#651 #655: Fix overflow and eof issue

### DIFF
--- a/examples/recording_service/pluggable_storage/c/FileStorageReader.c
+++ b/examples/recording_service/pluggable_storage/c/FileStorageReader.c
@@ -442,9 +442,23 @@ void FileStorageStreamReader_read(
     struct FileStorageStreamReader *stream_reader =
             (struct FileStorageStreamReader *) stream_reader_data;
     int i = 0;
-    long long timestamp_limit =
-            (long long) selector->time_range_end.sec * NANOSECS_PER_SEC
-            + selector->time_range_end.nanosec;
+    /*
+     * If the last sample was already provided and we are at the end of the file
+     * we will skip the read operation in order to finalize the execution.
+     */
+    if (stream_reader->current_timestamp == INT64_MAX
+        && feof(stream_reader->file_record.file)) {
+        *count = 0;
+        return;
+    }
+    DDS_LongLong timestamp_limit;
+    if (selector->time_range_end.sec == DDS_TIME_MAX.sec
+        && selector->time_range_end.nanosec == DDS_TIME_MAX.nanosec) {
+        timestamp_limit = selector->time_range_end.sec;
+    } else {
+        timestamp_limit = selector->time_range_end.sec * NANOSECS_PER_SEC;
+        timestamp_limit += selector->time_range_end.nanosec;
+    }
     int read_samples = 0;
     /*
      * The value of the sample selector's max samples could be
@@ -461,12 +475,21 @@ void FileStorageStreamReader_read(
         *count = 0;
         return;
     }
-    /* Add the currently read sample and sample info values to the taken data
-     * and info collections (sequences) */
+    /*
+     * Add the currently read sample and sample info values to the taken data
+     * and info collections (sequences)
+     */
     do {
         FileStorageStreamReader_addSampleToData(stream_reader);
-        FileStorageStreamReader_readSample(stream_reader);
         read_samples++;
+        /*
+         * if we reach the end of the file or we cant read a proper sample,
+         * we dont add that sample on this iteration but we should send the
+         * previous samples
+         */
+        if (FileStorageStreamReader_readSample(stream_reader) == FALSE) {
+            break;
+        }
     } while (stream_reader->current_timestamp <= timestamp_limit
              && read_samples < max_samples);
     /* The number of taken samples is the current length of the data sequence */
@@ -583,6 +606,7 @@ int FileStorageStreamReader_initialize(
     /* Bootstrap the take loop: read the first sample */
     if (!FileStorageStreamReader_readSample(stream_reader)) {
         printf("Failed to get first sample from file, maybe EOF was reached\n");
+        return FALSE;
     }
 
     RTI_RecordingServiceStorageStreamReader_initialize(


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->
### Details and comments
Fix overflow provoked by the update of type DDS_Time_t.
Fix end of file mechanism.

### Checks

<!-- Change te space between the square brackets to an `x` -->
-   [x] I have updated the documentation accordingly. - It was not required.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.

<!-- Uncomment bellow if you added a C/C++ example and updated examples/connext_dds/CMakeList.txt -->
<!--
-   [ ] I have added a new C/C++ example and updated `examples/connext_dds/CMakeList.txt` accordingly.
-->
<!-- Uncomment bellow if you added a Java example and updated examples/connext_dds/settings.gradle -->
<!--
-   [ ] I have added a new Java example and updated `examples/connext_dds/settings.gradle` accordingly.
-->
