### PR TITLE
DIT-246: Use of tags for version and products of the test instructions

### DIFF
--- a/tests/examples/connext_dds/dynamic_data_nested_structs/quack_files/dynamic_data_nested_structs_example_test_01.ti.yml
+++ b/tests/examples/connext_dds/dynamic_data_nested_structs/quack_files/dynamic_data_nested_structs_example_test_01.ti.yml
@@ -1,23 +1,23 @@
 apps:
   -
     name: test_dd_nested_structs_c
-    product: pro
-    version: 7.5.0
+    product: {first_product}
+    version: {first_version}
     executable: rticonnextdds-examples/examples/connext_dds/dynamic_data_nested_structs/c/build/dynamic_data_nested_struct
   -
     name: test_dd_nested_structs_cpp98
-    product: pro
-    version: 7.5.0
+    product: {first_product}
+    version: {first_version}
     executable: rticonnextdds-examples/examples/connext_dds/dynamic_data_nested_structs/c++98/build/dynamic_data_nested_struct
   -
     name: test_dd_nested_structs_cpp11
-    product: pro
-    version: 7.5.0
+    product: {first_product}
+    version: {first_version}
     executable: rticonnextdds-examples/examples/connext_dds/dynamic_data_nested_structs/c++11/build/dynamic_data_nested_struct
   -
     name: test_dd_nested_structs_java
-    product: pro
-    version: 7.5.0
+    product: {first_product}
+    version: {first_version}
     executable: rticonnextdds-examples/examples/connext_dds/dynamic_data_nested_structs/java/DynamicDataNestedStruct.sh
 test_scenarios:
   -
@@ -25,7 +25,7 @@ test_scenarios:
     actions:
       -
         action:
-          run test_dd_nested_structs_c on $740_arch
+          run test_dd_nested_structs_c on $first_architecture
         verification:
           - stdout contains "struct InnerStruct"
           - stdout contains "double x;"
@@ -45,7 +45,7 @@ test_scenarios:
     actions:
       -
         action:
-          run test_dd_nested_structs_cpp98 on $740_arch
+          run test_dd_nested_structs_cpp98 on $first_architecture
         verification:
           - stdout contains "struct InnerStruct"
           - stdout contains "double x;"
@@ -66,7 +66,7 @@ test_scenarios:
     actions:
       -
         action:
-          run test_dd_nested_structs_cpp11 on $740_arch
+          run test_dd_nested_structs_cpp11 on $first_architecture
         verification:
           - stdout contains "struct InnerStruct"
           - stdout contains "double x;"
@@ -86,7 +86,7 @@ test_scenarios:
     actions:
       -
         action:
-          run test_dd_nested_structs_java on $740_arch
+          run test_dd_nested_structs_java on $first_architecture
         verification:
           - stdout contains "Setting the initial values of struct with set_complex_member()"
           - stdout contains "get_complex_member() called"

--- a/tests/examples/connext_dds/remote_procedure_call/quack_files/remote_procedure_call_example_test_01.ti.yml
+++ b/tests/examples/connext_dds/remote_procedure_call/quack_files/remote_procedure_call_example_test_01.ti.yml
@@ -1,23 +1,23 @@
 apps:
   -
     name: test_client_cpp11
-    product: pro
-    version: 7.5.0
+    product: {first_product}
+    version: {first_version}
     executable: rticonnextdds-examples/examples/connext_dds/remote_procedure_call/c++11/Inventory_client.sh
   -
     name: test_service_cpp11
-    product: pro
-    version: 7.5.0
+    product: {first_product}
+    version: {first_version}
     executable: rticonnextdds-examples/examples/connext_dds/remote_procedure_call/c++11/Inventory_service.sh
   -
     name: test_client_py
-    product: pro
-    version: 7.5.0
+    product: {first_product}
+    version: {first_version}
     executable: rticonnextdds-examples/examples/connext_dds/remote_procedure_call/py/inventory_client.sh
   -
     name: test_service_py
-    product: pro
-    version: 7.5.0
+    product: {first_product}
+    version: {first_version}
     executable: rticonnextdds-examples/examples/connext_dds/remote_procedure_call/py/inventory_service.sh
 test_scenarios:
   -
@@ -25,7 +25,7 @@ test_scenarios:
     actions:
       -
         action:
-          run test_client_cpp11 with args '--domain $domain_id --add banana --quantity 7' on $740_arch
+          run test_client_cpp11 with args '--domain $domain_id --add banana --quantity 7' on $first_architecture
         verification:
           - stdout contains "Add 7 banana"
           - 'stdout contains "[name: banana, quantity: 7]"'
@@ -33,7 +33,7 @@ test_scenarios:
           - stdout does_not_contain "Exception in run_client()"
       -
         action:
-          run test_client_cpp11 with args '--domain $domain_id --remove blueberry' on $740_arch
+          run test_client_cpp11 with args '--domain $domain_id --remove blueberry' on $first_architecture
         verification:
           - stdout contains "Remove 1 blueberry"
           - 'stdout contains "Unknown item: blueberry"'
@@ -41,7 +41,7 @@ test_scenarios:
           - stdout does_not_contain "Exception in run_client()"
       -
         action:
-          run test_service_cpp11 with args '--domain $domain_id --service-timeout 15' on $740_arch
+          run test_service_cpp11 with args '--domain $domain_id --service-timeout 15' on $first_architecture
         verification:
           - stdout contains "InventoryService running..."
           - stdout does_not_contain "ERROR"
@@ -51,21 +51,21 @@ test_scenarios:
     actions:
       -
         action:
