### PR TITLE
CORE-14969: Remove asynchronous publishing from examples in which it is no longer needed

### DIFF
--- a/examples/connext_dds/flat_data_latency/c++11/README.md
+++ b/examples/connext_dds/flat_data_latency/c++11/README.md
@@ -49,13 +49,14 @@ feature:
 
 The FlatData profile used in this example inherits from the builtin
 `StrictReliable.LargeData` profile. This builtin profile sets up the middleware
-for sending large data by using Asynchronous Pubisher, a default Flow Controller
-and other optimizations. In the FlatData profile, the *Durability QoS* of the
-DataWriter is set to volatile to enable managed samples to be reused when they
-are acknowledged. The *DataRepresentation QoS* is set to *Extended CDR version
-2* at both the DataWriter and the DataReader as FlatData language binding is
-only supported with this data representation. The tranport settings of the
-participant are also tuned to ensure reduced latency while sending large data.
+for sending large data by enabling some optimizations in the reliability
+protocol, the history, and how dynamic memory allocations are handled. In the
+FlatData profile, the *Durability QoS* of the DataWriter is set to volatile to
+enable managed samples to be reused when they are acknowledged. The
+*DataRepresentation QoS* is set to *Extended CDR version 2* at both the
+DataWriter and the DataReader as FlatData language binding is only supported
+with this data representation. The transport settings of the participant are
+also tuned to ensure reduced latency while sending large data.
 
 ## Building the Example :wrench:
 

--- a/examples/connext_dds/flat_data_latency/c++11/README.md
+++ b/examples/connext_dds/flat_data_latency/c++11/README.md
@@ -50,11 +50,11 @@ feature:
 The FlatData profile used in this example inherits from the builtin
 `StrictReliable.LargeData` profile. This builtin profile sets up the middleware
 for sending large data by enabling some optimizations in the reliability
-protocol, the history, and how dynamic memory allocations are handled. In the
+protocol, the history, and the handling of dynamic memory allocations. In the
 FlatData profile, the *Durability QoS* of the DataWriter is set to volatile to
 enable managed samples to be reused when they are acknowledged. The
-*DataRepresentation QoS* is set to *Extended CDR version 2* at both the
-DataWriter and the DataReader as FlatData language binding is only supported
+*DataRepresentation QoS* is set to *Extended CDR version 2* on both the
+DataWriter and the DataReader since FlatData language binding is only supported
 with this data representation. The transport settings of the participant are
 also tuned to ensure reduced latency while sending large data.
 

--- a/examples/connext_dds/flat_data_latency/c++11/USER_QOS_PROFILES.xml
+++ b/examples/connext_dds/flat_data_latency/c++11/USER_QOS_PROFILES.xml
@@ -19,8 +19,6 @@
     -->
     <qos_library name="CameraImage_Library">
 
-        <!-- Base for profiles that need asynchronous publisher (flat_types
-             and plain_types) -->
         <qos_profile name="FlatData"
                      base_name="BuiltinQosLibExp::Generic.StrictReliable.LargeData" is_default_qos="true">
             <datawriter_qos>

--- a/examples/connext_dds/fragmented_data_statistics/c++11/USER_QOS_PROFILES.xml
+++ b/examples/connext_dds/fragmented_data_statistics/c++11/USER_QOS_PROFILES.xml
@@ -24,15 +24,6 @@
              A QoS profile groups a set of related QoS.
         -->
         <qos_profile name="fragment_Profile" base_name="BuiltinQosLib::Generic.StrictReliable" is_default_qos="true">
-            <!-- QoS used to configure the data writer created in the example code -->
-            <datawriter_qos>
-
-                <!-- QoS for asynchronous publishing -->
-                <publish_mode>
-                    <kind>ASYNCHRONOUS_PUBLISH_MODE_QOS</kind>
-                    <flow_controller_name>DDS_FIXED_RATE_FLOW_CONTROLLER_NAME</flow_controller_name>
-                </publish_mode>
-            </datawriter_qos>
             <domain_participant_qos>
                 <transport_builtin>
                     <shmem>

--- a/examples/connext_dds/fragmented_data_statistics/c++98/USER_QOS_PROFILES.xml
+++ b/examples/connext_dds/fragmented_data_statistics/c++98/USER_QOS_PROFILES.xml
@@ -24,15 +24,6 @@
              A QoS profile groups a set of related QoS.
         -->
         <qos_profile name="fragment_Profile" base_name="BuiltinQosLib::Generic.StrictReliable" is_default_qos="true">
-            <!-- QoS used to configure the data writer created in the example code -->
-            <datawriter_qos>
-
-                <!-- QoS for asynchronous publishing -->
-                <publish_mode>
-                    <kind>ASYNCHRONOUS_PUBLISH_MODE_QOS</kind>
-                    <flow_controller_name>DDS_FIXED_RATE_FLOW_CONTROLLER_NAME</flow_controller_name>
-                </publish_mode>
-            </datawriter_qos>
             <domain_participant_qos>
                 <transport_builtin>
                     <shmem>

