### PR TITLE
 Use new property names and values in the lightweight and cds examples

### DIFF
--- a/examples/connext_secure/cds/c++11/USER_QOS_PROFILES.xml
+++ b/examples/connext_secure/cds/c++11/USER_QOS_PROFILES.xml
@@ -10,7 +10,8 @@ obligation to maintain or support the software. RTI shall not be liable for
 any incidental or consequential damages arising out of the use or inability
 to use the software. -->
 
-<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/7.2.0/rti_dds_profiles.xsd">
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/7.3.0/rti_dds_profiles.xsd">
     <!-- QoS Library containing the QoS profile used in the generated example.
 
         A QoS library is a named set of QoS profiles.

--- a/examples/connext_secure/cds/c++11/USER_QOS_PROFILES.xml
+++ b/examples/connext_secure/cds/c++11/USER_QOS_PROFILES.xml
@@ -54,12 +54,16 @@ to use the software. -->
                             <value>RTI_SecurityLightweight_PluginSuite_create</value>
                         </element>
                         <element>
-                            <name>com.rti.serv.secure.cryptography.rtps_protection_preshared_key</name>
-                            <value>str:0:uIqNqiN11xMbRcuUSdT4BGOEUjLapfosAyzCg7uUBFo=</value>
+                            <name>dds.sec.crypto.rtps_psk_secret_passphrase</name>
+                            <value>data:,0:uIqNqiN11xMbRcuUSdT4BGOEUjLapfosAyzCg7uUBFo=</value>
                         </element>
                         <element>
-                            <name>com.rti.serv.secure.cryptography.rtps_protection_preshared_key_algorithm</name>
-                            <value>AES256+GMAC</value>
+                            <name>dds.sec.crypto.rtps_psk_symmetric_cipher_algorithm</name>
+                            <value>AES256+GCM</value>
+                        </element>
+                        <element>
+                            <name>dds.sec.access.rtps_psk_protection_kind</name>
+                            <value>SIGN</value>
                         </element>
                     </value>
                 </property>

--- a/examples/connext_secure/cds/cds.xml
+++ b/examples/connext_secure/cds/cds.xml
@@ -11,7 +11,7 @@ any incidental or consequential damages arising out of the use or inability
 to use the software. -->
 
 <dds  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/7.2.0/rti_cloud_discovery_service.xsd">
+      xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/7.3.0/rti_cloud_discovery_service.xsd">
             
     <cloud_discovery_service name="secure_cds">
         <transport>

--- a/examples/connext_secure/cds/cds.xml
+++ b/examples/connext_secure/cds/cds.xml
@@ -23,12 +23,16 @@ to use the software. -->
         <security>
           <property>
             <element>
-              <name>com.rti.serv.secure.cryptography.rtps_protection_preshared_key</name>
-              <value>str:0:uIqNqiN11xMbRcuUSdT4BGOEUjLapfosAyzCg7uUBFo=</value>
+              <name>dds.sec.crypto.rtps_psk_secret_passphrase</name>
+              <value>data:,0:uIqNqiN11xMbRcuUSdT4BGOEUjLapfosAyzCg7uUBFo=</value>
             </element>
             <element>
-              <name>com.rti.serv.secure.cryptography.rtps_protection_preshared_key_algorithm</name>
-              <value>AES256+GMAC</value>
+              <name>dds.sec.crypto.rtps_psk_symmetric_cipher_algorithm</name>
+              <value>AES256+GCM</value>
+            </element>
+            <element>
+                <name>dds.sec.access.rtps_psk_protection_kind</name>
+                <value>SIGN</value>
             </element>
           </property>
         </security>

--- a/examples/connext_secure/certificate_revocation_list/c++11/USER_QOS_PROFILES.xml
+++ b/examples/connext_secure/certificate_revocation_list/c++11/USER_QOS_PROFILES.xml
@@ -11,7 +11,7 @@ any incidental or consequential damages arising out of the use or inability
 to use the software. -->
 
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/7.2.0/rti_dds_profiles.xsd">
+        xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/7.3.0/rti_dds_profiles.xsd">
   <qos_library name="full_library">
 
       <qos_profile name="peer1" base_name="BuiltinQosSnippetLib::Feature.Security.Enable" is_default_qos="true">

--- a/examples/connext_secure/certificate_revocation_list/security/xml/Governance.xml
+++ b/examples/connext_secure/certificate_revocation_list/security/xml/Governance.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/7.2.0/dds_security_governance.xsd">
+    xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/7.3.0/dds_security_governance.xsd">
     <domain_access_rules>
         <domain_rule>
             <domains>

--- a/examples/connext_secure/certificate_revocation_list/security/xml/Permissions.xml
+++ b/examples/connext_secure/certificate_revocation_list/security/xml/Permissions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/7.2.0/dds_security_permissions.xsd">
+    xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/7.3.0/dds_security_permissions.xsd">
     <permissions>
         <grant name="CrlParticipantA">
             <subject_name>C = US, ST = CA, L = Santa Clara, O = Real Time Innovations, emailAddress = ecdsa01ParticipantA@rti.com, CN = Crl Participant A</subject_name>

