### PR TITLE
TRUST-4765: Upgrade Connext arch inside the Docker container for the CI builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
             )
         )
         // Set a timeout for the entire pipeline
-        timeout(time: 2, unit: 'HOURS')
+        timeout(time: 3, unit: 'HOURS')
     }
 
     stages {

--- a/resources/docker/Dockerfile.linux
+++ b/resources/docker/Dockerfile.linux
@@ -15,7 +15,7 @@ ARG USER_NAME=jenkins
 ARG USER_UID
 
 ENV DEBIAN_FRONTEND="noninteractive"
-ENV CONNEXTDDS_ARCH="x64Linux4gcc7.3.0"
+ENV CONNEXTDDS_ARCH="x64Linux4gcc8.5.0"
 
 RUN apt-get update && apt-get install -y \
         gcc \


### PR DESCRIPTION
<!--
:warning: Please, try to follow the template.
:warning: Your pull request title should be short, detailed and understandable for all.
:warning: If your pull request fixes an open issue, please link to the issue.
-->

### Summary

The arch inside the Docker container is old and for the new versions it is deprecated.


### Details and comments


### Checks

<!-- Change te space between the square brackets to an `x` -->
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.

<!-- Uncomment bellow if you added a C/C++ example and updated examples/connext_dds/CMakeList.txt -->
<!--
-   [ ] I have added a new C/C++ example and updated `examples/connext_dds/CMakeList.txt` accordingly.
-->
<!-- Uncomment bellow if you added a Java example and updated examples/connext_dds/settings.gradle -->
<!--
-   [ ] I have added a new Java example and updated `examples/connext_dds/settings.gradle` accordingly.
-->
