### PR TITLE
 CORE-13335: Fix examples that assume invalid data cannot be ALIVE

### DIFF
--- a/examples/connext_dds/keyed_data/c++11/keys_subscriber.cxx
+++ b/examples/connext_dds/keyed_data/c++11/keys_subscriber.cxx
@@ -42,9 +42,10 @@ int process_data(dds::sub::DataReader<keys> reader)
             if (state
                 == dds::sub::status::InstanceState::not_alive_no_writers()) {
                 std::cout << "Instance " << sample.code() << " has no writers"
-                        << std::endl;
-            } else if (state
-                == dds::sub::status::InstanceState::not_alive_disposed()) {
+                          << std::endl;
+            } else if (
+                    state
+                    == dds::sub::status::InstanceState::not_alive_disposed()) {
                 std::cout << "Instance " << sample.code() << " is disposed"
                           << std::endl;
             } else {

--- a/examples/connext_dds/keyed_data/c++11/keys_subscriber.cxx
+++ b/examples/connext_dds/keyed_data/c++11/keys_subscriber.cxx
@@ -35,24 +35,20 @@ int process_data(dds::sub::DataReader<keys> reader)
                       << ", x: " << sample.data().x()
                       << ", y: " << sample.data().y() << std::endl;
         } else {
-            // A sample without valid data can be in any instance state, but the
-            // key value is only available if it is ALIVE or NOT_ALIVE_DISPOSED
+            keys sample;
+            reader.key_value(sample, info.instance_handle());
             const dds::sub::status::InstanceState &state =
                     info.state().instance_state();
             if (state
                 == dds::sub::status::InstanceState::not_alive_no_writers()) {
-                std::cout
-                        << "Instance is in NOT_ALIVE_NO_WRITERS instance state"
+                std::cout << "Instance " << sample.code() << " has no writers"
                         << std::endl;
+            } else if (state
+                == dds::sub::status::InstanceState::not_alive_disposed()) {
+                std::cout << "Instance " << sample.code() << " is disposed"
+                          << std::endl;
             } else {
-                // Since there is not valid data, it may include metadata.
-                keys sample;
-                reader.key_value(sample, info.instance_handle());
-                std::cout << "Instance " << sample.code() << " is "
-                          << ((state
-                               == dds::sub::status::InstanceState::alive())
-                                      ? "alive"
-                                      : "disposed")
+                std::cout << "Instance " << sample.code() << " is alive"
                           << std::endl;
             }
         }

--- a/examples/connext_dds/keyed_data/c++11/keys_subscriber.cxx
+++ b/examples/connext_dds/keyed_data/c++11/keys_subscriber.cxx
@@ -34,23 +34,26 @@ int process_data(dds::sub::DataReader<keys> reader)
             std::cout << "Instance " << sample.data().code()
                       << ", x: " << sample.data().x()
                       << ", y: " << sample.data().y() << std::endl;
-        } else {        
+        } else {
             // A sample without valid data can be in any instance state, but the
             // key value is only available if it is ALIVE or NOT_ALIVE_DISPOSED
             const dds::sub::status::InstanceState &state =
                     info.state().instance_state();
-            if (state == dds::sub::status::InstanceState::not_alive_no_writers()) {
-                std::cout << "Instance is in NOT_ALIVE_NO_WRITERS instance state"
-                          << std::endl;
+            if (state
+                    == dds::sub::status::InstanceState::not_alive_no_writers()) {
+                std::cout
+                        << "Instance is in NOT_ALIVE_NO_WRITERS instance state"
+                        << std::endl;
             } else {
                 // Since there is not valid data, it may include metadata.
                 keys sample;
                 reader.key_value(sample, info.instance_handle());
-                std::cout << "Instance " << sample.code() << " is " <<
-                        ((state == dds::sub::status::InstanceState::not_alive_disposed())
-                                ? "disposed "
-                                : "alive ")
-                                        << std::endl;
+                std::cout << "Instance " << sample.code() << " is "
+                        << ((state
+                            == dds::sub::status::InstanceState::alive())
+                                ? "alive"
+                                : "disposed")
+                        << std::endl;
             }
         }
 

--- a/examples/connext_dds/keyed_data/c++11/keys_subscriber.cxx
+++ b/examples/connext_dds/keyed_data/c++11/keys_subscriber.cxx
@@ -40,7 +40,7 @@ int process_data(dds::sub::DataReader<keys> reader)
             const dds::sub::status::InstanceState &state =
                     info.state().instance_state();
             if (state
-                    == dds::sub::status::InstanceState::not_alive_no_writers()) {
+                == dds::sub::status::InstanceState::not_alive_no_writers()) {
                 std::cout
                         << "Instance is in NOT_ALIVE_NO_WRITERS instance state"
                         << std::endl;
@@ -49,11 +49,11 @@ int process_data(dds::sub::DataReader<keys> reader)
                 keys sample;
                 reader.key_value(sample, info.instance_handle());
                 std::cout << "Instance " << sample.code() << " is "
-                        << ((state
-                            == dds::sub::status::InstanceState::alive())
-                                ? "alive"
-                                : "disposed")
-                        << std::endl;
+                          << ((state
+                               == dds::sub::status::InstanceState::alive())
+                                      ? "alive"
+                                      : "disposed")
+                          << std::endl;
             }
         }
 

