### PR TITLE
JH-76 -- change test branch from EAR to 7.4.0, links had already been…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ git submodule update --init --recursive
 ## Versioning
 
 The examples contained in this branch were built and tested against **RTI Connext
-7.4.0 EAR**. If you need examples that have been built and tested against older
+7.4.0**. If you need examples that have been built and tested against older
 versions of RTI Connext, please check out **master** or the appropriate branch:
 
 - [release/7.3.0](https://github.com/rticommunity/rticonnextdds-examples/tree/release/7.3.0)


### PR DESCRIPTION
### Summary
Small change to README.md. Drop the EAR suffix from the mention of which branch this release was tested. All other links had already been changed.

### Details and comments
Smallish change to README.md

### Checks

<!-- Change te space between the square brackets to an `x` -->
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.
