### PR TITLE
Fix dynamic permissions build in Darwin

### DIFF
--- a/examples/connext_secure/dynamic_permissions/c++11/dynamic_permissions_publisher.cxx
+++ b/examples/connext_secure/dynamic_permissions/c++11/dynamic_permissions_publisher.cxx
@@ -46,7 +46,7 @@ void run_publisher_application(
          !application::shutdown_requested && samples_written < sample_count;
          samples_written++) {
         // Modify the data to be written here
-        data.value(static_cast<int32_t>(samples_written));
+        data.value = static_cast<int32_t>(samples_written);
         std::cout << "Writing ::DynamicPermissions, count " << samples_written
                   << std::endl;
 


### PR DESCRIPTION
### Summary

This Pull Request fixes the build, which fails for some platforms such as Darwin.