### PR TITLE
Feature/routing 1292 and record-1523

### DIFF
--- a/examples/recording_service/service_admin/c++11/Requester.cxx
+++ b/examples/recording_service/service_admin/c++11/Requester.cxx
@@ -453,6 +453,11 @@ Application::Application(ArgumentsParser &args_parser)
             dds::core::QosProvider::Default().datawriter_qos(
                     "ServiceAdministrationProfiles::"
                     "ServiceAdminRequesterProfile"));
+
+    // configure the requester for compatibility with the RTI routing service
+    // request reply.
+    requester_params_.require_matching_service_on_send_request(false);
+
     /*
      * Now that we have set up all the parameters for the requester instance, we
      * can create it.

--- a/examples/routing_service/remote_admin/c++11/src/Requester.cxx
+++ b/examples/routing_service/remote_admin/c++11/src/Requester.cxx
@@ -64,6 +64,9 @@ int main(int argc, char *argv[])
         rti::request::RequesterParams requester_params(participant);
         requester_params.request_topic_name(COMMAND_REQUEST_TOPIC_NAME);
         requester_params.reply_topic_name(COMMAND_REPLY_TOPIC_NAME);
+        // configure the requester for compatibility with the RTI routing service
+        // request reply.
+        requester_params.require_matching_service_on_send_request(false);
 
         rti::request::Requester<
                 RTI::Service::Admin::CommandRequest,

--- a/examples/routing_service/remote_admin/c++11/src/Requester.cxx
+++ b/examples/routing_service/remote_admin/c++11/src/Requester.cxx
@@ -64,8 +64,8 @@ int main(int argc, char *argv[])
         rti::request::RequesterParams requester_params(participant);
         requester_params.request_topic_name(COMMAND_REQUEST_TOPIC_NAME);
         requester_params.reply_topic_name(COMMAND_REPLY_TOPIC_NAME);
-        // configure the requester for compatibility with the RTI routing service
-        // request reply.
+        // configure the requester for compatibility with the RTI routing
+        // service request reply.
         requester_params.require_matching_service_on_send_request(false);
 
         rti::request::Requester<


### PR DESCRIPTION
### Summary

A requester in C++11 must wait for discovery to connect with a C++11 replier or configure the parameter require_matching_service_on_send_request false to be compatible with other languages.

### Details and comments

This examples must connect with a C implementation. Then the fix is set require_matching_service_on_send_request(false) in the requester parameters

### Checks

Tested routing and recording remote admin, see the tests with RTI Connext 7.5.0:
![PR1](https://github.com/user-attachments/assets/7aa3b7b4-3445-4708-9863-7665632201ae)

![PR2](https://github.com/user-attachments/assets/13eb11dd-7a01-4c30-b1aa-2255a29c82af)