--- a/examples/connext_dds/keyed_data/c++11/keys_subscriber.cxx
+++ b/examples/connext_dds/keyed_data/c++11/keys_subscriber.cxx
@@ -34,24 +34,23 @@ int process_data(dds::sub::DataReader<keys> reader)
             std::cout << "Instance " << sample.data().code()
                       << ", x: " << sample.data().x()
                       << ", y: " << sample.data().y() << std::endl;
-        } else {
-            // Since there is not valid data, it may include metadata.
-            keys sample;
-            reader.key_value(sample, info.instance_handle());
-
-            // Here we print a message if the instance state is
-            // 'not_alive_no_writers' or 'not_alive_disposed'.
+        } else {        
+            // A sample without valid data can be in any instance state, but the
+            // key value is only available if it is ALIVE or NOT_ALIVE_DISPOSED
             const dds::sub::status::InstanceState &state =
                     info.state().instance_state();
-            if (state
-                == dds::sub::status::InstanceState::not_alive_no_writers()) {
-                std::cout << "Instance " << sample.code() << " has no writers"
+            if (state == dds::sub::status::InstanceState::not_alive_no_writers()) {
+                std::cout << "Instance is in NOT_ALIVE_NO_WRITERS instance state"
                           << std::endl;
-            } else if (
-                    state
-                    == dds::sub::status::InstanceState::not_alive_disposed()) {
-                std::cout << "Instance " << sample.code() << " disposed"
-                          << std::endl;
+            } else {
+                // Since there is not valid data, it may include metadata.
+                keys sample;
+                reader.key_value(sample, info.instance_handle());
+                std::cout << "Instance " << sample.code() << " is " <<
+                        ((state == dds::sub::status::InstanceState::not_alive_disposed())
+                                ? "disposed "
+                                : "alive ")
+                                        << std::endl;
             }
         }
 

--- a/examples/connext_dds/keyed_data/c++98/keys_subscriber.cxx
+++ b/examples/connext_dds/keyed_data/c++98/keys_subscriber.cxx
@@ -72,11 +72,11 @@ unsigned int process_data(keysDataReader *typed_reader)
                     continue;
                 }
                 std::cout << "Instance " << dummy.code << " is "
-                        << ((info_seq[i].instance_state
-                            == DDS_ALIVE_INSTANCE_STATE)
-                                    ? "alive"
-                                    : "disposed")
-                        << std::endl;
+                          << ((info_seq[i].instance_state
+                               == DDS_ALIVE_INSTANCE_STATE)
+                                      ? "alive"
+                                      : "disposed")
+                          << std::endl;
             }
         }
         /* End changes for Keyed_Data */