-          run test_client_py with args '--domain $domain_id --add banana --quantity 7' on $740_arch
+          run test_client_py with args '--domain $domain_id --add banana --quantity 7' on $first_architecture
         verification:
           - stdout contains "Add 7 banana"
           - stdout contains "Item(name='banana', quantity=7)]"
           - stdout does_not_contain "ERROR"
       -
         action:
-          run test_client_py with args '--domain $domain_id --remove blueberry' on $740_arch
+          run test_client_py with args '--domain $domain_id --remove blueberry' on $first_architecture
         verification:
           - stdout contains "Remove 1 blueberry"
           - 'stdout contains "Unknown item: blueberry"'
           - stdout does_not_contain "ERROR"
       -
         action:
-          run test_service_py with args '--domain $domain_id --service-timeout 15' on $740_arch
+          run test_service_py with args '--domain $domain_id --service-timeout 15' on $first_architecture
         verification:
           - stdout contains "InventoryService running..."
           - stdout does_not_contain "ERROR"

--- a/tests/examples/connext_dds/request_reply/cs/PrimesRequester.sh
+++ b/tests/examples/connext_dds/request_reply/cs/PrimesRequester.sh
@@ -1,9 +1,4 @@
 #!/bin/bash
 
-# Sleep to try to avoid DIT-194
-# The replier run for 20 seconds, so we can sleep for 10 seconds
-# to try to avoid the issue
-sleep 10
-
 cd ${BaseExamplePath}/cs
 /usr/bin/dotnet run -- --requester $@

--- a/tests/examples/connext_dds/request_reply/quack_files/request_reply_example_test_01.ti.yml
+++ b/tests/examples/connext_dds/request_reply/quack_files/request_reply_example_test_01.ti.yml
@@ -1,23 +1,23 @@
 apps:
   -
     name: test_requester_py
-    product: pro
-    version: 7.5.0
+    product: {first_product}
+    version: {first_version}
     executable: rticonnextdds-examples/examples/connext_dds/request_reply/py/primes_requester.sh
   -
     name: test_replier_py
-    product: pro
-    version: 7.5.0
+    product: {first_product}
+    version: {first_version}
     executable: rticonnextdds-examples/examples/connext_dds/request_reply/py/primes_replier.sh
   -
     name: test_requester_cs
-    product: pro
-    version: 7.5.0
+    product: {first_product}
+    version: {first_version}
     executable: rticonnextdds-examples/examples/connext_dds/request_reply/cs/PrimesRequester.sh
   -
     name: test_replier_cs
-    product: pro
-    version: 7.5.0
+    product: {first_product}
+    version: {first_version}
     executable: rticonnextdds-examples/examples/connext_dds/request_reply/cs/PrimesReplier.sh
 test_scenarios:
   -
@@ -25,7 +25,7 @@ test_scenarios:
     actions:
       -
         action:
-          run test_requester_py with args '--domain $domain_id --primes-per-reply 5 100' on $740_arch
+          run test_requester_py with args '--domain $domain_id --primes-per-reply 5 100' on $first_architecture
         verification:
           - stdout contains "Sending a request to calculate the prime numbers <= 100 in sequences of 5 or fewer elements"
           - stdout contains "[2, 3, 5, 7, 11]"
@@ -33,7 +33,7 @@ test_scenarios:
           - stdout contains "DONE"
       -
         action:
-          run test_requester_py with args '--domain $domain_id --primes-per-reply 7 120' on $740_arch
+          run test_requester_py with args '--domain $domain_id --primes-per-reply 7 120' on $first_architecture
         verification:
           - stdout contains "Sending a request to calculate the prime numbers <= 120 in sequences of 7 or fewer elements"
           - stdout contains "[2, 3, 5, 7, 11, 13, 17]"
@@ -41,7 +41,7 @@ test_scenarios:
           - stdout contains "DONE"
       -
         action:
-          run test_replier_py with args '--domain $domain_id' on $740_arch
+          run test_replier_py with args '--domain $domain_id' on $first_architecture
         verification:
           - stdout contains "Prime calculation replier started"
           - 'stdout contains "Timeout: no requests received"'
@@ -50,7 +50,7 @@ test_scenarios:
     actions:
       -
         action:
-          run test_requester_cs with args '--domain $domain_id --primes-per-reply 5 --number 100' on $740_arch
+          run test_requester_cs with args '--domain $domain_id --primes-per-reply 5 --number 100' on $first_architecture
         verification:
           - stdout contains "Running PrimesRequester on domain "
           - stdout contains "2 3 5 7 11"
@@ -58,7 +58,7 @@ test_scenarios:
           - stdout contains "DONE"
       -
         action:
-          run test_replier_cs with args '--domain $domain_id --timeout 20' on $740_arch
+          run test_replier_cs with args '--domain $domain_id --timeout 20' on $first_architecture
         verification:
           - stdout contains "Running PrimesReplier on domain "
           - stdout contains "Calculating prime numbers below 100..."


### PR DESCRIPTION
### Summary
With this PR we want to update some quack_files from: dynamic_data_nested_structs, remote_procedure_call and request_reply.

### Details and comments
The update is using the dynamic labels to set the correct product and version to use and a new tag for the architecture to use in the test, following the standard template that is use in the main interoperability scenarios repo.

### Checks
-   [X] I have tested these changes in the main interoperability scenarios repo. ([Link](https://jenkins.rti.com/blue/organizations/jenkins/interoperability-test%2Finteroperability-test-scenarios/detail/feature%2FDIT-246/8/pipeline/) to the pipeline execution) 
-   [ ] I have updated the documentation accordingly.
-   [ ] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.
