### PR TITLE
Fix Routing Service file adapter examples

### DIFF
--- a/examples/routing_service/file_adapter/c++11/README.md
+++ b/examples/routing_service/file_adapter/c++11/README.md
@@ -97,10 +97,10 @@ appropriate value of ```SHAPE_TOPIC``` before starting Routing Service.
 To run Routing Service, you will need first to set up your environment as follows.
 
 Before running the RTI Routing Service, you need to specify where the
-`fileadapter` library is located as shown below:
+`FileAdapterC++11` library is located as shown below:
 
 ```bash
-$export RTI_LD_LIBRARY_PATH=<Connext DDS Directory>/lib/<Connext DDS Architecture>:<Path to fileadapter library>
+$export RTI_LD_LIBRARY_PATH=<Connext DDS Directory>/lib/<Connext DDS Architecture>:<Path to FileAdapterC++11 library>
 ```
 
 ```bash

--- a/examples/routing_service/file_adapter/c++11/RsFileAdapter.xml
+++ b/examples/routing_service/file_adapter/c++11/RsFileAdapter.xml
@@ -10,8 +10,8 @@
         <adapter_plugin name="FileAdapter">
             <!--
             By specifing this value, RTI Router will search for
-            libfileadapter.so in Unix systems, fileadapter.dll on
-            Windows systems and libfileadapter.dylib on Mac OS. 
+            libFileAdapterC++11.so in Unix systems, FileAdapterC++11.dll on
+            Windows systems and libFileAdapterC++11.dylib on Mac OS. 
             RTI Routing Service will attempt to load this library from:
                 - Working directory or plugin_search_path
                 - Executable directory

--- a/examples/routing_service/file_adapter/c/README.md
+++ b/examples/routing_service/file_adapter/c/README.md
@@ -76,7 +76,7 @@ $export NDDSHOME=<RTI Connext DDS Directory>
 ```
 
 Before running the RTI Routing Service, you also need to specify where the
-`fileadapter` library is located as shown below:
+`FileAdapterC` library is located as shown below:
 
 ```bash
 $export RTI_LD_LIBRARY_PATH=<Path to CMake build folder>

--- a/examples/routing_service/file_adapter/c/file_bridge.xml
+++ b/examples/routing_service/file_adapter/c/file_bridge.xml
@@ -17,7 +17,7 @@
     <!-- Adapter entry points are defined here -->
     <adapter_library name="adapters">
         <adapter_plugin name="file">
-            <dll>fileadapter</dll>
+            <dll>FileAdapterC</dll>
             <create_function>RTI_RoutingServiceFileAdapterPlugin_create</create_function>
         </adapter_plugin>
     </adapter_library>


### PR DESCRIPTION
### Summary
Fix Routing Service file adapter examples to use the correct dynamic libraries.

### Details and comments
The shared libraries that CMake was generating were named `FileAdapterC` and `FileAdapterC++11` instead of `fileadapter`, so I used the correct names in the xml files.

### Checks

<!-- Change te space between the square brackets to an `x` -->
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.

<!-- Uncomment bellow if you added a C/C++ example and updated examples/connext_dds/CMakeList.txt -->
<!--
-   [ ] I have added a new C/C++ example and updated `examples/connext_dds/CMakeList.txt` accordingly.
-->
<!-- Uncomment bellow if you added a Java example and updated examples/connext_dds/settings.gradle -->
<!--
-   [ ] I have added a new Java example and updated `examples/connext_dds/settings.gradle` accordingly.
-->