--- a/examples/connext_dds/keyed_data/c++98/keys_subscriber.cxx
+++ b/examples/connext_dds/keyed_data/c++98/keys_subscriber.cxx
@@ -55,25 +55,26 @@ unsigned int process_data(keysDataReader *typed_reader)
 
             samples_read++;
         } else {
-            /* Since there is not valid data, it may include metadata */
-            keys dummy;
-            retcode = typed_reader->get_key_value(
-                    dummy,
-                    info_seq[i].instance_handle);
-            if (retcode != DDS_RETCODE_OK) {
-                std::cout << "get_key_value error " << retcode << std::endl;
-                continue;
-            }
-
-            /* Here we print a message if the instance state is ALIVE_NO_WRITERS
-             * or ALIVE_DISPOSED */
-            if (info_seq[i].instance_state
-                == DDS_NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
-                std::cout << "Instance " << dummy.code << " has no writers\n";
-            } else if (
-                    info_seq[i].instance_state
-                    == DDS_NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
-                std::cout << "Instance " << dummy.code << " disposed\n";
+            /*
+             * An invalid sample can be in any instance state. The key value is
+             * only available if it is ALIVE or NOT_ALIVE_DISPOSED.
+             */
+            if (info_seq[i].instance_state == DDS_NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
+                std::cout << "Instance has no writers" << std::endl;
+            } else {
+                keys dummy;
+                retcode = typed_reader->get_key_value(
+                        dummy,
+                        info_seq[i].instance_handle);
+                if (retcode != DDS_RETCODE_OK) {
+                    std::cout << "get_key_value error " << retcode << std::endl;
+                    continue;
+                }
+                std::cout << "Instance " << dummy.code << " is "
+                        << ((info_seq[i].instance_state == DDS_ALIVE_INSTANCE_STATE)
+                                ? "alive"
+                                : "disposed")
+                        << std::endl;
             }
         }
         /* End changes for Keyed_Data */

--- a/examples/connext_dds/keyed_data/c++98/keys_subscriber.cxx
+++ b/examples/connext_dds/keyed_data/c++98/keys_subscriber.cxx
@@ -55,28 +55,29 @@ unsigned int process_data(keysDataReader *typed_reader)
 
             samples_read++;
         } else {
-            /*
-             * An invalid sample can be in any instance state. The key value is
-             * only available if it is ALIVE or NOT_ALIVE_DISPOSED.
-             */
+            /* An invalid sample can be in any instance state. */
+            keys dummy;
+            retcode = typed_reader->get_key_value(
+                    dummy,
+                    info_seq[i].instance_handle);
+            if (retcode != DDS_RETCODE_OK) {
+                std::cout << "get_key_value error " << retcode << std::endl;
+                continue;
+            }
             if (info_seq[i].instance_state
                 == DDS_NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
-                std::cout << "Instance has no writers" << std::endl;
+                std::cout
+                        << "Instance " << dummy.code << " has no writers"
+                        << std::endl;
+            } else if (info_seq[i].instance_state
+                == DDS_NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
+                std::cout
+                        << "Instance " << dummy.code << " is disposed"
+                        << std::endl;
             } else {
-                keys dummy;
-                retcode = typed_reader->get_key_value(
-                        dummy,
-                        info_seq[i].instance_handle);
-                if (retcode != DDS_RETCODE_OK) {
-                    std::cout << "get_key_value error " << retcode << std::endl;
-                    continue;
-                }
-                std::cout << "Instance " << dummy.code << " is "
-                          << ((info_seq[i].instance_state
-                               == DDS_ALIVE_INSTANCE_STATE)
-                                      ? "alive"
-                                      : "disposed")
-                          << std::endl;
+                std::cout
+                        << "Instance " << dummy.code << " is alive"
+                        << std::endl;
             }
         }
         /* End changes for Keyed_Data */

--- a/examples/connext_dds/keyed_data/c++98/keys_subscriber.cxx
+++ b/examples/connext_dds/keyed_data/c++98/keys_subscriber.cxx
@@ -59,7 +59,8 @@ unsigned int process_data(keysDataReader *typed_reader)
              * An invalid sample can be in any instance state. The key value is
              * only available if it is ALIVE or NOT_ALIVE_DISPOSED.
              */
