### PR TITLE
Modifies Lightweight example to with PSL changes

### DIFF
--- a/examples/connext_secure/lightweight/c++11/README.md
+++ b/examples/connext_secure/lightweight/c++11/README.md
@@ -41,6 +41,8 @@ which will create the lightweight subscriber.
 ./Lws_subscriber -lw
 ```
 
+The lightweight profile uses the OpenSSL PSL.
+
 Then, in a third window, launch the publisher.
 
 ```sh
@@ -68,6 +70,19 @@ Lws subscriber sleeping up to 1 sec...
 Lws subscriber sleeping up to 1 sec...
 ```
 
+## Notes on Lightweight Platform Support Library (PSL) configuration
+
+The lightweight participant profiles now include explicit PSL configuration
+properties for OpenSSL Cryptographic Library:
+
+- OpenSSL profile (`lightweight_library::peer`):
+  - `com.rti.serv.secure.psl_library=psl_openssl3`
+  - `com.rti.serv.secure.psl_get_interface=PSL_OSSL_get_interface`
+  - `com.rti.serv.secure.psl_get_configuration=PSL_OSSL_get_default_configuration`
+
+This mirrors the newer lightweight security initialization model where PSL abstracts
+cryptography library and enables easy switch between different cryptographic libraries
+with properties.
 
 ## Troubleshooting
 
@@ -84,3 +99,11 @@ Connext version you're using, e.g.
 ```sh
 git checkout release/7.3.0
 ```
+
+### Application does not start because of linking errors
+
+If your application does not start because of errors related to library linking
+or missing symbols, make sure your LD_LIBRARY_PATH contains `lib` directory within
+Connext installation. Check if the `lib` directory contains PSL library matching
+the value of `psl_library` property and make sure `psl_get_interface` and
+`psl_get_configuration` match the functions provided by this library.

--- a/examples/connext_secure/lightweight/c++11/USER_QOS_PROFILES.xml
+++ b/examples/connext_secure/lightweight/c++11/USER_QOS_PROFILES.xml
@@ -138,7 +138,7 @@ to use the software. -->
 
   <qos_library name="lightweight_library">
 
-    <qos_profile name="common">
+    <qos_profile name="peer">
       <domain_participant_qos>
         <transport_builtin>
           <mask>UDPv4</mask>
@@ -159,6 +159,18 @@ to use the software. -->
               <value>RTI_SecurityLightweight_PluginSuite_create</value>
             </element>
             <element>
+              <name>com.rti.serv.secure.psl_library</name>
+              <value>psl_openssl3</value>
+            </element>
+            <element>
+              <name>com.rti.serv.secure.psl_get_interface</name>
+              <value>PSL_OSSL_get_interface</value>
+            </element>
+            <element>
+              <name>com.rti.serv.secure.psl_get_configuration</name>
+              <value>PSL_OSSL_get_default_configuration</value>
+            </element>
+            <element>
               <name>dds.sec.crypto.rtps_psk_secret_passphrase</name>
               <value>data:,0:PLEASE-CHANGE-THIS-DEFAULT-SEED</value>
             </element>
@@ -173,34 +185,6 @@ to use the software. -->
           </value>
         </property>
       </domain_participant_qos>
-    </qos_profile>
-
-    <qos_profile name="openssl_psl_snippet">
-      <?rti-qos_snippet?>
-      <domain_participant_qos>
-        <property>
-          <value>
-            <element>
-              <name>com.rti.serv.secure.psl_library</name>
-              <value>psl_openssl3</value>
-            </element>
-            <element>
-              <name>com.rti.serv.secure.psl_get_interface</name>
-              <value>PSL_OSSL_get_interface</value>
-            </element>
-            <element>
-              <name>com.rti.serv.secure.psl_get_configuration</name>
-              <value>PSL_OSSL_get_default_configuration</value>
-            </element>
-          </value>
-        </property>
-      </domain_participant_qos>
-    </qos_profile>
-
-    <qos_profile name="peer" base_name="lightweight_library::common">
-      <base_name>
-        <element>lightweight_library::openssl_psl_snippet</element>
-      </base_name>
     </qos_profile>
 
 </qos_library>

--- a/examples/connext_secure/lightweight/c++11/USER_QOS_PROFILES.xml
+++ b/examples/connext_secure/lightweight/c++11/USER_QOS_PROFILES.xml
@@ -138,44 +138,69 @@ to use the software. -->
 
   <qos_library name="lightweight_library">
 
-    <qos_profile name="peer">
-        
-        <domain_participant_qos>
-          
-          <transport_builtin>
-            <mask>UDPv4</mask>
-          </transport_builtin>
+    <qos_profile name="common">
+      <domain_participant_qos>
+        <transport_builtin>
+          <mask>UDPv4</mask>
+        </transport_builtin>
 
-          <property>
-            <value>
-              <element>
-                <name>com.rti.serv.load_plugin</name>
-                <value>com.rti.serv.secure</value>
-              </element>
-              <element>
-                <name>com.rti.serv.secure.library</name>
-                <value>nddslightweightsecurity</value>
-              </element>
-              <element>
-                <name>com.rti.serv.secure.create_function</name>
-                <value>RTI_SecurityLightweight_PluginSuite_create</value>
-              </element>   
-              <element>
-                  <name>dds.sec.crypto.rtps_psk_secret_passphrase</name>
-                  <value>data:,0:PLEASE-CHANGE-THIS-DEFAULT-SEED</value>
-              </element>
-              <element>
-                <name>dds.sec.crypto.symmetric_cipher_algorithm</name>
-                <value>AES256+GCM</value>
-              </element>
-              <element>
-                <name>com.rti.serv.secure.logging.verbosity</name>
+        <property>
+          <value>
+            <element>
+              <name>com.rti.serv.load_plugin</name>
+              <value>com.rti.serv.secure</value>
+            </element>
+            <element>
+              <name>com.rti.serv.secure.library</name>
+              <value>nddslightweightsecurity</value>
+            </element>
+            <element>
+              <name>com.rti.serv.secure.create_function</name>
+              <value>RTI_SecurityLightweight_PluginSuite_create</value>
+            </element>
+            <element>
+              <name>dds.sec.crypto.rtps_psk_secret_passphrase</name>
+              <value>data:,0:PLEASE-CHANGE-THIS-DEFAULT-SEED</value>
+            </element>
+            <element>
+              <name>dds.sec.crypto.symmetric_cipher_algorithm</name>
+              <value>AES256+GCM</value>
+            </element>
+            <element>
+              <name>com.rti.serv.secure.logging.verbosity</name>
               <value>INFORMATIONAL</value>
-          </element>
-            </value>
-          </property>
+            </element>
+          </value>
+        </property>
+      </domain_participant_qos>
+    </qos_profile>
 
-        </domain_participant_qos>
+    <qos_profile name="openssl_psl_snippet">
+      <?rti-qos_snippet?>
+      <domain_participant_qos>
+        <property>
+          <value>
+            <element>
+              <name>com.rti.serv.secure.psl_library</name>
+              <value>psl_openssl3</value>
+            </element>
+            <element>
+              <name>com.rti.serv.secure.psl_get_interface</name>
+              <value>PSL_OSSL_get_interface</value>
+            </element>
+            <element>
+              <name>com.rti.serv.secure.psl_get_configuration</name>
+              <value>PSL_OSSL_get_default_configuration</value>
+            </element>
+          </value>
+        </property>
+      </domain_participant_qos>
+    </qos_profile>
+
+    <qos_profile name="peer" base_name="lightweight_library::common">
+      <base_name>
+        <element>lightweight_library::openssl_psl_snippet</element>
+      </base_name>
     </qos_profile>
 
 </qos_library>


### PR DESCRIPTION
### Summary
Modifies Lightweight security example to work with PSL

### Details and comments
Added content about PSL in README.md and new PSL-related properties in the QoS profile. Note, the changes are optional, since the values of these properties are the default values. Example works without them if the intent is to work with openssl lib. 

####Observations
- Changes for wolfssl are not necessary, since the original example does not support it. 
- The example is built statically, yet the QoS changes are compiled in. No need to modify the code.

### Checks

-   [ X] I have updated the documentation accordingly.
-   [ X] I have read the [CONTRIBUTING](https://github.com/rticommunity/rticonnextdds-examples/blob/develop/CONTRIBUTING.md) document.