--- a/examples/connext_dds/fragmented_data_statistics/c/USER_QOS_PROFILES.xml
+++ b/examples/connext_dds/fragmented_data_statistics/c/USER_QOS_PROFILES.xml
@@ -24,15 +24,6 @@
              A QoS profile groups a set of related QoS.
         -->
         <qos_profile name="fragment_Profile" base_name="BuiltinQosLib::Generic.StrictReliable" is_default_qos="true">
-            <!-- QoS used to configure the data writer created in the example code -->
-            <datawriter_qos>
-
-                <!-- QoS for asynchronous publishing -->
-                <publish_mode>
-                    <kind>ASYNCHRONOUS_PUBLISH_MODE_QOS</kind>
-                    <flow_controller_name>DDS_FIXED_RATE_FLOW_CONTROLLER_NAME</flow_controller_name>
-                </publish_mode>
-            </datawriter_qos>
             <domain_participant_qos>
                 <transport_builtin>
                     <shmem>

--- a/examples/connext_dds/fragmented_data_statistics/java/USER_QOS_PROFILES.xml
+++ b/examples/connext_dds/fragmented_data_statistics/java/USER_QOS_PROFILES.xml
@@ -24,15 +24,6 @@
              A QoS profile groups a set of related QoS.
         -->
         <qos_profile name="fragment_Profile" base_name="BuiltinQosLib::Generic.StrictReliable" is_default_qos="true">
-            <!-- QoS used to configure the data writer created in the example code -->
-            <datawriter_qos>
-
-                <!-- QoS for asynchronous publishing -->
-                <publish_mode>
-                    <kind>ASYNCHRONOUS_PUBLISH_MODE_QOS</kind>
-                    <flow_controller_name>DDS_FIXED_RATE_FLOW_CONTROLLER_NAME</flow_controller_name>
-                </publish_mode>
-            </datawriter_qos>
             <domain_participant_qos>
                 <transport_builtin>
                     <shmem>

--- a/examples/connext_dds/high_priority_first_flow_controller/README.md
+++ b/examples/connext_dds/high_priority_first_flow_controller/README.md
@@ -15,10 +15,9 @@ actual samples based on the scheduling policy specified by the flow controller.
 
 Large data is defined as samples larger than the message_size_max of the
 installed transports. Sending large data requires a sample to be fragmented into
-smaller messages, and reassembled at the other end. Sending large data RELIABLY
-requires the use of an asynchronous publisher.
+smaller messages, and reassembled at the other end.
 
-The default QoS configuration must be modified to use a high priority flow
+The default QoS configuration can be modified to use a high priority flow
 controller and asynchronous publishing. Further optimizations can be made for
 large data.
 
@@ -70,8 +69,7 @@ Flow Controller. The stock examples is modified as follows:
     HPF_MAX_PAYLOAD_SIZE = 8192*16; // 131MB
     ```
 
-    so that we can easily test the the flow controller with asynchronous large
-    data.
+    so that we can easily test the the flow controller with large data.
 
 2.  A HelloWorld example is generated in C++
 

--- a/examples/connext_dds/real_time_wan_transport/c++98/USER_QOS_PROFILES.xml
+++ b/examples/connext_dds/real_time_wan_transport/c++98/USER_QOS_PROFILES.xml
@@ -29,19 +29,6 @@
             <sec>5</sec>
             <nanosec>0</nanosec>
           </participant_liveliness_assert_period>
-          <!-- Required when IP fragmentation is disabled -->
-          <publication_writer_publish_mode>
-            <kind>ASYNCHRONOUS_PUBLISH_MODE_QOS</kind>
-          </publication_writer_publish_mode>
-          <subscription_writer_publish_mode>
-              <kind>ASYNCHRONOUS_PUBLISH_MODE_QOS</kind>
-          </subscription_writer_publish_mode>
-          <secure_volatile_writer_publish_mode>
-              <kind>ASYNCHRONOUS_PUBLISH_MODE_QOS</kind>
-          </secure_volatile_writer_publish_mode>
-          <service_request_writer_publish_mode>
-              <kind>ASYNCHRONOUS_PUBLISH_MODE_QOS</kind>
-          </service_request_writer_publish_mode>
         </discovery_config>
         <property>
           <value>


### PR DESCRIPTION
### Summary

Now that asynchronous publishing is no longer a requirement for sending reliable fragmented data, I reviewed all our GitHub examples and removed the asynchronous publish mode from all the places in which it is no longer necessary.

### Details and comments

Mostly, update documentation and `USER_QOS_PROFILES.xml` files.

### Checks

-   [X] I have updated the documentation accordingly.
-   [X] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.