-            if (info_seq[i].instance_state == DDS_NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
+            if (info_seq[i].instance_state
+                == DDS_NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
                 std::cout << "Instance has no writers" << std::endl;
             } else {
                 keys dummy;
@@ -71,9 +72,10 @@ unsigned int process_data(keysDataReader *typed_reader)
                     continue;
                 }
                 std::cout << "Instance " << dummy.code << " is "
-                        << ((info_seq[i].instance_state == DDS_ALIVE_INSTANCE_STATE)
-                                ? "alive"
-                                : "disposed")
+                        << ((info_seq[i].instance_state
+                            == DDS_ALIVE_INSTANCE_STATE)
+                                    ? "alive"
+                                    : "disposed")
                         << std::endl;
             }
         }

--- a/examples/connext_dds/keyed_data/c++98/keys_subscriber.cxx
+++ b/examples/connext_dds/keyed_data/c++98/keys_subscriber.cxx
@@ -66,18 +66,16 @@ unsigned int process_data(keysDataReader *typed_reader)
             }
             if (info_seq[i].instance_state
                 == DDS_NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
-                std::cout
-                        << "Instance " << dummy.code << " has no writers"
-                        << std::endl;
-            } else if (info_seq[i].instance_state
-                == DDS_NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
-                std::cout
-                        << "Instance " << dummy.code << " is disposed"
-                        << std::endl;
+                std::cout << "Instance " << dummy.code << " has no writers"
+                          << std::endl;
+            } else if (
+                    info_seq[i].instance_state
+                    == DDS_NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
+                std::cout << "Instance " << dummy.code << " is disposed"
+                          << std::endl;
             } else {
-                std::cout
-                        << "Instance " << dummy.code << " is alive"
-                        << std::endl;
+                std::cout << "Instance " << dummy.code << " is alive"
+                          << std::endl;
             }
         }
         /* End changes for Keyed_Data */

--- a/examples/connext_dds/keyed_data/c/keys_subscriber.c
+++ b/examples/connext_dds/keyed_data/c/keys_subscriber.c
@@ -148,30 +148,24 @@ void keysListener_on_data_available(void *listener_data, DDS_DataReader *reader)
             printf("Instance %d: x: %d, y: %d\n", data->code, data->x, data->y);
 
         } else {
-            printf("No valid data for sample\n");
-            /*
-             * An invalid data sample can be in any instance state. The key
-             * value may be available if the instance is either ALIVE or
-             * NOT_ALIVE_DISPOSED.
-             */
+            /* An invalid data sample can be in any instance state. */
+            keys key_value;
+            retcode = keysDataReader_get_key_value(
+                    keys_reader,
+                    &key_value,
+                    &info->instance_handle);
+            if (retcode != DDS_RETCODE_OK) {
+                printf("get_key_value error %d\n", retcode);
+                continue;
+            }
             if (info->instance_state
                 == DDS_NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
-                printf("Instance is in NOT_ALIVE_NO_WRITERS instance state\n");
+                printf("Instance %d has no writers\n", key_value.code);
+            } else if (info->instance_state 
+                == DDS_NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
+                printf("Instance %d is disposed\n", key_value.code);
             } else {
-                keys key_value;
-                retcode = keysDataReader_get_key_value(
-                        keys_reader,
-                        &key_value,
-                        &info->instance_handle);
-                if (retcode != DDS_RETCODE_OK) {
-                    printf("get_key_value error %d\n", retcode);
-                    continue;
-                }
-                printf("Instance %d is in %s instance state\n",
-                       key_value.code,
-                       ((info->instance_state == DDS_ALIVE_INSTANCE_STATE)
-                                ? "ALIVE"
-                                : "NOT_ALIVE_DISPOSED"));
+                printf("Instance %d is alive\n", key_value.code);
             }
         }
         /* End changes for Keyed_Data */

