### PR TITLE
Update README.md to reflect 7.4 EAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,13 @@ git submodule update --init --recursive
 
 The examples contained in the
 [master](https://github.com/rticommunity/rticonnextdds-examples/tree/master)
-branch of this repository have been built and tested against RTI Connext DDS
-7.3.0. If you need examples that have been built and tested against older
-versions of RTI Connext DDS, please check out the appropriate branch:
+branch of this repository have been built and tested against **RTI Connext 7.3.0 LTS**. 
+
+If you are using a newer feature release:
+
+- [release/7.4.0](https://github.com/rticommunity/rticonnextdds-examples/tree/release/7.4.0)
+
+If are you using an older release, please check out the appropriate branch:
 
 - [release/7.2.0](https://github.com/rticommunity/rticonnextdds-examples/tree/release/7.2.0)
 - [release/7.1.0](https://github.com/rticommunity/rticonnextdds-examples/tree/release/7.1.0)


### PR DESCRIPTION
The README now explains how to check out examples for newer EARs as well as older Connext releases, assuming that the master version of the repo continues to target 7.3 LTS

**Note: this PR shouldn't be merged until the 7.4 release is out**