### PR TITLE
COREPLG-740: fix wrong CMakeLists.txt file in lbediscovery_xml_app_creation example

### DIFF
--- a/examples/connext_dds/lbediscovery_xml_app_creation/c++11/CMakeLists.txt
+++ b/examples/connext_dds/lbediscovery_xml_app_creation/c++11/CMakeLists.txt
@@ -11,10 +11,11 @@
 #
 cmake_minimum_required(VERSION 3.11)
 project(rtiexamples-lbediscovery-xml-app-creation)
-set(CMAKE_MODULE_PATH
-    ${CMAKE_MODULE_PATH}
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../resources/cmake"
+list(APPEND CMAKE_MODULE_PATH
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../resources/cmake/Modules"
 )
+include(ConnextDdsConfigureCmakeUtils)
+connextdds_configure_cmake_utils()
 
 # Include ConnextDdsAddExample.cmake from resources/cmake
 include(ConnextDdsAddExample)


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->

### Summary

The usage of `connextdds_configure_cmake_utils` was missing in the LBED CMakeLists.txt example.
I added it.

### Checks

<!-- Change te space between the square brackets to an `x` -->
-   [X] I have updated the documentation accordingly.
-   [X] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.

<!-- Uncomment bellow if you added a C/C++ example and updated examples/connext_dds/CMakeList.txt -->
<!--
-   [ ] I have added a new C/C++ example and updated `examples/connext_dds/CMakeList.txt` accordingly.
-->
<!-- Uncomment bellow if you added a Java example and updated examples/connext_dds/settings.gradle -->
<!--
-   [ ] I have added a new Java example and updated `examples/connext_dds/settings.gradle` accordingly.
-->