--- a/examples/connext_dds/keyed_data/c/keys_subscriber.c
+++ b/examples/connext_dds/keyed_data/c/keys_subscriber.c
@@ -161,8 +161,9 @@ void keysListener_on_data_available(void *listener_data, DDS_DataReader *reader)
             if (info->instance_state
                 == DDS_NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
                 printf("Instance %d has no writers\n", key_value.code);
-            } else if (info->instance_state 
-                == DDS_NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
+            } else if (
+                    info->instance_state
+                    == DDS_NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
                 printf("Instance %d is disposed\n", key_value.code);
             } else {
                 printf("Instance %d is alive\n", key_value.code);

--- a/examples/connext_dds/keyed_data/c/keys_subscriber.c
+++ b/examples/connext_dds/keyed_data/c/keys_subscriber.c
@@ -149,12 +149,13 @@ void keysListener_on_data_available(void *listener_data, DDS_DataReader *reader)
 
         } else {
             printf("No valid data for sample\n");
-            /* 
+            /*
              * An invalid data sample can be in any instance state. The key
              * value may be available if the instance is either ALIVE or
              * NOT_ALIVE_DISPOSED.
              */
-            if (info->instance_state == DDS_NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
+            if (info->instance_state
+                == DDS_NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
                 printf("Instance is in NOT_ALIVE_NO_WRITERS instance state\n");
             } else {
                 keys key_value;
@@ -166,11 +167,12 @@ void keysListener_on_data_available(void *listener_data, DDS_DataReader *reader)
                     printf("get_key_value error %d\n", retcode);
                     continue;
                 }
-                printf("Instance %d is in %s instance state\n",
+                printf(
+                        "Instance %d is in %s instance state\n",
                         key_value.code,
-                        info->instance_state == DDS_NOT_ALIVE_DISPOSED_INSTANCE_STATE
-                                ? "NOT_ALIVE_DISPOSED"
-                                : "ALIVE");
+                        ((info->instance_state == DDS_ALIVE_INSTANCE_STATE)
+                                ? "ALIVE"
+                                : "NOT_ALIVE_DISPOSED"));
             }
         }
         /* End changes for Keyed_Data */

--- a/examples/connext_dds/keyed_data/c/keys_subscriber.c
+++ b/examples/connext_dds/keyed_data/c/keys_subscriber.c
@@ -148,26 +148,29 @@ void keysListener_on_data_available(void *listener_data, DDS_DataReader *reader)
             printf("Instance %d: x: %d, y: %d\n", data->code, data->x, data->y);
 
         } else {
-            /* Since there is not valid data, it may include metadata */
-            keys dummy;
-            retcode = keysDataReader_get_key_value(
-                    keys_reader,
-                    &dummy,
-                    &info->instance_handle);
-            if (retcode != DDS_RETCODE_OK) {
-                printf("get_key_value error %d\n", retcode);
-                continue;
-            }
-
-            /* Here we print a message if the instance state is ALIVE_NO_WRITERS
-             * or ALIVE_DISPOSED */
-            if (info->instance_state
-                == DDS_NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
-                printf("Instance %d has no writers\n", dummy.code);
-            } else if (
-                    info->instance_state
-                    == DDS_NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
-                printf("Instance %d disposed\n", dummy.code);
+            printf("No valid data for sample\n");
+            /* 
+             * An invalid data sample can be in any instance state. The key
+             * value may be available if the instance is either ALIVE or
+             * NOT_ALIVE_DISPOSED.
+             */
+            if (info->instance_state == DDS_NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
+                printf("Instance is in NOT_ALIVE_NO_WRITERS instance state\n");
+            } else {
+                keys key_value;
+                retcode = keysDataReader_get_key_value(
+                        keys_reader,
+                        &key_value,
+                        &info->instance_handle);
+                if (retcode != DDS_RETCODE_OK) {
+                    printf("get_key_value error %d\n", retcode);
+                    continue;
+                }
+                printf("Instance %d is in %s instance state\n",
+                        key_value.code,
+                        info->instance_state == DDS_NOT_ALIVE_DISPOSED_INSTANCE_STATE
+                                ? "NOT_ALIVE_DISPOSED"
+                                : "ALIVE");
             }
         }
         /* End changes for Keyed_Data */

--- a/examples/connext_dds/keyed_data/c/keys_subscriber.c
+++ b/examples/connext_dds/keyed_data/c/keys_subscriber.c
@@ -167,10 +167,9 @@ void keysListener_on_data_available(void *listener_data, DDS_DataReader *reader)
                     printf("get_key_value error %d\n", retcode);
                     continue;
                 }
