### PR TITLE
Improve documentation in Recording examples so the CMake command always works

### DIFF
--- a/examples/recording_service/pluggable_storage/c++11/README.md
+++ b/examples/recording_service/pluggable_storage/c++11/README.md
@@ -58,12 +58,20 @@ In order to build this example, you need to provide the following variables to
 -   `BUILD_SHARED_LIBS`: specifies the link mode. Valid values are ON for
     dynamic linking and OFF for static linking.
 
+-   `CONNEXTDDS_DIR`: specifies the path to your RTI Connext installation
+    folder.
+
+-   `CONNEXTDDS_ARCH`: specifies the architecture of the specific libraries
+    you want to link against.
+
 Build the example code by running the following command:
 
 ```bash
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON ..
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON \
+        -DCONNEXTDDS_DIR=<connext dir> \
+        -DCONNEXTDDS_ARCH=<connext architecture> ..
 cmake --build .
 ```
 
@@ -77,7 +85,9 @@ In case you are using Windows x64, you have to add the option -A in the cmake
 command as follow:
 
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON .. -A x64
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON \
+        -DCONNEXTDDS_DIR=<connext dir> \
+        -DCONNEXTDDS_ARCH=<connext architecture> .. -A x64 
 ```
 
 **Cross-compilation**.

--- a/examples/recording_service/pluggable_storage/c++11/README.md
+++ b/examples/recording_service/pluggable_storage/c++11/README.md
@@ -87,7 +87,7 @@ command as follow:
 ```bash
 cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON \
         -DCONNEXTDDS_DIR=<connext dir> \
-        -DCONNEXTDDS_ARCH=<connext architecture> .. -A x64 
+        -DCONNEXTDDS_ARCH=<connext architecture> .. -A x64
 ```
 
 **Cross-compilation**.

--- a/examples/recording_service/pluggable_storage/c/README.md
+++ b/examples/recording_service/pluggable_storage/c/README.md
@@ -58,12 +58,20 @@ In order to build this example, you need to provide the following variables to
 -   `BUILD_SHARED_LIBS`: specifies the link mode. Valid values are ON for
     dynamic linking and OFF for static linking.
 
+-   `CONNEXTDDS_DIR`: specifies the path to your RTI Connext installation
+    folder.
+
+-   `CONNEXTDDS_ARCH`: specifies the architecture of the specific libraries
+    you want to link against.
+
 Build the example code by running the following command:
 
 ```bash
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON ..
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON \
+        -DCONNEXTDDS_DIR=<connext dir> \
+        -DCONNEXTDDS_ARCH=<connext architecture> ..
 cmake --build .
 ```
 
@@ -77,7 +85,9 @@ In case you are using Windows x64, you have to add the option -A in the cmake
 command as follow:
 
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON .. -A x64
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON \
+        -DCONNEXTDDS_DIR=<connext dir> \
+        -DCONNEXTDDS_ARCH=<connext architecture> .. -A x64 
 ```
 
 **Cross-compilation**.

--- a/examples/recording_service/pluggable_storage/c/README.md
+++ b/examples/recording_service/pluggable_storage/c/README.md
@@ -87,7 +87,7 @@ command as follow:
 ```bash
 cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON \
         -DCONNEXTDDS_DIR=<connext dir> \
-        -DCONNEXTDDS_ARCH=<connext architecture> .. -A x64 
+        -DCONNEXTDDS_ARCH=<connext architecture> .. -A x64
 ```
 
 **Cross-compilation**.

--- a/examples/recording_service/service_admin/c++11/README.md
+++ b/examples/recording_service/service_admin/c++11/README.md
@@ -47,7 +47,7 @@ Build the example code by running the following command:
 ```sh
 mkdir build
 cd build
-cmake ..
+cmake -DCONNEXTDDS_DIR=<connext dir> -DCONNEXTDDS_ARCH=<connext architecture> ..
 cmake --build .
 ```
 

--- a/examples/recording_service/service_as_lib/c++11/README.md
+++ b/examples/recording_service/service_as_lib/c++11/README.md
@@ -48,12 +48,20 @@ In order to build this example, you need to provide the following variables to
 -   `BUILD_SHARED_LIBS`: specifies the link mode. Valid values are ON for
     dynamic linking and OFF for static linking.
 
+-   `CONNEXTDDS_DIR`: specifies the path to your RTI Connext installation
+    folder.
+
+-   `CONNEXTDDS_ARCH`: specifies the architecture of the specific libraries
+    you want to link against.
+
 Build the example code by running the following command:
 
-```sh
+```bash
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON ..
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON \
+        -DCONNEXTDDS_DIR=<connext dir> \
+        -DCONNEXTDDS_ARCH=<connext architecture> ..
 cmake --build .
 ```
 
@@ -66,8 +74,10 @@ cmake --build .
 In case you are using Windows x64, you have to add the option -A in the cmake
 command as follow:
 
-```sh
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON .. -A x64
+```bash
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON \
+        -DCONNEXTDDS_DIR=<connext dir> \
+        -DCONNEXTDDS_ARCH=<connext architecture> .. -A x64 
 ```
 
 This will produce a binary directory (*build*) where the `ServiceAsLibExample`

--- a/examples/recording_service/service_as_lib/c++11/README.md
+++ b/examples/recording_service/service_as_lib/c++11/README.md
@@ -77,7 +77,7 @@ command as follow:
 ```bash
 cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON \
         -DCONNEXTDDS_DIR=<connext dir> \
-        -DCONNEXTDDS_ARCH=<connext architecture> .. -A x64 
+        -DCONNEXTDDS_ARCH=<connext architecture> .. -A x64
 ```
 
 This will produce a binary directory (*build*) where the `ServiceAsLibExample`


### PR DESCRIPTION
### Summary
Improve the documentation in the recording examples so that the CMake command to build them always works.

### Details and comments
Added the variables `CONNEXTDDS_DIR` and `CONNEXTDDS_ARCH` to the CMake build command.

### Checks

-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.

<!-- Uncomment bellow if you added a C/C++ example and updated examples/connext_dds/CMakeList.txt -->
<!--
-   [ ] I have added a new C/C++ example and updated `examples/connext_dds/CMakeList.txt` accordingly.
-->
<!-- Uncomment bellow if you added a Java example and updated examples/connext_dds/settings.gradle -->
<!--
-   [ ] I have added a new Java example and updated `examples/connext_dds/settings.gradle` accordingly.
-->
