### PR TITLE
Update README in develop to reflect 7.4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,11 @@ git submodule update --init --recursive
 
 ## Versioning
 
-The examples contained in the
-[master](https://github.com/rticommunity/rticonnextdds-examples/tree/master)
-branch of this repository have been built and tested against RTI Connext DDS
-7.3.0. If you need examples that have been built and tested against older
-versions of RTI Connext DDS, please check out the appropriate branch:
+The examples contained in this branch have been built and tested against **RTI Connext
+7.4.0 EAR**. If you need examples that have been built and tested against older
+versions of RTI Connext DDS, please check out **master** or the appropriate branch:
 
+- [release/7.3.0](https://github.com/rticommunity/rticonnextdds-examples/tree/release/7.3.0)
 - [release/7.2.0](https://github.com/rticommunity/rticonnextdds-examples/tree/release/7.2.0)
 - [release/7.1.0](https://github.com/rticommunity/rticonnextdds-examples/tree/release/7.1.0)
 - [release/7.0.0](https://github.com/rticommunity/rticonnextdds-examples/tree/release/7.0.0)

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ git submodule update --init --recursive
 
 ## Versioning
 
-The examples contained in this branch have been built and tested against **RTI Connext
+The examples contained in this branch were built and tested against **RTI Connext
 7.4.0 EAR**. If you need examples that have been built and tested against older
-versions of RTI Connext DDS, please check out **master** or the appropriate branch:
+versions of RTI Connext, please check out **master** or the appropriate branch:
 
 - [release/7.3.0](https://github.com/rticommunity/rticonnextdds-examples/tree/release/7.3.0)
 - [release/7.2.0](https://github.com/rticommunity/rticonnextdds-examples/tree/release/7.2.0)


### PR DESCRIPTION
This version of the README indicates that the required version of Connext is 7.4.