--- a/examples/connext_secure/lightweight/c++11/USER_QOS_PROFILES.xml
+++ b/examples/connext_secure/lightweight/c++11/USER_QOS_PROFILES.xml
@@ -11,7 +11,7 @@ any incidental or consequential damages arising out of the use or inability
 to use the software. -->
 
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/7.2.0/rti_dds_profiles.xsd">
+      xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/7.3.0/rti_dds_profiles.xsd">
   <qos_library name="full_library">
 
     <qos_profile name="peer1">

--- a/examples/connext_secure/lightweight/c++11/USER_QOS_PROFILES.xml
+++ b/examples/connext_secure/lightweight/c++11/USER_QOS_PROFILES.xml
@@ -52,8 +52,8 @@ to use the software. -->
                 <value>file:./security/xml/signed/signed_permissions.p7s</value>
               </element>
               <element>
-                <name>com.rti.serv.secure.cryptography.rtps_protection_preshared_key</name>
-                <value>str:0:uIqNqiN11xMbRcuUSdT4BGOEUjLapfosAyzCg7uUBFo=</value>
+                <name>dds.sec.crypto.rtps_psk_secret_passphrase</name>
+                <value>data:,0:uIqNqiN11xMbRcuUSdT4BGOEUjLapfosAyzCg7uUBFo=</value>
               </element>
               <element>
                 <name>com.rti.serv.secure.cryptography.encryption_algorithm</name>
@@ -112,11 +112,11 @@ to use the software. -->
                 <value>RTI_SecurityLightweight_PluginSuite_create</value>
               </element>   
               <element>
-                <name>com.rti.serv.secure.cryptography.rtps_protection_preshared_key</name>
-                <value>str:0:uIqNqiN11xMbRcuUSdT4BGOEUjLapfosAyzCg7uUBFo=</value>
+                <name>dds.sec.crypto.rtps_psk_secret_passphrase</name>
+                <value>data:,0:uIqNqiN11xMbRcuUSdT4BGOEUjLapfosAyzCg7uUBFo=</value>
               </element>
               <element>
-                <name>com.rti.serv.secure.cryptography.rtps_protection_preshared_key_algorithm</name>
+                <name>dds.sec.crypto.rtps_psk_symmetric_cipher_algorithm</name>
                 <value>AES256+GCM</value>
               </element>
               <element>

--- a/examples/connext_secure/lightweight/security/xml/governance_lws.xml
+++ b/examples/connext_secure/lightweight/security/xml/governance_lws.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="C:\RTI\rti_connext_dds-7.2.0\resource\schema\dds_security_governance.xsd">
+    xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/7.3.0/dds_security_governance.xsd">
     <domain_access_rules>
         <domain_rule>
             <domains>

--- a/examples/connext_secure/lightweight/security/xml/governance_lws.xml
+++ b/examples/connext_secure/lightweight/security/xml/governance_lws.xml
@@ -13,7 +13,7 @@
             <discovery_protection_kind>NONE</discovery_protection_kind>
             <liveliness_protection_kind>NONE</liveliness_protection_kind>
             <rtps_protection_kind>NONE</rtps_protection_kind>
-            <rtps_preshared_secret_protection_kind>ENCRYPT</rtps_preshared_secret_protection_kind>
+            <rtps_psk_protection_kind>ENCRYPT</rtps_psk_protection_kind>
             <topic_access_rules>
                 <topic_rule>
                     <topic_expression>Square</topic_expression>

--- a/examples/connext_secure/lightweight/security/xml/permissions.xml
+++ b/examples/connext_secure/lightweight/security/xml/permissions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="C:\RTI\rti_connext_dds-7.2.0\resource\schema\dds_security_permissions.xsd">
+    xsi:noNamespaceSchemaLocation="http://community.rti.com/schema/7.3.0/dds_security_permissions.xsd">
     <permissions>
         <grant name="LightParticipantA">
             <subject_name>/C=US/ST=CA/L=Santa Clara/O=Real Time Innovations/emailAddress=ecdsa01ParticipantA@rti.com/CN=Lightweight Participant A</subject_name>


### PR DESCRIPTION
### Summary

Fix the lightweight and cds examples. They became outdated because we changed the following to match the DDS Security 1.2 Specification:

- From `com.rti.serv.secure.cryptography.rtps_protection_preshared_key` to `dds.sec.crypto.rtps_psk_secret_passphrase`.
- In the previous property, the prefix used for the value associated to text is now `data:,` instead of `str`.
- Replaced `com.rti.serv.secure.cryptography.rtps_protection_preshared_key_algorithm` with `dds.sec.crypto.rtps_psk_symmetric_cipher_algorithm` and MAC options require setting `dds.sec.access.rtps_psk_protection_kind` to `SIGN`.

This PR also updates the schema links to point to the latest 7.3.0 version and fixes a couple of them that were local.