-                printf(
-                        "Instance %d is in %s instance state\n",
-                        key_value.code,
-                        ((info->instance_state == DDS_ALIVE_INSTANCE_STATE)
+                printf("Instance %d is in %s instance state\n",
+                       key_value.code,
+                       ((info->instance_state == DDS_ALIVE_INSTANCE_STATE)
                                 ? "ALIVE"
                                 : "NOT_ALIVE_DISPOSED"));
             }

--- a/examples/connext_dds/keyed_data/java/keysPublisher.java
+++ b/examples/connext_dds/keyed_data/java/keysPublisher.java
@@ -105,7 +105,7 @@ public class keysPublisher extends Application implements AutoCloseable {
         instance[2].code = 2;
 
         // The keys must have been set before making this call
-        System.out.println("Registering instance" + instance[0].code);
+        System.out.println("Registering instance " + instance[0].code);
         handle[0] = writer.register_instance(instance[0]);
 
         // Modify the data to be sent here

--- a/examples/connext_dds/keyed_data/java/keysSubscriber.java
+++ b/examples/connext_dds/keyed_data/java/keysSubscriber.java
@@ -74,9 +74,10 @@ public class keysSubscriber extends Application implements AutoCloseable {
                                    .NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
                         System.out.print(
                                 "Instance " + dummy.code + " has no writers\n");
-                    } else if (info.instance_state
-                        == InstanceStateKind
-                                   .NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
+                    } else if (
+                            info.instance_state
+                            == InstanceStateKind
+                                       .NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
                         System.out.print(
                                 "Instance " + dummy.code + " is disposed\n");
                     } else {

--- a/examples/connext_dds/keyed_data/java/keysSubscriber.java
+++ b/examples/connext_dds/keyed_data/java/keysSubscriber.java
@@ -67,18 +67,22 @@ public class keysSubscriber extends Application implements AutoCloseable {
                             "Instance " + sample.code + ": x: " + sample.x
                             + ", y: " + sample.y + "\n");
                 } else {
-                    if (info.instance_state ==
-                            InstanceStateKind.NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
+                    if (info.instance_state
+                            == InstanceStateKind
+                                    .NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
                         System.out.print("Instance has no writers\n");
                     } else {
                         keys dummy = new keys();
                         reader.get_key_value(dummy, info.instance_handle);
-                        if (info.instance_state ==
-                                InstanceStateKind.ALIVE_INSTANCE_STATE) {
-                            System.out.print("Instance " + dummy.code + " is ALIVE\n");
-                        } else if (info.instance_state ==
-                                InstanceStateKind.NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
-                            System.out.print("Instance " + dummy.code + " is disposed\n");
+                        if (info.instance_state
+                                == InstanceStateKind.ALIVE_INSTANCE_STATE) {
+                            System.out.print(
+                                    "Instance " + dummy.code + " is ALIVE\n");
+                        } else if (info.instance_state
+                                == InstanceStateKind.NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
+                            System.out.print(
+                                    "Instance " + dummy.code
+                                    + " is disposed\n");
                         }
                     }
                 }

--- a/examples/connext_dds/keyed_data/java/keysSubscriber.java
+++ b/examples/connext_dds/keyed_data/java/keysSubscriber.java
@@ -67,25 +67,21 @@ public class keysSubscriber extends Application implements AutoCloseable {
                             "Instance " + sample.code + ": x: " + sample.x
                             + ", y: " + sample.y + "\n");
                 } else {
+                    keys dummy = new keys();
+                    reader.get_key_value(dummy, info.instance_handle);
                     if (info.instance_state
                         == InstanceStateKind
                                    .NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
-                        System.out.print("Instance has no writers\n");
+                        System.out.print(
+                                "Instance " + dummy.code + " has no writers\n");
+                    } else if (info.instance_state
+                        == InstanceStateKind
+                                   .NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
+                        System.out.print(
+                                "Instance " + dummy.code + " is disposed\n");
                     } else {
-                        keys dummy = new keys();
-                        reader.get_key_value(dummy, info.instance_handle);
-                        if (info.instance_state
-                            == InstanceStateKind.ALIVE_INSTANCE_STATE) {
-                            System.out.print(
-                                    "Instance " + dummy.code + " is ALIVE\n");
-                        } else if (
-                                info.instance_state
-                                == InstanceStateKind
-                                           .NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
-                            System.out.print(
-                                    "Instance " + dummy.code
-                                    + " is disposed\n");
-                        }
+                        System.out.print(
+                                "Instance " + dummy.code + " is alive\n");
                     }
                 }
                 samplesRead++;

--- a/examples/connext_dds/keyed_data/java/keysSubscriber.java
+++ b/examples/connext_dds/keyed_data/java/keysSubscriber.java
@@ -67,23 +67,19 @@ public class keysSubscriber extends Application implements AutoCloseable {
                             "Instance " + sample.code + ": x: " + sample.x
                             + ", y: " + sample.y + "\n");
                 } else {
-                    // Since there is not valid data, it may include metadata
-                    keys dummy = new keys();
-                    reader.get_key_value(dummy, info.instance_handle);
-
-                    // Here we print a message if the instance state is
-                    // ALIVE_NO_WRITERS or ALIVE_DISPOSED
-                    if (info.instance_state
-                        == InstanceStateKind
-                                   .NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
-                        System.out.print(
-                                "Instance " + dummy.code + " has no writers\n");
-                    } else if (
-                            info.instance_state
-                            == InstanceStateKind
-                                       .NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
-                        System.out.print(
-                                "Instance " + dummy.code + " disposed\n");
+                    if (info.instance_state ==
+                            InstanceStateKind.NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
+                        System.out.print("Instance has no writers\n");
+                    } else {
+                        keys dummy = new keys();
+                        reader.get_key_value(dummy, info.instance_handle);
+                        if (info.instance_state ==
+                                InstanceStateKind.ALIVE_INSTANCE_STATE) {
+                            System.out.print("Instance " + dummy.code + " is ALIVE\n");
+                        } else if (info.instance_state ==
+                                InstanceStateKind.NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
+                            System.out.print("Instance " + dummy.code + " is disposed\n");
+                        }
                     }
                 }
                 samplesRead++;

--- a/examples/connext_dds/keyed_data/java/keysSubscriber.java
+++ b/examples/connext_dds/keyed_data/java/keysSubscriber.java
@@ -68,18 +68,20 @@ public class keysSubscriber extends Application implements AutoCloseable {
                             + ", y: " + sample.y + "\n");
                 } else {
                     if (info.instance_state
-                            == InstanceStateKind
-                                    .NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
+                        == InstanceStateKind
+                                   .NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
                         System.out.print("Instance has no writers\n");
                     } else {
                         keys dummy = new keys();
                         reader.get_key_value(dummy, info.instance_handle);
                         if (info.instance_state
-                                == InstanceStateKind.ALIVE_INSTANCE_STATE) {
+                            == InstanceStateKind.ALIVE_INSTANCE_STATE) {
                             System.out.print(
                                     "Instance " + dummy.code + " is ALIVE\n");
-                        } else if (info.instance_state
-                                == InstanceStateKind.NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
+                        } else if (
+                                info.instance_state
+                                == InstanceStateKind
+                                           .NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
                             System.out.print(
                                     "Instance " + dummy.code
                                     + " is disposed\n");


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->

### Summary
Update the keyed_data example that assumes that !valid_data means an instance cannot be ALIVE.

### Details and comments
The introduction of Instance State Consistency means that a sample without valid_data can be in any instance state.
The following code is no longer correct:
```
if (!valid_data)
     if (instance_state == NOT_ALIVE_DISPOSED) {
         // handle disposed
     } else {
         // handle NOT_ALIVE_NO_WRITERS
     }
```


### Checks

<!-- Change te space between the square brackets to an `x` -->
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.

<!-- Uncomment bellow if you added a C/C++ example and updated examples/connext_dds/CMakeList.txt -->
<!--
-   [ ] I have added a new C/C++ example and updated `examples/connext_dds/CMakeList.txt` accordingly.
-->
<!-- Uncomment bellow if you added a Java example and updated examples/connext_dds/settings.gradle -->
<!--
-   [ ] I have added a new Java example and updated `examples/connext_dds/settings.gradle` accordingly.
-->
