### PR TITLE
Minor improvement for Inventory.py

### DIFF
--- a/examples/connext_dds/remote_procedure_call/py/Inventory.py
+++ b/examples/connext_dds/remote_procedure_call/py/Inventory.py
@@ -9,6 +9,7 @@
 # damages arising out of the use or inability to use the software.
 #
 
+from abc import ABC
 from dataclasses import field
 from typing import Sequence
 import rti.idl as idl
@@ -32,7 +33,7 @@ class UnknownItemError(Exception):
 
 
 @rpc.service
-class InventoryService:
+class InventoryService(ABC):
     @rpc.operation
     def get_inventory(self) -> InventoryContents:
         """Get the current inventory inventory"""


### PR DESCRIPTION
Update service interface `InventoryService` to inherit from ABC, as `rpc.Service` expects. (This is an improvement for type checker; it doesn't fix any runtime bug)
